### PR TITLE
[14-1069] Fix/send amount

### DIFF
--- a/lib/providers/view_model/send/send_amount_view_model.dart
+++ b/lib/providers/view_model/send/send_amount_view_model.dart
@@ -31,6 +31,13 @@ class SendAmountViewModel extends ChangeNotifier {
   bool get isNextButtonEnabled => _isNextButtonEnabled;
   int get unconfirmedBalance => _unconfirmedBalance;
 
+  // TODO: 추후 반환 타입 변경
+  void checkGoingNextAvailable() {
+    if (_isNetworkOn != true) {
+      throw ErrorCodes.networkError.message;
+    }
+  }
+
   void onKeyTap(String newInput) {
     if (newInput == '<') {
       if (_input.isNotEmpty) {
@@ -107,12 +114,5 @@ class SendAmountViewModel extends ChangeNotifier {
     _isNextButtonEnabled = true;
 
     notifyListeners();
-  }
-
-  // TODO: 추후 반환 타입 변경
-  void checkGoingNextAvailable() {
-    if (_isNetworkOn != true) {
-      throw ErrorCodes.networkError.message;
-    }
   }
 }

--- a/lib/providers/view_model/send/send_amount_view_model.dart
+++ b/lib/providers/view_model/send/send_amount_view_model.dart
@@ -25,7 +25,7 @@ class SendAmountViewModel extends ChangeNotifier {
     _input = '';
     _isNextButtonEnabled = false;
 
-    addWalletUpdateListner();
+    _addWalletUpdateListner();
   }
 
   int get confirmedBalance => _confirmedBalance;
@@ -35,11 +35,13 @@ class SendAmountViewModel extends ChangeNotifier {
   bool get isNextButtonEnabled => _isNextButtonEnabled;
   int get incomingBalance => _incomingBalance;
 
-  // TODO: 추후 반환 타입 변경
-  void checkGoingNextAvailable() {
-    if (_isNetworkOn != true) {
-      throw ErrorCodes.networkError.message;
-    }
+  void onBeforeGoNextScreen() {
+    _setAmountWithInput();
+    _removeWalletUpdateListener();
+  }
+
+  void onBackFromNextScreen() {
+    _addWalletUpdateListner();
   }
 
   void onKeyTap(String newInput) {
@@ -97,7 +99,7 @@ class SendAmountViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setAmountWithInput() {
+  void _setAmountWithInput() {
     _sendInfoProvider.setAmount(double.parse(_input));
   }
 
@@ -149,12 +151,12 @@ class SendAmountViewModel extends ChangeNotifier {
   }
 
   // pending tx가 완료되었을 때 잔액을 업데이트 하기 위해
-  void addWalletUpdateListner() {
+  void _addWalletUpdateListner() {
     _walletProvider.addWalletUpdateListener(
         _sendInfoProvider.walletId!, _onWalletUpdated);
   }
 
-  void removeWalletUpdateListener() {
+  void _removeWalletUpdateListener() {
     _walletProvider.removeWalletUpdateListener(
         _sendInfoProvider.walletId!, _onWalletUpdated);
   }
@@ -162,7 +164,7 @@ class SendAmountViewModel extends ChangeNotifier {
   @override
   void dispose() {
     if (_sendInfoProvider.walletId != null) {
-      removeWalletUpdateListener();
+      _removeWalletUpdateListener();
     }
     super.dispose();
   }

--- a/lib/providers/view_model/send/send_confirm_view_model.dart
+++ b/lib/providers/view_model/send/send_confirm_view_model.dart
@@ -36,7 +36,7 @@ class SendConfirmViewModel extends ChangeNotifier {
       ? null
       : UnmodifiableMapView(_recipientsForBatch!);
   int? get bitcoinPriceKrw => _bitcoinPriceKrw;
-  int get estimatedFee => _sendInfoProvider.estimatedFee!;
+  int get estimatedFee => _sendInfoProvider.estimatedFee ?? 0;
   String get walletName => _walletListItemBase.name;
   int get totalUsedAmount => _totalUsedAmount;
 

--- a/lib/providers/view_model/send/send_fee_selection_view_model.dart
+++ b/lib/providers/view_model/send/send_fee_selection_view_model.dart
@@ -1,6 +1,7 @@
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
+import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/node_provider/node_provider.dart';
 import 'package:coconut_wallet/providers/send_info_provider.dart';
@@ -30,14 +31,20 @@ class SendFeeSelectionViewModel extends ChangeNotifier {
 
   SendFeeSelectionViewModel(this._sendInfoProvider, this._walletProvider,
       this._nodeProvider, this._bitcoinPriceKrw, this._isNetworkOn) {
-    var balance = _walletProvider.getWalletBalance(_sendInfoProvider.walletId!);
     _walletListItemBase =
         _walletProvider.getWalletById(_sendInfoProvider.walletId!);
     _walletAddressType =
         _walletListItemBase.walletType == WalletType.singleSignature
             ? AddressType.p2wpkh
             : AddressType.p2wsh;
-    _confirmedBalance = balance.confirmed;
+    _confirmedBalance = _walletProvider
+        .getUtxoList(_sendInfoProvider.walletId!)
+        .fold<int>(0, (sum, utxo) {
+      if (utxo.status == UtxoStatus.unspent) {
+        return sum + utxo.amount;
+      }
+      return sum;
+    });
     _isMultisigWallet =
         _walletListItemBase.walletType == WalletType.multiSignature;
     _bitcoinPriceKrw = _bitcoinPriceKrw;

--- a/lib/screens/send/send_amount_screen.dart
+++ b/lib/screens/send/send_amount_screen.dart
@@ -4,6 +4,7 @@ import 'package:coconut_wallet/providers/connectivity_provider.dart';
 import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/view_model/send/send_amount_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
+import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/styles.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/widgets/appbar/custom_appbar.dart';
@@ -62,7 +63,7 @@ class _SendAmountScreenState extends State<SendAmountScreen> {
                               alignment: Alignment.center,
                               child: Column(children: [
                                 const SizedBox(height: 16),
-                                if (viewModel.unconfirmedBalance > 0)
+                                if (viewModel.incomingBalance > 0)
                                   CustomTooltip(
                                       backgroundColor:
                                           MyColors.white.withOpacity(0.9),
@@ -70,7 +71,7 @@ class _SendAmountScreenState extends State<SendAmountScreen> {
                                           text: TextSpan(
                                         text: t.tooltip.amount_to_be_sent(
                                             bitcoin: satoshiToBitcoinString(
-                                                viewModel.unconfirmedBalance)),
+                                                viewModel.incomingBalance)),
                                         style: const TextStyle(
                                           fontFamily: 'Pretendard',
                                           fontWeight: FontWeight.normal,
@@ -249,6 +250,9 @@ class _SendAmountScreenState extends State<SendAmountScreen> {
     }
 
     _viewModel.setAmountWithInput();
-    Navigator.pushNamed(context, routeName);
+    _viewModel.removeWalletUpdateListener();
+    Navigator.pushNamed(context, routeName).then((_) {
+      _viewModel.addWalletUpdateListner();
+    });
   }
 }

--- a/lib/screens/send/send_amount_screen.dart
+++ b/lib/screens/send/send_amount_screen.dart
@@ -1,5 +1,6 @@
 import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
+import 'package:coconut_wallet/model/error/app_error.dart';
 import 'package:coconut_wallet/providers/connectivity_provider.dart';
 import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/view_model/send/send_amount_view_model.dart';
@@ -242,17 +243,15 @@ class _SendAmountScreenState extends State<SendAmountScreen> {
   }
 
   void _goNextScreen(String routeName) {
-    try {
-      _viewModel.checkGoingNextAvailable();
-    } catch (e) {
-      CustomToast.showWarningToast(context: context, text: e.toString());
+    if (_viewModel.isNetworkOn != true) {
+      CustomToast.showWarningToast(
+          context: context, text: ErrorCodes.networkError.message);
       return;
     }
 
-    _viewModel.setAmountWithInput();
-    _viewModel.removeWalletUpdateListener();
+    _viewModel.onBeforeGoNextScreen();
     Navigator.pushNamed(context, routeName).then((_) {
-      _viewModel.addWalletUpdateListner();
+      _viewModel.onBackFromNextScreen();
     });
   }
 }


### PR DESCRIPTION
- send_amount_view_model
    - unspent 상태의 utxo 총합만큼만 보낼 수 있음
    - 화면에 머무르는 동안 Utxo 목록이 변하는 경우 최대 전송 금액이 달라져야 하기 때문에 _walletProvider에 이벤트 등록/해제 로직을 추가
- send_fee_selection_view_model
    - confirmedBalance 계산로직 변경 - unspent 상태의 utxo 총합
- send_utxo_selection_view_model
    - confirmedBalance 계산로직 변경 - unspent 상태의 utxo 총합
    - _createTransaction 함수에서 할당 안된 satsPerVb와 _sendInfoProvider.feeRate을 할당하는 코드가 있어서 수정