### PR TITLE
[13-999] refactoring tx provider 

### DIFF
--- a/lib/providers/transaction_provider.dart
+++ b/lib/providers/transaction_provider.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/enums/network_enums.dart';
-import 'package:coconut_wallet/enums/transaction_enums.dart';
 import 'package:coconut_wallet/model/error/app_error.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/transaction_address.dart';
@@ -16,42 +15,16 @@ import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/fetch_transaction_response.dart';
 import 'package:coconut_wallet/services/model/stream/stream_state.dart';
 import 'package:coconut_wallet/utils/logger.dart';
-import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:flutter/cupertino.dart';
 
 class TransactionProvider extends ChangeNotifier {
-  static const int kReceiveInputCount = 3;
-  static const int kNotReceiveInputCount = 5;
-  static const int kReceiveOutputCount = 4;
-  static const int kNotReceiveOutputCount = 2;
-  static const int kViewMoreCount = 5;
-  static const int kInputMaxCount = 3;
-  static const int kOutputMaxCount = 2;
   final WalletDataManager _walletDataManager = WalletDataManager();
 
   TransactionRecord? _transaction;
   List<TransactionRecord> _txList = [];
 
-  bool _canSeeMoreInputs = false;
-  bool _canSeeMoreOutputs = false;
-
-  int _inputCountToShow = kViewMoreCount;
-  int _outputCountToShow = kViewMoreCount;
-
-  int _utxoInputMaxCount = kInputMaxCount;
-  int _utxoOutputMaxCount = kOutputMaxCount;
-
   TransactionRecord? get transaction => _transaction;
   List<TransactionRecord> get txList => _txList;
-
-  bool get canSeeMoreInputs => _canSeeMoreInputs;
-  bool get canSeeMoreOutputs => _canSeeMoreOutputs;
-
-  int get inputCountToShow => _inputCountToShow;
-  int get outputCountToShow => _outputCountToShow;
-
-  int get utxoInputMaxCount => _utxoInputMaxCount;
-  int get utxoOutputMaxCount => _utxoOutputMaxCount;
 
   void initTransaction(int walletId, String txHash, {String? utxoTo}) {
     final tx = _loadTransaction(walletId, txHash);
@@ -69,85 +42,25 @@ class TransactionProvider extends ChangeNotifier {
     _transaction = tx;
   }
 
+  TransactionRecord? getTransaction(int walletId, String txHash,
+      {String? utxoTo}) {
+    final tx = _loadTransaction(walletId, txHash);
+
+    if (utxoTo != null && tx != null) {
+      if (tx.outputAddressList.isNotEmpty) {
+        tx.outputAddressList.sort((a, b) {
+          if (a.address == utxoTo) return -1;
+          if (b.address == utxoTo) return 1;
+          return 0;
+        });
+      }
+    }
+
+    return tx;
+  }
+
   void initTxList(int walletId) {
     _txList = _walletDataManager.getTxList(walletId) ?? [];
-  }
-
-  void initUtxoInOutputList() {
-    if (_transaction == null) return;
-
-    _utxoInputMaxCount = _transaction!.inputAddressList.length <= kInputMaxCount
-        ? _transaction!.inputAddressList.length
-        : kInputMaxCount;
-    _utxoOutputMaxCount =
-        _transaction!.outputAddressList.length <= kOutputMaxCount
-            ? _transaction!.outputAddressList.length
-            : kOutputMaxCount;
-    if (_transaction!.inputAddressList.length <= utxoInputMaxCount) {
-      _utxoInputMaxCount = _transaction!.inputAddressList.length;
-    }
-    if (_transaction!.outputAddressList.length <= utxoOutputMaxCount) {
-      _utxoOutputMaxCount = _transaction!.outputAddressList.length;
-    }
-  }
-
-  bool initViewMoreButtons() {
-    if (_transaction == null) {
-      return false;
-    }
-
-    final status = TransactionUtil.getStatus(_transaction!);
-
-    final isSending = [
-      TransactionStatus.sending,
-      TransactionStatus.sent,
-      TransactionStatus.self,
-      TransactionStatus.selfsending,
-    ].contains(status);
-
-    int initialInputMaxCount =
-        isSending ? kNotReceiveInputCount : kReceiveInputCount;
-    int initialOutputMaxCount =
-        isSending ? kNotReceiveOutputCount : kReceiveOutputCount;
-
-    if (_transaction!.inputAddressList.length <= initialInputMaxCount) {
-      _canSeeMoreInputs = false;
-      _inputCountToShow = _transaction!.inputAddressList.length;
-    } else {
-      _canSeeMoreInputs = true;
-      _inputCountToShow = initialInputMaxCount;
-    }
-    if (_transaction!.outputAddressList.length <= initialOutputMaxCount) {
-      _canSeeMoreOutputs = false;
-      _outputCountToShow = _transaction!.outputAddressList.length;
-    } else {
-      _canSeeMoreOutputs = true;
-      _outputCountToShow = initialOutputMaxCount;
-    }
-    return true;
-  }
-
-  void viewMoreInput() {
-    if (_transaction == null) return;
-
-    _inputCountToShow = (_inputCountToShow + kViewMoreCount)
-        .clamp(0, _transaction!.inputAddressList.length);
-    if (_inputCountToShow == _transaction!.inputAddressList.length) {
-      _canSeeMoreInputs = false;
-    }
-    notifyListeners();
-  }
-
-  void viewMoreOutput() {
-    if (_transaction == null) return;
-
-    _outputCountToShow = (_outputCountToShow + kViewMoreCount)
-        .clamp(0, _transaction!.outputAddressList.length);
-    if (_outputCountToShow == _transaction!.outputAddressList.length) {
-      _canSeeMoreOutputs = false;
-    }
-
-    notifyListeners();
   }
 
   bool updateTransactionMemo(int walletId, String txHash, String memo) {

--- a/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
@@ -1,11 +1,23 @@
+import 'package:coconut_wallet/enums/transaction_enums.dart';
+import 'package:coconut_wallet/model/wallet/transaction_address.dart';
 import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/providers/node_provider.dart';
 import 'package:coconut_wallet/providers/transaction_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
+import 'package:coconut_wallet/utils/logger.dart';
+import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:flutter/material.dart';
 
 class TransactionDetailViewModel extends ChangeNotifier {
+  static const int kReceiveInputCount = 3;
+  static const int kNotReceiveInputCount = 5;
+  static const int kReceiveOutputCount = 4;
+  static const int kNotReceiveOutputCount = 2;
+  static const int kViewMoreCount = 5;
+  static const int kInputMaxCount = 3;
+  static const int kOutputMaxCount = 2;
+
   final int _walletId;
   final String _txHash;
   final WalletProvider _walletProvider;
@@ -17,17 +29,30 @@ class TransactionDetailViewModel extends ChangeNotifier {
   final ValueNotifier<bool> _showDialogNotifier = ValueNotifier(false);
   final ValueNotifier<bool> _loadCompletedNotifier = ValueNotifier(false);
 
-  TransactionDetailViewModel(this._walletId, this._txHash, this._walletProvider,
-      this._txProvider, this._nodeProvider);
+  bool _canSeeMoreInputs = false;
+  bool _canSeeMoreOutputs = false;
 
+  int _inputCountToShow = 0;
+  int _outputCountToShow = 0;
+
+  TransactionRecord? _transaction;
+  TransactionRecord? get transaction => _transaction;
+
+  TransactionDetailViewModel(this._walletId, this._txHash, this._walletProvider,
+      this._txProvider, this._nodeProvider) {
+    _transaction = _txProvider.getTransaction(_walletId, _txHash);
+    _initViewMoreButtons();
+  }
+
+  bool get canSeeMoreInputs => _canSeeMoreInputs;
+  bool get canSeeMoreOutputs => _canSeeMoreOutputs;
+  int get inputCountToShow => _inputCountToShow;
+  int get outputCountToShow => _outputCountToShow;
   BlockTimestamp? get currentBlock => _currentBlock;
 
-  TransactionProvider get txModel => _txProvider;
-  TransactionRecord? get transaction => _txProvider.transaction;
-  bool get canSeeMoreInputs => _txProvider.canSeeMoreInputs;
-  bool get canSeeMoreOutputs => _txProvider.canSeeMoreOutputs;
-  int get inputCountToShow => _txProvider.inputCountToShow;
-  int get outputCountToShow => _txProvider.outputCountToShow;
+  ValueNotifier<bool> get loadCompletedNotifier => _loadCompletedNotifier;
+  ValueNotifier<bool> get showDialogNotifier => _showDialogNotifier;
+
   DateTime? get timestamp {
     final blockHeight = _txProvider.transaction?.blockHeight;
     return (blockHeight != null && blockHeight > 0)
@@ -35,10 +60,39 @@ class TransactionDetailViewModel extends ChangeNotifier {
         : null;
   }
 
-  ValueNotifier<bool> get showDialogNotifier => _showDialogNotifier;
-  ValueNotifier<bool> get loadCompletedNotifier => _loadCompletedNotifier;
+  void init() {
+    _canSeeMoreInputs = false;
+    _canSeeMoreOutputs = false;
+    _inputCountToShow = 0;
+    _outputCountToShow = 0;
+  }
 
-  WalletProvider get walletProvider => _walletProvider;
+  bool isSameAddress(String address) {
+    return _walletProvider.containsAddress(_walletId, address);
+  }
+
+  void onTapViewMoreInputs() {
+    // ignore: no_leading_underscores_for_local_identifiers
+    if (_transaction == null) return;
+
+    _inputCountToShow = (_inputCountToShow + kViewMoreCount)
+        .clamp(0, _transaction!.inputAddressList.length);
+    if (_inputCountToShow == _transaction!.inputAddressList.length) {
+      _canSeeMoreInputs = false;
+    }
+    notifyListeners();
+  }
+
+  void onTapViewMoreOutputs() {
+    if (_transaction == null) return;
+
+    _outputCountToShow = (_outputCountToShow + kViewMoreCount)
+        .clamp(0, _transaction!.outputAddressList.length);
+    if (_outputCountToShow == _transaction!.outputAddressList.length) {
+      _canSeeMoreOutputs = false;
+    }
+    notifyListeners();
+  }
 
   void updateProvider() {
     // TODO: addressBook
@@ -48,11 +102,59 @@ class TransactionDetailViewModel extends ChangeNotifier {
       //     _walletProvider.getWalletById(_walletId).walletBase.addressBook;
       _setCurrentBlockHeight();
       _txProvider.initTransaction(_walletId, _txHash);
-      if (_txProvider.initViewMoreButtons() == false) {
+
+      if (_initViewMoreButtons() == false) {
         _showDialogNotifier.value = true;
       }
     }
     notifyListeners();
+  }
+
+  bool updateTransactionMemo(String memo) {
+    return _txProvider.updateTransactionMemo(_walletId, _txHash, memo);
+  }
+
+  bool _initViewMoreButtons() {
+    if (_transaction == null) {
+      _canSeeMoreInputs = false;
+      _canSeeMoreOutputs = false;
+      _inputCountToShow = 0;
+      _outputCountToShow = 0;
+      notifyListeners();
+      return false;
+    }
+
+    final status = TransactionUtil.getStatus(_transaction!);
+
+    final isSending = [
+      TransactionStatus.sending,
+      TransactionStatus.sent,
+      TransactionStatus.self,
+      TransactionStatus.selfsending,
+    ].contains(status);
+
+    int initialInputMaxCount =
+        isSending ? kNotReceiveInputCount : kReceiveInputCount;
+    int initialOutputMaxCount =
+        isSending ? kNotReceiveOutputCount : kReceiveOutputCount;
+
+    if (_transaction!.inputAddressList.length <= initialInputMaxCount) {
+      _canSeeMoreInputs = false;
+      _inputCountToShow = _transaction!.inputAddressList.length;
+    } else {
+      _canSeeMoreInputs = true;
+      _inputCountToShow = initialInputMaxCount;
+    }
+    if (_transaction!.outputAddressList.length <= initialOutputMaxCount) {
+      _canSeeMoreOutputs = false;
+      _outputCountToShow = _transaction!.outputAddressList.length;
+    } else {
+      _canSeeMoreOutputs = true;
+      _outputCountToShow = initialOutputMaxCount;
+    }
+
+    notifyListeners();
+    return true;
   }
 
   void _setCurrentBlockHeight() async {
@@ -63,4 +165,16 @@ class TransactionDetailViewModel extends ChangeNotifier {
       notifyListeners();
     }
   }
+
+  String getInputAddress(int index) =>
+      TransactionUtil.getInputAddress(_transaction, index);
+
+  String getOutputAddress(int index) =>
+      TransactionUtil.getOutputAddress(_transaction, index);
+
+  int getInputAmount(int index) =>
+      TransactionUtil.getInputAmount(_transaction, index);
+
+  int getOutputAmount(int index) =>
+      TransactionUtil.getOutputAmount(_transaction, index);
 }

--- a/lib/providers/view_model/wallet_detail/utxo_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_detail_view_model.dart
@@ -4,9 +4,13 @@ import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/providers/transaction_provider.dart';
 import 'package:coconut_wallet/providers/utxo_tag_provider.dart';
 import 'package:coconut_wallet/utils/datetime_util.dart';
+import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:flutter/material.dart';
 
 class UtxoDetailViewModel extends ChangeNotifier {
+  static const int kInputMaxCount = 3;
+  static const int kOutputMaxCount = 2;
+
   final int _walletId;
   final UtxoState _utxo;
 
@@ -14,17 +18,27 @@ class UtxoDetailViewModel extends ChangeNotifier {
   final TransactionProvider _txProvider;
 
   late final List<String>? _dateString;
+  late final TransactionRecord? _transaction;
+
+  int _utxoInputMaxCount = 0;
+  int _utxoOutputMaxCount = 0;
+
+  int get utxoInputMaxCount => _utxoInputMaxCount;
+  int get utxoOutputMaxCount => _utxoOutputMaxCount;
 
   UtxoDetailViewModel(
       this._walletId, this._utxo, this._tagProvider, this._txProvider) {
     _tagProvider.initTagList(_walletId, utxoId: _utxo.utxoId);
-    _txProvider.initTransaction(_walletId, _utxo.transactionHash,
+    _transaction = _txProvider.getTransaction(_walletId, _utxo.transactionHash,
         utxoTo: _utxo.to);
-    _txProvider.initUtxoInOutputList();
+    // _txProvider.initTransaction(_walletId, _utxo.transactionHash,
+    //     utxoTo: _utxo.to);
     final blockHeight = _txProvider.transaction?.blockHeight;
     _dateString = (blockHeight != null && blockHeight > 0)
         ? DateTimeUtil.formatTimeStamp(_utxo.timestamp)
         : null;
+
+    _initUtxoInOutputList();
   }
 
   UtxoTagProvider? get tagProvider => _tagProvider;
@@ -32,8 +46,36 @@ class UtxoDetailViewModel extends ChangeNotifier {
   List<UtxoTag> get tagList => _tagProvider.tagList;
 
   TransactionRecord? get transaction => _txProvider.transaction;
-  int get utxoInputMaxCount => _txProvider.utxoInputMaxCount;
-  int get utxoOutputMaxCount => _txProvider.utxoOutputMaxCount;
 
   List<String>? get dateString => _dateString;
+
+  void _initUtxoInOutputList() {
+    if (_transaction == null) return;
+
+    _utxoInputMaxCount = _transaction.inputAddressList.length <= kInputMaxCount
+        ? _transaction.inputAddressList.length
+        : kInputMaxCount;
+    _utxoOutputMaxCount =
+        _transaction.outputAddressList.length <= kOutputMaxCount
+            ? _transaction.outputAddressList.length
+            : kOutputMaxCount;
+    if (_transaction.inputAddressList.length <= utxoInputMaxCount) {
+      _utxoInputMaxCount = _transaction.inputAddressList.length;
+    }
+    if (_transaction.outputAddressList.length <= utxoOutputMaxCount) {
+      _utxoOutputMaxCount = _transaction.outputAddressList.length;
+    }
+  }
+
+  String getInputAddress(int index) =>
+      TransactionUtil.getInputAddress(_transaction, index);
+
+  String getOutputAddress(int index) =>
+      TransactionUtil.getOutputAddress(_transaction, index);
+
+  int getInputAmount(int index) =>
+      TransactionUtil.getInputAmount(_transaction, index);
+
+  int getOutputAmount(int index) =>
+      TransactionUtil.getOutputAmount(_transaction, index);
 }

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -139,25 +139,21 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> {
                               itemCount: viewModel.inputCountToShow,
                               padding: EdgeInsets.zero,
                               itemBuilder: (context, index) {
+                                final address =
+                                    viewModel.getInputAddress(index);
+                                final amount = viewModel.getInputAmount(index);
                                 return Column(
                                   children: [
                                     InputOutputDetailRow(
-                                      address: viewModel.transaction!
-                                          .inputAddressList[index].address,
-                                      balance: viewModel.transaction!
-                                          .inputAddressList[index].amount,
+                                      address: address,
+                                      balance: amount,
                                       balanceMaxWidth:
                                           _balanceWidthSize.width > 0
                                               ? _balanceWidthSize.width
                                               : 100,
                                       rowType: InputOutputRowType.input,
-                                      isCurrentAddress: viewModel.walletProvider
-                                          .containsAddress(
-                                              widget.id,
-                                              viewModel
-                                                  .transaction!
-                                                  .inputAddressList[index]
-                                                  .address),
+                                      isCurrentAddress:
+                                          viewModel.isSameAddress(address),
                                       transactionStatus: status,
                                     ),
                                     const SizedBox(height: 8),
@@ -171,7 +167,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> {
                                 child: CustomUnderlinedButton(
                                   text: t.view_more,
                                   onTap: () {
-                                    viewModel.txModel.viewMoreInput();
+                                    viewModel.onTapViewMoreInputs();
                                   },
                                   fontSize: 12,
                                   lineHeight: 14,
@@ -198,13 +194,14 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> {
                               itemCount: viewModel.outputCountToShow,
                               padding: EdgeInsets.zero,
                               itemBuilder: (context, index) {
+                                final address =
+                                    viewModel.getOutputAddress(index);
+                                final amount = viewModel.getOutputAmount(index);
                                 return Column(
                                   children: [
                                     InputOutputDetailRow(
-                                      address: viewModel.transaction!
-                                          .outputAddressList[index].address,
-                                      balance: viewModel.transaction!
-                                          .outputAddressList[index].amount,
+                                      address: address,
+                                      balance: amount,
                                       balanceMaxWidth:
                                           _balanceWidthSize.width > 0
                                               ? _balanceWidthSize.width
@@ -230,7 +227,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> {
                                 child: CustomUnderlinedButton(
                                   text: t.view_more,
                                   onTap: () {
-                                    viewModel.txModel.viewMoreOutput();
+                                    viewModel.onTapViewMoreOutputs();
                                   },
                                   fontSize: 12,
                                   lineHeight: 14,
@@ -283,9 +280,8 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> {
                                   originalMemo:
                                       viewModel.transaction!.memo ?? '',
                                   onComplete: (memo) {
-                                    if (!viewModel.txModel
-                                        .updateTransactionMemo(
-                                            widget.id, widget.txHash, memo)) {
+                                    if (!viewModel
+                                        .updateTransactionMemo(memo)) {
                                       CustomToast.showWarningToast(
                                         context: context,
                                         text: t.toast.memo_update_failed,
@@ -326,6 +322,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> {
 
   @override
   void dispose() {
+    _viewModel.init();
     _viewModel.showDialogNotifier.removeListener(_showDialogListener);
     _viewModel.showDialogNotifier.removeListener(_loadCompletedListener);
     super.dispose();

--- a/lib/screens/wallet_detail/wallet_detail_screen.dart
+++ b/lib/screens/wallet_detail/wallet_detail_screen.dart
@@ -201,6 +201,7 @@ class _WalletDetailScreenState extends State<WalletDetailScreen> {
                                   state, balance, isNetworkOn)) {
                                 return;
                               }
+                              // fixme: 직접 호출하지 않도록 수정
                               viewModel.walletProvider
                                   ?.initWallet(targetId: widget.id);
                             } finally {

--- a/lib/utils/transaction_util.dart
+++ b/lib/utils/transaction_util.dart
@@ -25,4 +25,39 @@ class TransactionUtil {
 
     return null;
   }
+
+  static String getInputAddress(TransactionRecord? transaction, index) =>
+      _getTransactionField<String>(transaction, index,
+          (tx) => transaction!.inputAddressList, (item) => item.address,
+          defaultValue: '');
+
+  static String getOutputAddress(TransactionRecord? transaction, int index) =>
+      _getTransactionField<String>(transaction, index,
+          (tx) => transaction!.outputAddressList, (item) => item.address,
+          defaultValue: '');
+
+  static int getOutputAmount(TransactionRecord? transaction, int index) =>
+      _getTransactionField<int>(transaction, index,
+          (tx) => transaction!.inputAddressList, (item) => item.amount,
+          defaultValue: 0);
+
+  static int getInputAmount(TransactionRecord? transaction, int index) =>
+      _getTransactionField<int>(transaction, index,
+          (tx) => transaction!.outputAddressList, (item) => item.amount,
+          defaultValue: 0);
+
+  static T _getTransactionField<T>(
+    TransactionRecord? transaction,
+    int index,
+    List<dynamic> Function(TransactionRecord) listSelector,
+    T Function(dynamic) valueSelector, {
+    required T defaultValue,
+  }) {
+    if (transaction == null) return defaultValue;
+
+    final list = listSelector(transaction);
+    if (index < 0 || index >= list.length) return defaultValue;
+
+    return valueSelector(list[index]);
+  }
 }


### PR DESCRIPTION
Issue #99 

TransactionProvider에 뷰 관련 로직 뷰 모델로 분리
 - TransactionProvider에서 제거할 변수 및 함수: 화면에 표시할 input/output 갯수, 더보기 버튼, 더보기 버튼 클릭 시 호출 함수
 - 이동 대상 뷰 모델: TransactionDetailViewModel, UtxoDetailViewModel
    - 두 뷰 모델에서 Input/Output 요소를 보여주기 위해 필요한 공통 함수를 TransactionUtil에 추가 