### PR TITLE
[13-980/982] utxo 목록 조회에 실패했을 때,  walletStatus 정의 안됐을 때 에러 처리

### DIFF
--- a/lib/providers/app_sub_state_model.dart
+++ b/lib/providers/app_sub_state_model.dart
@@ -172,8 +172,9 @@ class AppSubStateModel with ChangeNotifier {
     _isNotEmptyWalletList = isNotEmpty;
     await _sharedPrefs.setBool(
         SharedPrefsRepository.kIsNotEmptyWalletList, isNotEmpty);
-    if (!isNotEmpty)
+    if (!isNotEmpty) {
       await _sharedPrefs.setInt(SharedPrefsRepository.kLastUpdateTime, 0);
+    }
     notifyListeners();
   }
 

--- a/lib/providers/view_model/send/send_fee_selection_view_model.dart
+++ b/lib/providers/view_model/send/send_fee_selection_view_model.dart
@@ -4,7 +4,6 @@ import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
-import 'package:coconut_wallet/services/recommend_fee_service.dart';
 import 'package:flutter/material.dart';
 
 class SendFeeSelectionViewModel extends ChangeNotifier {

--- a/lib/providers/view_model/wallet_detail/wallet_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/wallet_detail_view_model.dart
@@ -1,5 +1,7 @@
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
+import 'package:coconut_wallet/providers/connectivity_provider.dart';
+import 'package:coconut_wallet/providers/upbit_connect_model.dart';
 import 'package:coconut_wallet/services/model/error/default_error_response.dart';
 import 'package:coconut_wallet/services/model/request/faucet_request.dart';
 import 'package:coconut_wallet/services/model/response/faucet_response.dart';
@@ -25,6 +27,8 @@ class WalletDetailViewModel extends ChangeNotifier {
   final WalletProvider _walletProvider;
   final TransactionProvider _txProvider;
   final UtxoTagProvider _tagProvider;
+  final ConnectivityProvider _connectProvider;
+  final UpbitConnectModel _upbitConnectModel;
 
   final SharedPrefsRepository _sharedPrefs = SharedPrefsRepository();
 
@@ -65,7 +69,7 @@ class WalletDetailViewModel extends ChangeNotifier {
   bool _isRequesting = false;
 
   WalletDetailViewModel(this._walletId, this._walletProvider, this._txProvider,
-      this._tagProvider) {
+      this._tagProvider, this._connectProvider, this._upbitConnectModel) {
     // 지갑 상세 초기화
     _prevWalletInitState = _walletProvider.walletInitState;
     final walletBaseItem = _walletProvider.getWalletById(_walletId);
@@ -127,6 +131,9 @@ class WalletDetailViewModel extends ChangeNotifier {
 
   WalletProvider? get walletProvider => _walletProvider;
   WalletType get walletType => _walletType;
+
+  bool? get isNetworkOn => _connectProvider.isNetworkOn;
+  int? get bitcoinPriceKrw => _upbitConnectModel.bitcoinPriceKrw;
 
   WalletStatus? getInitializedWalletStatus() {
     try {

--- a/lib/screens/wallet_detail/wallet_detail_screen.dart
+++ b/lib/screens/wallet_detail/wallet_detail_screen.dart
@@ -446,7 +446,7 @@ class _WalletDetailScreenState extends State<WalletDetailScreen> {
 
   bool _checkStateAndShowToast(
       WalletInitState state, int? balance, bool? isNetworkOn) {
-    if (isNetworkOn == false) {
+    if (isNetworkOn != true) {
       CustomToast.showWarningToast(
           context: context, text: ErrorCodes.networkError.message);
       return false;

--- a/lib/screens/wallet_detail/wallet_detail_screen.dart
+++ b/lib/screens/wallet_detail/wallet_detail_screen.dart
@@ -77,24 +77,29 @@ class _WalletDetailScreenState extends State<WalletDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProxyProvider2<WalletProvider, TransactionProvider,
-        WalletDetailViewModel>(
+    return ChangeNotifierProxyProvider4<WalletProvider, TransactionProvider,
+        ConnectivityProvider, UpbitConnectModel, WalletDetailViewModel>(
       create: (_) {
         _viewModel = WalletDetailViewModel(
           widget.id,
           Provider.of<WalletProvider>(_, listen: false),
           Provider.of<TransactionProvider>(_, listen: false),
           Provider.of<UtxoTagProvider>(_, listen: false),
+          Provider.of<ConnectivityProvider>(_, listen: false),
+          Provider.of<UpbitConnectModel>(_, listen: false),
         );
         return _viewModel;
       },
-      update: (_, walletProvider, txProvider, viewModel) {
+      update: (_, walletProvider, txProvider, connectProvider, upbitModel,
+          viewModel) {
         _updateFilterDropdownButtonRenderBox();
         return viewModel!..updateProvider();
       },
       child: Consumer<WalletDetailViewModel>(
         builder: (context, viewModel, child) {
+          final state = viewModel.walletInitState;
           final balance = viewModel.walletListBaseItem?.balance;
+          final isNetworkOn = viewModel.isNetworkOn;
           return PopScope(
             canPop: true,
             onPopInvokedWithResult: (didPop, _) {
@@ -106,272 +111,257 @@ class _WalletDetailScreenState extends State<WalletDetailScreen> {
               onTap: () {
                 _removeFilterDropdown(); // 모든 터치 이벤트에서 실행
               },
-              child: Selector<WalletProvider, WalletInitState>(
-                selector: (_, selectorModel) => selectorModel.walletInitState,
-                builder: (context, state, child) {
-                  return Stack(
-                    children: [
-                      Scaffold(
-                        backgroundColor: MyColors.black,
-                        appBar: CustomAppBar.build(
-                          entireWidgetKey: _appBarKey,
-                          faucetIconKey: _faucetIconKey,
-                          backgroundColor: MyColors.black,
-                          title: TextUtils.ellipsisIfLonger(
-                            viewModel.walletListBaseItem!.name,
-                            maxLength: 15,
-                          ),
-                          context: context,
-                          hasRightIcon: true,
-                          onFaucetIconPressed: () async {
-                            _removeFilterDropdown();
-                            viewModel.removeFaucetTooltip();
-                            if (!_checkStateAndShowToast(state, balance)) {
-                              return;
-                            }
-                            await CommonBottomSheets.showBottomSheet_50(
-                                context: context,
-                                child: FaucetRequestBottomSheet(
-                                  walletAddressBook:
-                                      viewModel.walletAddressBook,
-                                  walletData: {
-                                    'wallet_address': viewModel.walletAddress,
-                                    'wallet_name': viewModel.walletName,
-                                    'wallet_index':
-                                        viewModel.receiveAddressIndex,
-                                    'wallet_request_amount':
-                                        viewModel.requestAmount,
-                                  },
-                                  isFaucetRequestLimitExceeded:
-                                      viewModel.isFaucetRequestLimitExceeded,
-                                  isRequesting: viewModel.isRequesting,
-                                  onRequest: (address) {
-                                    if (viewModel.isRequesting) return;
-
-                                    viewModel.requestTestBitcoin(address,
-                                        (success, message) {
-                                      if (success) {
-                                        Navigator.pop(context);
-                                        vibrateLight();
-                                        Future.delayed(
-                                            const Duration(seconds: 1), () {
-                                          viewModel.walletProvider?.initWallet(
-                                              targetId: widget.id,
-                                              syncOthers: false);
-                                        });
-                                        CustomToast.showToast(
-                                            context: context, text: message);
-                                      } else {
-                                        vibrateMedium();
-                                        CustomToast.showWarningToast(
-                                            context: context, text: message);
-                                      }
-                                    });
-                                  },
-                                ));
-                          },
-                          onTitlePressed: () async {
-                            await Navigator.pushNamed(context, '/wallet-info',
-                                arguments: {
-                                  'id': widget.id,
-                                  'isMultisig': viewModel.walletType ==
-                                      WalletType.multiSignature
-                                });
-
-                            if (viewModel.isUpdatedTagList) {
-                              viewModel.getUtxoListWithHoldingAddress();
-                            }
-                          },
-                          showFaucetIcon: true,
-                        ),
-                        body: CustomScrollView(
-                          controller: _scrollController,
-                          semanticChildCount: viewModel.txList.isEmpty
-                              ? 1
-                              : viewModel.txList.length,
-                          slivers: [
-                            CupertinoSliverRefreshControl(
-                              onRefresh: () async {
-                                _isPullToRefreshing = true;
-                                try {
-                                  if (!_checkStateAndShowToast(
-                                      state, balance)) {
-                                    return;
-                                  }
-                                  viewModel.walletProvider
-                                      ?.initWallet(targetId: widget.id);
-                                } finally {
-                                  _isPullToRefreshing = false;
-                                }
+              child: Stack(
+                children: [
+                  Scaffold(
+                    backgroundColor: MyColors.black,
+                    appBar: CustomAppBar.build(
+                      entireWidgetKey: _appBarKey,
+                      faucetIconKey: _faucetIconKey,
+                      backgroundColor: MyColors.black,
+                      title: TextUtils.ellipsisIfLonger(
+                        viewModel.walletListBaseItem!.name,
+                        maxLength: 15,
+                      ),
+                      context: context,
+                      hasRightIcon: true,
+                      onFaucetIconPressed: () async {
+                        _removeFilterDropdown();
+                        viewModel.removeFaucetTooltip();
+                        if (!_checkStateAndShowToast(
+                            state, balance, isNetworkOn)) {
+                          return;
+                        }
+                        await CommonBottomSheets.showBottomSheet_50(
+                            context: context,
+                            child: FaucetRequestBottomSheet(
+                              walletAddressBook: viewModel.walletAddressBook,
+                              walletData: {
+                                'wallet_address': viewModel.walletAddress,
+                                'wallet_name': viewModel.walletName,
+                                'wallet_index': viewModel.receiveAddressIndex,
+                                'wallet_request_amount':
+                                    viewModel.requestAmount,
                               },
-                            ),
-                            SliverToBoxAdapter(
-                              child: Selector<UpbitConnectModel, int?>(
-                                selector: (context, model) =>
-                                    model.bitcoinPriceKrw,
-                                builder: (context, bitcoinPriceKrw, child) {
-                                  return WalletDetailHeader(
-                                    key: _headerWidgetKey,
-                                    walletId: widget.id,
-                                    address: viewModel.walletAddress,
-                                    derivationPath: viewModel.derivationPath,
-                                    balance: balance,
-                                    currentUnit: _currentUnit,
-                                    btcPriceInKrw: bitcoinPriceKrw,
-                                    onPressedUnitToggle: () {
-                                      _toggleUnit();
-                                    },
-                                    removePopup: () {
-                                      _removeFilterDropdown();
-                                      viewModel.removeFaucetTooltip();
-                                    },
-                                    checkPrerequisites: () {
-                                      return _checkStateAndShowToast(
-                                          state, balance);
-                                    },
-                                  );
-                                },
-                              ),
-                            ),
-                            SliverToBoxAdapter(
-                              child: WalletDetailTab(
-                                key: _tabWidgetKey,
-                                selectedListType: _selectedListType,
-                                utxoListLength: viewModel.utxoList.length,
-                                state: state,
-                                isUtxoDropdownVisible: _selectedListType ==
-                                        WalletDetailTabType.utxo &&
+                              isFaucetRequestLimitExceeded:
+                                  viewModel.isFaucetRequestLimitExceeded,
+                              isRequesting: viewModel.isRequesting,
+                              onRequest: (address) {
+                                if (viewModel.isRequesting) return;
+
+                                viewModel.requestTestBitcoin(address,
+                                    (success, message) {
+                                  if (success) {
+                                    Navigator.pop(context);
+                                    vibrateLight();
+                                    Future.delayed(const Duration(seconds: 1),
+                                        () {
+                                      viewModel.walletProvider?.initWallet(
+                                          targetId: widget.id,
+                                          syncOthers: false);
+                                    });
+                                    CustomToast.showToast(
+                                        context: context, text: message);
+                                  } else {
+                                    vibrateMedium();
+                                    CustomToast.showWarningToast(
+                                        context: context, text: message);
+                                  }
+                                });
+                              },
+                            ));
+                      },
+                      onTitlePressed: () async {
+                        await Navigator.pushNamed(
+                            context, '/wallet-info', arguments: {
+                          'id': widget.id,
+                          'isMultisig':
+                              viewModel.walletType == WalletType.multiSignature
+                        });
+
+                        if (viewModel.isUpdatedTagList) {
+                          viewModel.getUtxoListWithHoldingAddress();
+                        }
+                      },
+                      showFaucetIcon: true,
+                    ),
+                    body: CustomScrollView(
+                      controller: _scrollController,
+                      semanticChildCount: viewModel.txList.isEmpty
+                          ? 1
+                          : viewModel.txList.length,
+                      slivers: [
+                        CupertinoSliverRefreshControl(
+                          onRefresh: () async {
+                            _isPullToRefreshing = true;
+                            try {
+                              if (!_checkStateAndShowToast(
+                                  state, balance, isNetworkOn)) {
+                                return;
+                              }
+                              viewModel.walletProvider
+                                  ?.initWallet(targetId: widget.id);
+                            } finally {
+                              _isPullToRefreshing = false;
+                            }
+                          },
+                        ),
+                        SliverToBoxAdapter(
+                          child: WalletDetailHeader(
+                            key: _headerWidgetKey,
+                            walletId: widget.id,
+                            address: viewModel.walletAddress,
+                            derivationPath: viewModel.derivationPath,
+                            balance: balance,
+                            currentUnit: _currentUnit,
+                            btcPriceInKrw: viewModel.bitcoinPriceKrw,
+                            onPressedUnitToggle: () {
+                              _toggleUnit();
+                            },
+                            removePopup: () {
+                              _removeFilterDropdown();
+                              viewModel.removeFaucetTooltip();
+                            },
+                            checkPrerequisites: () {
+                              return _checkStateAndShowToast(
+                                  state, balance, isNetworkOn);
+                            },
+                          ),
+                        ),
+                        SliverToBoxAdapter(
+                          child: WalletDetailTab(
+                            key: _tabWidgetKey,
+                            selectedListType: _selectedListType,
+                            utxoListLength: viewModel.utxoList.length,
+                            state: state,
+                            isUtxoDropdownVisible:
+                                _selectedListType == WalletDetailTabType.utxo &&
                                     viewModel.utxoList.isNotEmpty &&
                                     !_stickyHeaderVisible,
-                                isPullToRefreshing: _isPullToRefreshing,
-                                utxoOrderText: viewModel.selectedUtxoOrder.text,
-                                onTapTransaction: () {
-                                  _toggleListType(
-                                      WalletDetailTabType.transaction,
-                                      viewModel.utxoList);
-                                },
-                                onTapUtxo: () {
-                                  _toggleListType(WalletDetailTabType.utxo,
-                                      viewModel.utxoList);
-                                },
-                                onTapUtxoDropdown: () {
-                                  _scrollController
-                                      .jumpTo(_scrollController.offset);
-                                  if (_isHeaderDropdownVisible ||
-                                      _isStickyHeaderDropdownVisible) {
-                                    _isHeaderDropdownVisible = false;
-                                  } else {
-                                    _isHeaderDropdownVisible = true;
-                                  }
-                                  setState(() {});
-                                },
-                              ),
-                            ),
-                            SliverSafeArea(
-                              minimum:
-                                  const EdgeInsets.symmetric(horizontal: 16),
-                              sliver: WalletDetailBody(
-                                txSliverListKey: _txSliverListKey,
-                                utxoSliverListKey: _utxoSliverListKey,
-                                walletId: widget.id,
-                                walletType: viewModel.walletType,
-                                currentUnit: _currentUnit,
-                                isTransaction: _isSelectedTx(),
-                                isUtxoListLoadComplete:
-                                    viewModel.isUtxoListLoadComplete,
-                                txList: viewModel.txList,
-                                utxoList: viewModel.utxoList,
-                                removePopup: () {
-                                  _removeFilterDropdown();
-                                  viewModel.removeFaucetTooltip();
-                                },
-                                popFromUtxoDetail: (resultUtxo) {
-                                  if (viewModel.isUpdatedTagList) {
-                                    viewModel.updateUtxoTagList(
-                                        resultUtxo.utxoId,
-                                        viewModel.selectedTagList);
-                                  }
-                                },
-                              ),
-                            ),
-                            SliverToBoxAdapter(
-                              child: SizedBox(
-                                height: _listBottomMarginHeight(),
-                              ),
-                            ),
-                          ],
+                            isPullToRefreshing: _isPullToRefreshing,
+                            utxoOrderText: viewModel.selectedUtxoOrder.text,
+                            onTapTransaction: () {
+                              _toggleListType(WalletDetailTabType.transaction,
+                                  viewModel.utxoList);
+                            },
+                            onTapUtxo: () {
+                              _toggleListType(
+                                  WalletDetailTabType.utxo, viewModel.utxoList);
+                            },
+                            onTapUtxoDropdown: () {
+                              _scrollController
+                                  .jumpTo(_scrollController.offset);
+                              if (_isHeaderDropdownVisible ||
+                                  _isStickyHeaderDropdownVisible) {
+                                _isHeaderDropdownVisible = false;
+                              } else {
+                                _isHeaderDropdownVisible = true;
+                              }
+                              setState(() {});
+                            },
+                          ),
                         ),
-                      ),
-                      FaucetTooltip(
-                        text: '테스트용 비트코인으로 마음껏 테스트 해보세요',
-                        isVisible: viewModel.faucetTooltipVisible,
-                        width: MediaQuery.of(context).size.width,
-                        iconPosition: _faucetIconPosition,
-                        iconSize: _faucetIconSize,
-                        onTapRemove: viewModel.removeFaucetTooltip,
-                      ),
-                      WalletDetailStickyHeader(
-                        widgetKey: _stickyHeaderWidgetKey,
-                        height: _appBarSize.height,
-                        isVisible: _stickyHeaderVisible,
-                        currentUnit: _currentUnit,
-                        balance: balance,
-                        receiveAddress: viewModel.walletListBaseItem!.walletBase
-                            .getReceiveAddress(),
-                        walletStatus: viewModel.getInitializedWalletStatus(),
-                        selectedListType: _selectedListType,
-                        selectedFilter: viewModel.selectedUtxoOrder.text,
-                        onTapReceive: (balance, address, path) {
-                          _onTapReceiveOrSend(balance, state,
-                              address: address, path: path);
-                        },
-                        onTapSend: (balance) {
-                          _onTapReceiveOrSend(balance, state);
-                        },
-                        onTapDropdown: () {
-                          setState(() {
-                            _scrollController.jumpTo(_scrollController.offset);
-                            if (_isHeaderDropdownVisible ||
-                                _isStickyHeaderDropdownVisible) {
-                              _isStickyHeaderDropdownVisible = false;
-                            } else {
-                              _isStickyHeaderDropdownVisible = true;
-                            }
-                          });
-                        },
-                        removePopup: () {
-                          _removeFilterDropdown();
-                          viewModel.removeFaucetTooltip();
-                        },
-                      ),
-                      UtxoFilterDropdown(
-                        isVisible: viewModel.utxoList.isNotEmpty &&
-                                _isHeaderDropdownVisible ||
-                            _isStickyHeaderDropdownVisible,
-                        positionTop: _isHeaderDropdownVisible
-                            ? _headerDropdownPosition.dy +
-                                80 -
-                                _scrollController.offset * 0.01
-                            : _isStickyHeaderDropdownVisible
-                                ? _stickyHeaderDropdownPosition.dy + 92
-                                : 0,
-                        selectedFilter: viewModel.selectedUtxoOrder,
-                        onSelected: (filter) {
-                          setState(() {
-                            _isHeaderDropdownVisible =
-                                _isStickyHeaderDropdownVisible = false;
-                          });
-                          if (_stickyHeaderVisible) {
-                            _scrollController.animateTo(_topPadding + 1,
-                                duration: const Duration(milliseconds: 300),
-                                curve: Curves.easeInOut);
-                          }
-                          viewModel.updateUtxoFilter(filter);
-                        },
-                      ),
-                    ],
-                  );
-                },
+                        SliverSafeArea(
+                          minimum: const EdgeInsets.symmetric(horizontal: 16),
+                          sliver: WalletDetailBody(
+                            txSliverListKey: _txSliverListKey,
+                            utxoSliverListKey: _utxoSliverListKey,
+                            walletId: widget.id,
+                            walletType: viewModel.walletType,
+                            currentUnit: _currentUnit,
+                            isTransaction: _isSelectedTx(),
+                            isUtxoListLoadComplete:
+                                viewModel.isUtxoListLoadComplete,
+                            txList: viewModel.txList,
+                            utxoList: viewModel.utxoList,
+                            removePopup: () {
+                              _removeFilterDropdown();
+                              viewModel.removeFaucetTooltip();
+                            },
+                            popFromUtxoDetail: (resultUtxo) {
+                              if (viewModel.isUpdatedTagList) {
+                                viewModel.updateUtxoTagList(resultUtxo.utxoId,
+                                    viewModel.selectedTagList);
+                              }
+                            },
+                          ),
+                        ),
+                        SliverToBoxAdapter(
+                          child: SizedBox(
+                            height: _listBottomMarginHeight(),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  FaucetTooltip(
+                    text: '테스트용 비트코인으로 마음껏 테스트 해보세요',
+                    isVisible: viewModel.faucetTooltipVisible,
+                    width: MediaQuery.of(context).size.width,
+                    iconPosition: _faucetIconPosition,
+                    iconSize: _faucetIconSize,
+                    onTapRemove: viewModel.removeFaucetTooltip,
+                  ),
+                  WalletDetailStickyHeader(
+                    widgetKey: _stickyHeaderWidgetKey,
+                    height: _appBarSize.height,
+                    isVisible: _stickyHeaderVisible,
+                    currentUnit: _currentUnit,
+                    balance: balance,
+                    receiveAddress: viewModel.walletListBaseItem!.walletBase
+                        .getReceiveAddress(),
+                    walletStatus: viewModel.getInitializedWalletStatus(),
+                    selectedListType: _selectedListType,
+                    selectedFilter: viewModel.selectedUtxoOrder.text,
+                    onTapReceive: (balance, address, path) {
+                      _onTapReceiveOrSend(balance, state, isNetworkOn,
+                          address: address, path: path);
+                    },
+                    onTapSend: (balance) {
+                      _onTapReceiveOrSend(balance, state, isNetworkOn);
+                    },
+                    onTapDropdown: () {
+                      setState(() {
+                        _scrollController.jumpTo(_scrollController.offset);
+                        if (_isHeaderDropdownVisible ||
+                            _isStickyHeaderDropdownVisible) {
+                          _isStickyHeaderDropdownVisible = false;
+                        } else {
+                          _isStickyHeaderDropdownVisible = true;
+                        }
+                      });
+                    },
+                    removePopup: () {
+                      _removeFilterDropdown();
+                      viewModel.removeFaucetTooltip();
+                    },
+                  ),
+                  UtxoFilterDropdown(
+                    isVisible: viewModel.utxoList.isNotEmpty &&
+                            _isHeaderDropdownVisible ||
+                        _isStickyHeaderDropdownVisible,
+                    positionTop: _isHeaderDropdownVisible
+                        ? _headerDropdownPosition.dy +
+                            80 -
+                            _scrollController.offset * 0.01
+                        : _isStickyHeaderDropdownVisible
+                            ? _stickyHeaderDropdownPosition.dy + 92
+                            : 0,
+                    selectedFilter: viewModel.selectedUtxoOrder,
+                    onSelected: (filter) {
+                      setState(() {
+                        _isHeaderDropdownVisible =
+                            _isStickyHeaderDropdownVisible = false;
+                      });
+                      if (_stickyHeaderVisible) {
+                        _scrollController.animateTo(_topPadding + 1,
+                            duration: const Duration(milliseconds: 300),
+                            curve: Curves.easeInOut);
+                      }
+                      viewModel.updateUtxoFilter(filter);
+                    },
+                  ),
+                ],
               ),
             ),
           );
@@ -454,10 +444,9 @@ class _WalletDetailScreenState extends State<WalletDetailScreen> {
     });
   }
 
-  bool _checkStateAndShowToast(WalletInitState state, int? balance) {
-    var connectivityProvider =
-        Provider.of<ConnectivityProvider>(context, listen: false);
-    if (connectivityProvider.isNetworkOn == false) {
+  bool _checkStateAndShowToast(
+      WalletInitState state, int? balance, bool? isNetworkOn) {
+    if (isNetworkOn == false) {
       CustomToast.showWarningToast(
           context: context, text: ErrorCodes.networkError.message);
       return false;
@@ -520,9 +509,10 @@ class _WalletDetailScreenState extends State<WalletDetailScreen> {
     return 0;
   }
 
-  void _onTapReceiveOrSend(int? balance, WalletInitState state,
+  void _onTapReceiveOrSend(
+      int? balance, WalletInitState state, bool? isNetworkOn,
       {String? address, String? path}) {
-    if (!_checkStateAndShowToast(state, balance)) return;
+    if (!_checkStateAndShowToast(state, balance, isNetworkOn)) return;
     if (address != null && path != null) {
       CommonBottomSheets.showBottomSheet_90(
         context: context,

--- a/lib/widgets/selector/wallet_detail_tab.dart
+++ b/lib/widgets/selector/wallet_detail_tab.dart
@@ -1,3 +1,4 @@
+import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/styles.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -7,9 +8,10 @@ enum WalletDetailTabType { transaction, utxo }
 
 class WalletDetailTab extends StatelessWidget {
   final WalletDetailTabType selectedListType;
-  final bool isUpdateProgress;
+  final WalletInitState state;
   final int utxoListLength;
   final bool isUtxoDropdownVisible;
+  final bool isPullToRefreshing;
   final String utxoOrderText;
   final Function onTapTransaction;
   final Function onTapUtxo;
@@ -17,9 +19,10 @@ class WalletDetailTab extends StatelessWidget {
   const WalletDetailTab({
     super.key,
     required this.selectedListType,
-    required this.isUpdateProgress,
+    required this.state,
     required this.utxoListLength,
     required this.isUtxoDropdownVisible,
+    required this.isPullToRefreshing,
     this.utxoOrderText = '',
     required this.onTapTransaction,
     required this.onTapUtxo,
@@ -100,7 +103,8 @@ class WalletDetailTab extends StatelessWidget {
               ),
               const Spacer(),
               Visibility(
-                visible: isUpdateProgress,
+                visible:
+                    !isPullToRefreshing && state == WalletInitState.processing,
                 child: Row(
                   children: [
                     const Text(
@@ -119,6 +123,28 @@ class WalletDetailTab extends StatelessWidget {
                       width: 20,
                       height: 20,
                     ),
+                  ],
+                ),
+              ),
+              Visibility(
+                visible: state == WalletInitState.error,
+                child: Row(
+                  children: [
+                    const Text(
+                      '업데이트 실패',
+                      style: TextStyle(
+                        fontFamily: 'Pretendard',
+                        color: MyColors.failedYellow,
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                        fontStyle: FontStyle.normal,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    SvgPicture.asset('assets/svg/status-failure.svg',
+                        width: 18,
+                        colorFilter: const ColorFilter.mode(
+                            MyColors.failedYellow, BlendMode.srcIn)),
                   ],
                 ),
               ),


### PR DESCRIPTION
- wallet_detail_screen.dart 업데이트 실패 상태 텍스트 추가
- 업데이트 실패 상태일 때 '받기', '보내기' 버튼 차단 
- '화면을 아래로 당겨 최신 데이터를 가져와 주세요.' 토스트 추가