### PR TITLE
issue #15 fix(android8.0): 기기가 안드로이드 8.0일 경우 분기 처리

### DIFF
--- a/android/app/src/main/kotlin/onl/coconut/wallet/MainActivity.kt
+++ b/android/app/src/main/kotlin/onl/coconut/wallet/MainActivity.kt
@@ -1,5 +1,26 @@
 package onl.coconut.wallet
 
+import android.os.Build
+import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterFragmentActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterFragmentActivity()
+class MainActivity : FlutterFragmentActivity() {
+    private val CHANNEL = "onl.coconut.wallet/os"
+
+    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            if (call.method == "getPlatformVersion") {
+                val version = Build.VERSION.RELEASE
+                result.success(version)
+            } else if(call.method == "getSdkVersion"){
+                result.success(Build.VERSION.SDK_INT)
+            }
+            else {
+                result.notImplemented()
+            }
+        }
+    }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:flutter/material.dart';
@@ -14,13 +15,29 @@ import 'app.dart';
 
 late final String dbDirectoryPath;
 
+const methodChannelOS = 'onl.coconut.wallet/os';
+
 void main() {
   runZonedGuarded(() async {
     // This app is designed only to work vertically, so we limit
     // orientations to portrait up and down.
     WidgetsFlutterBinding.ensureInitialized();
-    SystemChrome.setPreferredOrientations(
-        [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+    if (Platform.isAndroid) {
+      try {
+        const MethodChannel channel = MethodChannel(methodChannelOS);
+
+        final int version = await channel.invokeMethod('getSdkVersion');
+        if (version != 26) {
+          SystemChrome.setPreferredOrientations(
+              [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+        }
+      } on PlatformException catch (e) {
+        Logger.log("Failed to get platform version: '${e.message}'.");
+      }
+    } else {
+      SystemChrome.setPreferredOrientations(
+          [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+    }
     await SystemChrome.setEnabledSystemUIMode(
       SystemUiMode.manual,
       overlays: [

--- a/lib/widgets/qrcode_info.dart
+++ b/lib/widgets/qrcode_info.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
-import 'package:device_info_plus/device_info_plus.dart';
+import 'package:coconut_wallet/main.dart';
+import 'package:coconut_wallet/utils/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:coconut_wallet/widgets/button/small_action_button.dart';
@@ -21,6 +22,7 @@ class QRCodeInfo extends StatefulWidget {
 }
 
 class _QRCodeInfoState extends State<QRCodeInfo> {
+  static const MethodChannel _channel = MethodChannel(methodChannelOS);
   @override
   Widget build(BuildContext context) {
     final double qrSize = MediaQuery.of(context).size.width * 275 / 375;
@@ -63,11 +65,17 @@ class _QRCodeInfoState extends State<QRCodeInfo> {
                 Clipboard.setData(ClipboardData(text: widget.qrData))
                     .then((value) => null);
                 if (Platform.isAndroid) {
-                  DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
-                  AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
-                  int androidVersion = int.parse(androidInfo.version.release);
-                  if (androidVersion >= 12) {
-                    return;
+                  try {
+                    final int version =
+                        await _channel.invokeMethod('getSdkVersion');
+
+                    // 안드로이드13 부터는 클립보드 복사 메세지가 나오기 때문에 예외 적용
+                    if (version > 31) {
+                      return;
+                    }
+                  } on PlatformException catch (e) {
+                    Logger.log(
+                        "Failed to get platform version: '${e.message}'.");
                   }
                 }
 


### PR DESCRIPTION
- 기기가 안드로이드 8.0일 경우에는 앱 실행시 SystemChrome.setPreferredOrientations 함수 실행하지 않습니다.
-deviceInfo 패키지를 통해 platformVersion을 확인하는 과정에서, 일부 버전에서는 '8.0.0' 형식으로 반환 하여 Integer를 Parse 하는 과정에서 충돌이 발생하였습니다. platformVersion이 아닌 sdkVersion을 통해 Integer 형식으로 가져오도록 하고, 네이티브 MethodChannel을 통해  버전을 가져오도록 변경했습니다.