### PR TITLE
#3 TextField 입력된 문자열에서 중간 문자 변경 시 커서가 이동됨

### DIFF
--- a/lib/screens/faucet_request_screen.dart
+++ b/lib/screens/faucet_request_screen.dart
@@ -312,7 +312,15 @@ class _FaucetRequestScreenState extends State<FaucetRequestScreen> {
 
                           addressValue = _validateAddress();
                           setState(() {
-                            _faucetAddressController.text = inputText;
+                            _faucetAddressController.value =
+                                _faucetAddressController.value.copyWith(
+                              text: inputText,
+                              selection: TextSelection.collapsed(
+                                offset: _faucetAddressController
+                                    .selection.baseOffset
+                                    .clamp(0, inputText.length),
+                              ),
+                            );
                             addressError = !addressValue;
                           });
                         },


### PR DESCRIPTION
## 버그 제보

TextField 입력된 문자열의 중간으로 커서 이동 후에 문자를 입력하면 커서가 문자열의 끝으로 이동하는 현상

## 관련 화면

[테스트 비트코인 받기] - 받을 주소