### PR TITLE
[14-1088] TransactionRecord 프로퍼티 수정

### DIFF
--- a/lib/enums/network_enums.dart
+++ b/lib/enums/network_enums.dart
@@ -1,5 +1,3 @@
-enum UtxoOrder { byAmountDesc, byAmountAsc, byTimestampDesc, byTimestampAsc }
-
 enum TransactionType {
   received('RECEIVED'),
   sent('SENT'),
@@ -9,6 +7,15 @@ enum TransactionType {
   const TransactionType(this.name);
 
   final String name;
+}
+
+extension TransactionTypeExtension on TransactionType {
+  static TransactionType fromString(String name) {
+    return TransactionType.values.firstWhere(
+      (type) => type.name == name,
+      orElse: () => TransactionType.unknown,
+    );
+  }
 }
 
 enum SocketConnectionStatus { reconnecting, connecting, connected, terminated }

--- a/lib/enums/utxo_enums.dart
+++ b/lib/enums/utxo_enums.dart
@@ -1,5 +1,6 @@
-import 'network_enums.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
+
+enum UtxoOrder { byAmountDesc, byAmountAsc, byTimestampDesc, byTimestampAsc }
 
 extension UtxoOrderEnumExtension on UtxoOrder {
   String get text {

--- a/lib/model/utxo/utxo_state.dart
+++ b/lib/model/utxo/utxo_state.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_lib/coconut_lib.dart';
-import 'package:coconut_wallet/enums/network_enums.dart';
+import 'package:coconut_wallet/enums/utxo_enums.dart';
 import 'package:coconut_wallet/model/utxo/utxo_tag.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 

--- a/lib/model/wallet/transaction_record.dart
+++ b/lib/model/wallet/transaction_record.dart
@@ -5,7 +5,7 @@ class TransactionRecord {
   final String _transactionHash;
   final DateTime _timestamp;
   final int _blockHeight;
-  String _transactionType;
+  TransactionType _transactionType;
   String? _memo;
   int _amount;
   int _fee;
@@ -27,7 +27,7 @@ class TransactionRecord {
 
   /// Get the transaction type of this transaction. (RECEIVED, SEND, SELF, UNKNOWN)
   /// [TransactionType]
-  String get transactionType => _transactionType;
+  TransactionType get transactionType => _transactionType;
 
   /// Get the memo of this transaction.
   String? get memo => _memo;
@@ -78,7 +78,7 @@ class TransactionRecord {
     required String transactionHash,
     required DateTime timestamp,
     required int blockHeight,
-    required String transactionType,
+    required TransactionType transactionType,
     required int amount,
     required int fee,
     required List<TransactionAddress> inputAddressList,

--- a/lib/model/wallet/transaction_record.dart
+++ b/lib/model/wallet/transaction_record.dart
@@ -3,16 +3,16 @@ import 'package:coconut_wallet/model/wallet/transaction_address.dart';
 
 class TransactionRecord {
   final String _transactionHash;
-  final DateTime? _timestamp;
-  final int? _blockHeight;
-  String? _transactionType;
+  final DateTime _timestamp;
+  final int _blockHeight;
+  String _transactionType;
   String? _memo;
-  int? _amount;
-  int? _fee;
+  int _amount;
+  int _fee;
   List<TransactionAddress> _inputAddressList;
   List<TransactionAddress> _outputAddressList;
-  DateTime? createdAt;
-  int _vSize;
+  DateTime createdAt;
+  double _vSize;
   List<RbfHistory>? _rbfHistoryList;
   CpfpHistory? _cpfpHistory;
 
@@ -20,29 +20,29 @@ class TransactionRecord {
   String get transactionHash => _transactionHash;
 
   /// Get the timestamp of this transaction.
-  DateTime? get timestamp => _timestamp;
+  DateTime get timestamp => _timestamp;
 
   /// Get the block height of this transaction.
-  int? get blockHeight => _blockHeight;
+  int get blockHeight => _blockHeight;
 
   /// Get the transaction type of this transaction. (RECEIVED, SEND, SELF, UNKNOWN)
   /// [TransactionType]
-  String? get transactionType => _transactionType;
+  String get transactionType => _transactionType;
 
   /// Get the memo of this transaction.
   String? get memo => _memo;
 
   /// Get the amount of this transaction.
-  int? get amount => _amount;
+  int get amount => _amount;
 
   /// Get the fee of this transaction.
-  int? get fee => _fee;
+  int get fee => _fee;
 
   /// Get the vSize of this transaction.
-  int get vSize => _vSize;
+  double get vSize => _vSize;
 
   /// Get the fee rate of this transaction.
-  double get feeRate => _fee != null ? (_fee! / _vSize * 100).ceil() / 100 : 0;
+  double get feeRate => (_fee / _vSize * 100).ceil() / 100;
 
   /// Get the input address list of this transaction.
   List<TransactionAddress> get inputAddressList => _inputAddressList;
@@ -83,7 +83,7 @@ class TransactionRecord {
     required int fee,
     required List<TransactionAddress> inputAddressList,
     required List<TransactionAddress> outputAddressList,
-    required int vSize,
+    required double vSize,
     String? memo,
   }) {
     return TransactionRecord(

--- a/lib/providers/node_provider/transaction/rbf_handler.dart
+++ b/lib/providers/node_provider/transaction/rbf_handler.dart
@@ -78,8 +78,7 @@ class RbfHandler {
         }
 
         // spentTransaction이 존재하고, 해당 트랜잭션이 미확인 상태일 때만 RBF로 간주
-        if (spentTransaction.blockHeight != null &&
-            spentTransaction.blockHeight! < 1) {
+        if (spentTransaction.blockHeight < 1) {
           Logger.log(
               'RBF 조건 충족: $utxoId, spentTx: ${utxo.spentByTransactionHash}');
           isRbf = true;
@@ -152,7 +151,7 @@ class RbfHandler {
               originalTransactionHash: rbfInfo.originalTransactionHash,
               transactionHash: rbfInfo.originalTransactionHash,
               feeRate: originalTx.feeRate,
-              timestamp: originalTx.timestamp ?? DateTime.now(),
+              timestamp: originalTx.timestamp,
             ));
           }
 

--- a/lib/providers/node_provider/transaction/transaction_fetcher.dart
+++ b/lib/providers/node_provider/transaction/transaction_fetcher.dart
@@ -58,6 +58,7 @@ class TransactionFetcher {
         knownTransactionHashes);
 
     final unconfirmedFetchedTxHashes = txFetchResults
+        // 언컨펌 UTXO가 사용된 트랜잭션은 블록 높이가 -1로 조회되어 '0이하' 조건이 필요함
         .where((tx) => tx.height <= 0)
         .map((tx) => tx.transactionHash)
         .toSet();

--- a/lib/providers/node_provider/transaction/transaction_processor.dart
+++ b/lib/providers/node_provider/transaction/transaction_processor.dart
@@ -131,7 +131,7 @@ class TransactionProcessor {
       transactionType: txDetails.txType.name,
       amount: txDetails.amount,
       fee: txDetails.fee,
-      vSize: tx.getVirtualByte().ceil(),
+      vSize: tx.getVirtualByte(),
     );
   }
 

--- a/lib/providers/node_provider/transaction/transaction_processor.dart
+++ b/lib/providers/node_provider/transaction/transaction_processor.dart
@@ -128,7 +128,7 @@ class TransactionProcessor {
       blockHeight: blockHeight,
       inputAddressList: txDetails.inputAddressList,
       outputAddressList: txDetails.outputAddressList,
-      transactionType: txDetails.txType.name,
+      transactionType: txDetails.txType,
       amount: txDetails.amount,
       fee: txDetails.fee,
       vSize: tx.getVirtualByte(),

--- a/lib/providers/transaction_provider.dart
+++ b/lib/providers/transaction_provider.dart
@@ -72,6 +72,10 @@ class TransactionProvider extends ChangeNotifier {
     return _transactionRepository.getTransactionRecord(walletId, txHash);
   }
 
+  bool hasTransactionConfirmed(int walletId, String txHash) {
+    return _transactionRepository.hasTransactionConfirmed(walletId, txHash);
+  }
+
   void resetData() {
     _transaction = null;
     _txList.clear();

--- a/lib/providers/view_model/send/broadcasting_view_model.dart
+++ b/lib/providers/view_model/send/broadcasting_view_model.dart
@@ -192,10 +192,8 @@ class BroadcastingViewModel extends ChangeNotifier {
 
   // pending상태였던 Tx가 confirmed 되었는지 조회
   bool hasTransactionConfirmed() {
-    TransactionRecord? tx = _txProvider.getTransactionRecord(
+    return _txProvider.hasTransactionConfirmed(
         walletId, _txProvider.transaction!.transactionHash);
-    if (tx == null || tx.blockHeight == 0) return false;
-    return true;
   }
 
   Future<void> updateTagsOfUsedUtxos(String signedTx) async {

--- a/lib/providers/view_model/send/broadcasting_view_model.dart
+++ b/lib/providers/view_model/send/broadcasting_view_model.dart
@@ -194,7 +194,7 @@ class BroadcastingViewModel extends ChangeNotifier {
   bool hasTransactionConfirmed() {
     TransactionRecord? tx = _txProvider.getTransactionRecord(
         walletId, _txProvider.transaction!.transactionHash);
-    if (tx == null || tx.blockHeight <= 0) return false;
+    if (tx == null || tx.blockHeight == 0) return false;
     return true;
   }
 

--- a/lib/providers/view_model/send/broadcasting_view_model.dart
+++ b/lib/providers/view_model/send/broadcasting_view_model.dart
@@ -194,7 +194,7 @@ class BroadcastingViewModel extends ChangeNotifier {
   bool hasTransactionConfirmed() {
     TransactionRecord? tx = _txProvider.getTransactionRecord(
         walletId, _txProvider.transaction!.transactionHash);
-    if (tx == null || tx.blockHeight! <= 0) return false;
+    if (tx == null || tx.blockHeight <= 0) return false;
     return true;
   }
 

--- a/lib/providers/view_model/send/send_utxo_selection_view_model.dart
+++ b/lib/providers/view_model/send/send_utxo_selection_view_model.dart
@@ -1,6 +1,6 @@
 import 'package:coconut_lib/coconut_lib.dart';
-import 'package:coconut_wallet/enums/network_enums.dart';
 import 'package:coconut_wallet/enums/transaction_enums.dart';
+import 'package:coconut_wallet/enums/utxo_enums.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/send/fee_info.dart';

--- a/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
@@ -106,10 +106,8 @@ class FeeBumpingViewModel extends ChangeNotifier {
 
   // pending상태였던 Tx가 confirmed 되었는지 조회
   bool hasTransactionConfirmed() {
-    TransactionRecord? tx = _txProvider.getTransactionRecord(
+    return _txProvider.hasTransactionConfirmed(
         _walletId, transaction.transactionHash);
-    if (tx == null || tx.blockHeight == 0) return false;
-    return true;
   }
 
   Future<bool> prepareToSend(double newTxFeeRate) async {

--- a/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
@@ -108,7 +108,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
   bool hasTransactionConfirmed() {
     TransactionRecord? tx = _txProvider.getTransactionRecord(
         _walletId, transaction.transactionHash);
-    if (tx == null || tx.blockHeight! <= 0) return false;
+    if (tx == null || tx.blockHeight <= 0) return false;
     return true;
   }
 
@@ -228,7 +228,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
       debugPrint(
           '😇 CPFP utxo (${utxoList.length})개 input: $inputSum / output: $outputSum / 👉🏻 입력한 fee rate: $newFeeRate');
       if (!_ensureSufficientUtxos(
-          utxoList, outputSum, estimatedVSize.ceil(), newFeeRate, amount)) {
+          utxoList, outputSum, estimatedVSize, newFeeRate, amount)) {
         debugPrint('❌ 사용할 수 있는 추가 UTXO가 없음!');
         return;
       }
@@ -261,7 +261,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
     //input 정보 추출
     List<Utxo> utxoList = await _getUtxoListForRbf();
     double inputSum = utxoList.fold(0, (sum, utxo) => sum + utxo.amount);
-    int estimatedVSize = _parentTx.vSize;
+    double estimatedVSize = _parentTx.vSize;
     double outputSum = amount + estimatedVSize * newFeeRate;
 
     if (inputSum <= outputSum) {
@@ -338,7 +338,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
   }
 
   bool _ensureSufficientUtxos(List<Utxo> utxoList, double outputSum,
-      int estimatedVSize, double newFeeRate, int amount) {
+      double estimatedVSize, double newFeeRate, int amount) {
     double inputSum = utxoList.fold(0, (sum, utxo) => sum + utxo.amount);
     List<UtxoState> unspentUtxos =
         _utxoRepository.getUtxosByStatus(_walletId, UtxoStatus.unspent);
@@ -488,7 +488,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
 
     double cpfpTxSize = _estimateVirtualByte(transaction);
     double totalFee = (_parentTx.vSize + cpfpTxSize) * recommendedFeeRate;
-    double cpfpTxFee = totalFee - _parentTx.fee!.toDouble();
+    double cpfpTxFee = totalFee - _parentTx.fee.toDouble();
     double cpfpTxFeeRate = cpfpTxFee / cpfpTxSize;
 
     if (cpfpTxFeeRate < recommendedFeeRate || cpfpTxFeeRate < 0) {
@@ -508,8 +508,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
     }
 
     double estimatedVirtualByte = _estimateVirtualByte(transaction);
-    double minimumRequiredFee =
-        _parentTx.fee!.toDouble() + estimatedVirtualByte;
+    double minimumRequiredFee = _parentTx.fee.toDouble() + estimatedVirtualByte;
     double mempoolRecommendedFee = estimatedVirtualByte * recommendedFeeRate;
 
     if (mempoolRecommendedFee < minimumRequiredFee) {
@@ -578,7 +577,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
       newTxSize: _formatNumber(cpfpTxSize),
       recommendedFeeRate: _formatNumber(recommendedFeeRate),
       originalTxSize: _formatNumber(_parentTx.vSize.toDouble()),
-      originalFee: _formatNumber((_parentTx.fee ?? 0).toDouble()),
+      originalFee: _formatNumber((_parentTx.fee).toDouble()),
       totalRequiredFee: _formatNumber(totalRequiredFee.toDouble()),
       newTxFee: _formatNumber(cpfpTxFee),
       newTxFeeRate: _formatNumber(cpfpTxFeeRate),

--- a/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
@@ -108,7 +108,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
   bool hasTransactionConfirmed() {
     TransactionRecord? tx = _txProvider.getTransactionRecord(
         _walletId, transaction.transactionHash);
-    if (tx == null || tx.blockHeight <= 0) return false;
+    if (tx == null || tx.blockHeight == 0) return false;
     return true;
   }
 

--- a/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
@@ -255,8 +255,8 @@ class TransactionDetailViewModel extends ChangeNotifier {
     debugPrint('----------------------------------------');
 
     // rbfHistory가 존재하면 높은 fee rate부터 _transactionList에 추가
-    if ((currentTransaction.transactionType == TransactionType.sent.name ||
-            currentTransaction.transactionType == TransactionType.self.name) &&
+    if ((currentTransaction.transactionType == TransactionType.sent ||
+            currentTransaction.transactionType == TransactionType.self) &&
         currentTransaction.rbfHistoryList != null &&
         currentTransaction.rbfHistoryList!.isNotEmpty) {
       var reversedRbfHistoryList = currentTransaction.rbfHistoryList!.reversed;
@@ -271,8 +271,7 @@ class TransactionDetailViewModel extends ChangeNotifier {
             _txProvider.getTransactionRecord(_walletId, rbfTx.transactionHash);
         _transactionList!.add(TransactionDetail(rbfTxTransaction));
       }
-    } else if (currentTransaction.transactionType ==
-            TransactionType.received.name &&
+    } else if (currentTransaction.transactionType == TransactionType.received &&
         currentTransaction.cpfpHistory != null) {
       _transactionList = [
         TransactionDetail(_txProvider.getTransactionRecord(
@@ -294,7 +293,7 @@ class TransactionDetailViewModel extends ChangeNotifier {
       debugPrint('  - Amount: ${transaction._transaction.amount}');
       debugPrint('  - Created At: ${transaction._transaction.createdAt}');
       debugPrint('  - Hash: ${transaction._transaction.transactionHash}');
-      debugPrint('  - Type: ${transaction._transaction.transactionType}');
+      debugPrint('  - Type: ${transaction._transaction.transactionType.name}');
       debugPrint('  - vSize: ${transaction._transaction.vSize}');
       debugPrint(
           '  - RBF History Count: ${transaction._transaction.rbfHistoryList?.length}');

--- a/lib/providers/view_model/wallet_detail/utxo_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_detail_view_model.dart
@@ -32,7 +32,7 @@ class UtxoDetailViewModel extends ChangeNotifier {
     _selectedUtxoTagList = _tagProvider.getUtxoTagsByUtxoId(_walletId, _utxoId);
 
     _transaction = _txProvider.getTransaction(_walletId, _utxo.transactionHash);
-    _dateString = DateTimeUtil.formatTimestamp(_transaction!.timestamp!);
+    _dateString = DateTimeUtil.formatTimestamp(_transaction!.timestamp);
 
     _initUtxoInOutputList();
   }

--- a/lib/providers/view_model/wallet_detail/utxo_list_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_list_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_wallet/enums/network_enums.dart';
+import 'package:coconut_wallet/enums/utxo_enums.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/node/wallet_update_info.dart';

--- a/lib/providers/view_model/wallet_detail/utxo_list_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_list_view_model.dart
@@ -169,7 +169,7 @@ class UtxoListViewModel extends ChangeNotifier {
     final tx = _txProvider.getTransaction(_walletId, utxo.transactionHash);
     if (tx == null) return [];
 
-    return DateTimeUtil.formatTimestamp(tx.timestamp!);
+    return DateTimeUtil.formatTimestamp(tx.timestamp);
   }
 
   @override

--- a/lib/providers/view_model/wallet_detail/wallet_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/wallet_detail_view_model.dart
@@ -186,16 +186,14 @@ class WalletDetailViewModel extends ChangeNotifier {
     int receiving = 0;
 
     for (var tx in _txProvider.txList) {
-      if (tx.transactionType == null) continue;
-
       if (tx.blockHeight == 0) {
-        switch (tx.transactionType!) {
+        switch (tx.transactionType) {
           case 'SENT':
           case 'SELF':
-            sending += tx.amount!.abs();
+            sending += tx.amount.abs();
             break;
           case 'RECEIVED':
-            receiving += tx.amount!;
+            receiving += tx.amount;
             break;
           default:
             break;

--- a/lib/providers/view_model/wallet_detail/wallet_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/wallet_detail_view_model.dart
@@ -188,11 +188,11 @@ class WalletDetailViewModel extends ChangeNotifier {
     for (var tx in _txProvider.txList) {
       if (tx.blockHeight == 0) {
         switch (tx.transactionType) {
-          case 'SENT':
-          case 'SELF':
+          case TransactionType.sent:
+          case TransactionType.self:
             sending += tx.amount.abs();
             break;
-          case 'RECEIVED':
+          case TransactionType.received:
             receiving += tx.amount;
             break;
           default:

--- a/lib/repository/realm/converter/transaction.dart
+++ b/lib/repository/realm/converter/transaction.dart
@@ -7,22 +7,26 @@ import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 
 // TransactionRecord -> _RealmTransaction 변환 함수
 RealmTransaction mapTransactionToRealmTransaction(
-    TransactionRecord transaction, int walletId, int id, DateTime? createdAt) {
+    TransactionRecord transaction, int walletId, int id) {
   return RealmTransaction(
-      id, transaction.transactionHash, walletId, transaction.vSize,
-      timestamp: transaction.timestamp,
-      blockHeight: transaction.blockHeight,
-      transactionType: transaction.transactionType,
-      memo: transaction.memo,
-      amount: transaction.amount,
-      fee: transaction.fee,
-      inputAddressList: transaction.inputAddressList
-          .map((address) => jsonEncode(addressToJson(address)))
-          .toList(),
-      outputAddressList: transaction.outputAddressList
-          .map((address) => jsonEncode(addressToJson(address)))
-          .toList(),
-      createdAt: createdAt);
+    id,
+    transaction.transactionHash,
+    walletId,
+    transaction.timestamp,
+    transaction.blockHeight,
+    transaction.transactionType,
+    transaction.amount,
+    transaction.fee,
+    transaction.vSize,
+    transaction.createdAt,
+    memo: transaction.memo,
+    inputAddressList: transaction.inputAddressList
+        .map((address) => jsonEncode(addressToJson(address)))
+        .toList(),
+    outputAddressList: transaction.outputAddressList
+        .map((address) => jsonEncode(addressToJson(address)))
+        .toList(),
+  );
 }
 
 // note(트랜잭션 메모) 정보가 추가로 필요하여 TransactionDto를 반환

--- a/lib/repository/realm/converter/transaction.dart
+++ b/lib/repository/realm/converter/transaction.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:coconut_wallet/enums/network_enums.dart';
 import 'package:coconut_wallet/model/wallet/transaction_address.dart';
 import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
@@ -14,7 +15,7 @@ RealmTransaction mapTransactionToRealmTransaction(
     walletId,
     transaction.timestamp,
     transaction.blockHeight,
-    transaction.transactionType,
+    transaction.transactionType.name,
     transaction.amount,
     transaction.fee,
     transaction.vSize,
@@ -38,7 +39,7 @@ TransactionRecord mapRealmTransactionToTransaction(
       realmTransaction.transactionHash,
       realmTransaction.timestamp,
       realmTransaction.blockHeight,
-      realmTransaction.transactionType,
+      TransactionTypeExtension.fromString(realmTransaction.transactionType),
       realmTransaction.memo,
       realmTransaction.amount,
       realmTransaction.fee,

--- a/lib/repository/realm/migration/migrator_ver2_1_0.dart
+++ b/lib/repository/realm/migration/migrator_ver2_1_0.dart
@@ -93,9 +93,7 @@ class MigratorVer2_1_0 {
             wallet[iconField],
             descriptor,
             wallet[nameField],
-            wallet[typeField] ?? WalletType.singleSignature.name,
-            balance: wallet[balanceField],
-            txCount: 0));
+            wallet[typeField] ?? WalletType.singleSignature.name));
 
         if (wallet[typeField] == WalletType.multiSignature.name) {
           migratedMultisigWallets.add(RealmMultisigWallet(

--- a/lib/repository/realm/model/coconut_wallet_model.dart
+++ b/lib/repository/realm/model/coconut_wallet_model.dart
@@ -15,8 +15,6 @@ class _RealmWalletBase {
   int usedChangeIndex = -1;
   int generatedReceiveIndex = -1;
   int generatedChangeIndex = -1;
-  int? balance;
-  int? txCount;
   bool isLatestTxBlockHeightZero = false;
 }
 
@@ -39,17 +37,17 @@ class _RealmTransaction {
   @Indexed()
   late int walletId;
   @Indexed()
-  DateTime? timestamp;
-  int? blockHeight;
-  String? transactionType;
+  late DateTime timestamp;
+  late int blockHeight;
+  late String transactionType;
   String? memo;
-  int? amount;
-  int? fee;
-  late int vSize;
+  late int amount;
+  late int fee;
+  late double vSize;
   late List<String> inputAddressList;
   late List<String> outputAddressList;
   String? note;
-  DateTime? createdAt;
+  late DateTime createdAt;
   String? replaceByTransactionHash;
 }
 

--- a/lib/repository/realm/model/coconut_wallet_model.realm.dart
+++ b/lib/repository/realm/model/coconut_wallet_model.realm.dart
@@ -22,8 +22,6 @@ class RealmWalletBase extends _RealmWalletBase
     int usedChangeIndex = -1,
     int generatedReceiveIndex = -1,
     int generatedChangeIndex = -1,
-    int? balance,
-    int? txCount,
     bool isLatestTxBlockHeightZero = false,
   }) {
     if (!_defaultsSet) {
@@ -45,8 +43,6 @@ class RealmWalletBase extends _RealmWalletBase
     RealmObjectBase.set(this, 'usedChangeIndex', usedChangeIndex);
     RealmObjectBase.set(this, 'generatedReceiveIndex', generatedReceiveIndex);
     RealmObjectBase.set(this, 'generatedChangeIndex', generatedChangeIndex);
-    RealmObjectBase.set(this, 'balance', balance);
-    RealmObjectBase.set(this, 'txCount', txCount);
     RealmObjectBase.set(
         this, 'isLatestTxBlockHeightZero', isLatestTxBlockHeightZero);
   }
@@ -116,16 +112,6 @@ class RealmWalletBase extends _RealmWalletBase
       RealmObjectBase.set(this, 'generatedChangeIndex', value);
 
   @override
-  int? get balance => RealmObjectBase.get<int>(this, 'balance') as int?;
-  @override
-  set balance(int? value) => RealmObjectBase.set(this, 'balance', value);
-
-  @override
-  int? get txCount => RealmObjectBase.get<int>(this, 'txCount') as int?;
-  @override
-  set txCount(int? value) => RealmObjectBase.set(this, 'txCount', value);
-
-  @override
   bool get isLatestTxBlockHeightZero =>
       RealmObjectBase.get<bool>(this, 'isLatestTxBlockHeightZero') as bool;
   @override
@@ -157,8 +143,6 @@ class RealmWalletBase extends _RealmWalletBase
       'usedChangeIndex': usedChangeIndex.toEJson(),
       'generatedReceiveIndex': generatedReceiveIndex.toEJson(),
       'generatedChangeIndex': generatedChangeIndex.toEJson(),
-      'balance': balance.toEJson(),
-      'txCount': txCount.toEJson(),
       'isLatestTxBlockHeightZero': isLatestTxBlockHeightZero.toEJson(),
     };
   }
@@ -190,8 +174,6 @@ class RealmWalletBase extends _RealmWalletBase
               fromEJson(ejson['generatedReceiveIndex'], defaultValue: -1),
           generatedChangeIndex:
               fromEJson(ejson['generatedChangeIndex'], defaultValue: -1),
-          balance: fromEJson(ejson['balance']),
-          txCount: fromEJson(ejson['txCount']),
           isLatestTxBlockHeightZero: fromEJson(
               ejson['isLatestTxBlockHeightZero'],
               defaultValue: false),
@@ -215,8 +197,6 @@ class RealmWalletBase extends _RealmWalletBase
       SchemaProperty('usedChangeIndex', RealmPropertyType.int),
       SchemaProperty('generatedReceiveIndex', RealmPropertyType.int),
       SchemaProperty('generatedChangeIndex', RealmPropertyType.int),
-      SchemaProperty('balance', RealmPropertyType.int, optional: true),
-      SchemaProperty('txCount', RealmPropertyType.int, optional: true),
       SchemaProperty('isLatestTxBlockHeightZero', RealmPropertyType.bool),
     ]);
   }();
@@ -333,17 +313,17 @@ class RealmTransaction extends _RealmTransaction
     int id,
     String transactionHash,
     int walletId,
-    int vSize, {
-    DateTime? timestamp,
-    int? blockHeight,
-    String? transactionType,
+    DateTime timestamp,
+    int blockHeight,
+    String transactionType,
+    int amount,
+    int fee,
+    double vSize,
+    DateTime createdAt, {
     String? memo,
-    int? amount,
-    int? fee,
     Iterable<String> inputAddressList = const [],
     Iterable<String> outputAddressList = const [],
     String? note,
-    DateTime? createdAt,
     String? replaceByTransactionHash,
   }) {
     RealmObjectBase.set(this, 'id', id);
@@ -386,23 +366,22 @@ class RealmTransaction extends _RealmTransaction
   set walletId(int value) => RealmObjectBase.set(this, 'walletId', value);
 
   @override
-  DateTime? get timestamp =>
-      RealmObjectBase.get<DateTime>(this, 'timestamp') as DateTime?;
+  DateTime get timestamp =>
+      RealmObjectBase.get<DateTime>(this, 'timestamp') as DateTime;
   @override
-  set timestamp(DateTime? value) =>
+  set timestamp(DateTime value) =>
       RealmObjectBase.set(this, 'timestamp', value);
 
   @override
-  int? get blockHeight => RealmObjectBase.get<int>(this, 'blockHeight') as int?;
+  int get blockHeight => RealmObjectBase.get<int>(this, 'blockHeight') as int;
   @override
-  set blockHeight(int? value) =>
-      RealmObjectBase.set(this, 'blockHeight', value);
+  set blockHeight(int value) => RealmObjectBase.set(this, 'blockHeight', value);
 
   @override
-  String? get transactionType =>
-      RealmObjectBase.get<String>(this, 'transactionType') as String?;
+  String get transactionType =>
+      RealmObjectBase.get<String>(this, 'transactionType') as String;
   @override
-  set transactionType(String? value) =>
+  set transactionType(String value) =>
       RealmObjectBase.set(this, 'transactionType', value);
 
   @override
@@ -411,19 +390,19 @@ class RealmTransaction extends _RealmTransaction
   set memo(String? value) => RealmObjectBase.set(this, 'memo', value);
 
   @override
-  int? get amount => RealmObjectBase.get<int>(this, 'amount') as int?;
+  int get amount => RealmObjectBase.get<int>(this, 'amount') as int;
   @override
-  set amount(int? value) => RealmObjectBase.set(this, 'amount', value);
+  set amount(int value) => RealmObjectBase.set(this, 'amount', value);
 
   @override
-  int? get fee => RealmObjectBase.get<int>(this, 'fee') as int?;
+  int get fee => RealmObjectBase.get<int>(this, 'fee') as int;
   @override
-  set fee(int? value) => RealmObjectBase.set(this, 'fee', value);
+  set fee(int value) => RealmObjectBase.set(this, 'fee', value);
 
   @override
-  int get vSize => RealmObjectBase.get<int>(this, 'vSize') as int;
+  double get vSize => RealmObjectBase.get<double>(this, 'vSize') as double;
   @override
-  set vSize(int value) => RealmObjectBase.set(this, 'vSize', value);
+  set vSize(double value) => RealmObjectBase.set(this, 'vSize', value);
 
   @override
   RealmList<String> get inputAddressList =>
@@ -447,10 +426,10 @@ class RealmTransaction extends _RealmTransaction
   set note(String? value) => RealmObjectBase.set(this, 'note', value);
 
   @override
-  DateTime? get createdAt =>
-      RealmObjectBase.get<DateTime>(this, 'createdAt') as DateTime?;
+  DateTime get createdAt =>
+      RealmObjectBase.get<DateTime>(this, 'createdAt') as DateTime;
   @override
-  set createdAt(DateTime? value) =>
+  set createdAt(DateTime value) =>
       RealmObjectBase.set(this, 'createdAt', value);
 
   @override
@@ -501,23 +480,29 @@ class RealmTransaction extends _RealmTransaction
         'id': EJsonValue id,
         'transactionHash': EJsonValue transactionHash,
         'walletId': EJsonValue walletId,
+        'timestamp': EJsonValue timestamp,
+        'blockHeight': EJsonValue blockHeight,
+        'transactionType': EJsonValue transactionType,
+        'amount': EJsonValue amount,
+        'fee': EJsonValue fee,
         'vSize': EJsonValue vSize,
+        'createdAt': EJsonValue createdAt,
       } =>
         RealmTransaction(
           fromEJson(id),
           fromEJson(transactionHash),
           fromEJson(walletId),
+          fromEJson(timestamp),
+          fromEJson(blockHeight),
+          fromEJson(transactionType),
+          fromEJson(amount),
+          fromEJson(fee),
           fromEJson(vSize),
-          timestamp: fromEJson(ejson['timestamp']),
-          blockHeight: fromEJson(ejson['blockHeight']),
-          transactionType: fromEJson(ejson['transactionType']),
+          fromEJson(createdAt),
           memo: fromEJson(ejson['memo']),
-          amount: fromEJson(ejson['amount']),
-          fee: fromEJson(ejson['fee']),
           inputAddressList: fromEJson(ejson['inputAddressList']),
           outputAddressList: fromEJson(ejson['outputAddressList']),
           note: fromEJson(ejson['note']),
-          createdAt: fromEJson(ejson['createdAt']),
           replaceByTransactionHash:
               fromEJson(ejson['replaceByTransactionHash']),
         ),
@@ -536,20 +521,19 @@ class RealmTransaction extends _RealmTransaction
       SchemaProperty('walletId', RealmPropertyType.int,
           indexType: RealmIndexType.regular),
       SchemaProperty('timestamp', RealmPropertyType.timestamp,
-          optional: true, indexType: RealmIndexType.regular),
-      SchemaProperty('blockHeight', RealmPropertyType.int, optional: true),
-      SchemaProperty('transactionType', RealmPropertyType.string,
-          optional: true),
+          indexType: RealmIndexType.regular),
+      SchemaProperty('blockHeight', RealmPropertyType.int),
+      SchemaProperty('transactionType', RealmPropertyType.string),
       SchemaProperty('memo', RealmPropertyType.string, optional: true),
-      SchemaProperty('amount', RealmPropertyType.int, optional: true),
-      SchemaProperty('fee', RealmPropertyType.int, optional: true),
-      SchemaProperty('vSize', RealmPropertyType.int),
+      SchemaProperty('amount', RealmPropertyType.int),
+      SchemaProperty('fee', RealmPropertyType.int),
+      SchemaProperty('vSize', RealmPropertyType.double),
       SchemaProperty('inputAddressList', RealmPropertyType.string,
           collectionType: RealmCollectionType.list),
       SchemaProperty('outputAddressList', RealmPropertyType.string,
           collectionType: RealmCollectionType.list),
       SchemaProperty('note', RealmPropertyType.string, optional: true),
-      SchemaProperty('createdAt', RealmPropertyType.timestamp, optional: true),
+      SchemaProperty('createdAt', RealmPropertyType.timestamp),
       SchemaProperty('replaceByTransactionHash', RealmPropertyType.string,
           optional: true),
     ]);

--- a/lib/repository/realm/transaction_repository.dart
+++ b/lib/repository/realm/transaction_repository.dart
@@ -142,7 +142,6 @@ class TransactionRepository extends BaseRepository {
     final existingTxs = realm.query<RealmTransaction>('walletId == $walletId');
     final existingTxMap = {for (var tx in existingTxs) tx.transactionHash: tx};
 
-    final now = DateTime.now();
     int lastId = getLastId(realm, (RealmTransaction).toString());
 
     // 새 트랜잭션과 업데이트할 트랜잭션을 분리
@@ -159,9 +158,8 @@ class TransactionRepository extends BaseRepository {
           tx,
           walletId,
           ++lastId,
-          now,
         ));
-      } else if (existingTx.blockHeight == 0 && (tx.blockHeight ?? 0) > 0) {
+      } else if (existingTx.blockHeight == 0 && tx.blockHeight > 0) {
         // 미확인 -> 확인 상태로 변경된 트랜잭션 - 업데이트
         txsToUpdate.add(MapEntry(existingTx, tx));
       }

--- a/lib/repository/realm/transaction_repository.dart
+++ b/lib/repository/realm/transaction_repository.dart
@@ -219,6 +219,19 @@ class TransactionRepository extends BaseRepository {
     return mapRealmTransactionToTransaction(realmTransaction);
   }
 
+  bool hasTransactionConfirmed(int walletId, String transactionHash) {
+    final realmTransaction = realm.query<RealmTransaction>(
+      r'walletId == $0 AND transactionHash == $1',
+      [walletId, transactionHash],
+    ).firstOrNull;
+
+    if (realmTransaction == null) {
+      return false;
+    }
+
+    return realmTransaction.blockHeight > 0;
+  }
+
   /// RBF 내역을 일괄 저장합니다.
   ///
   /// 중복 체크를 수행하여 이미 저장된 내역은 다시 저장하지 않습니다.

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -122,7 +122,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
                       children: [
                         HighlightedInfoArea(
                           textList: DateTimeUtil.formatTimestamp(
-                            tx.timestamp!.toLocal(),
+                            tx.timestamp.toLocal(),
                           ),
                         ),
                         CoconutLayout.spacing_500h,
@@ -147,7 +147,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
                           builder: (context, bitcoinPriceKrw, child) {
                             return Text(
                               bitcoinPriceKrw != null
-                                  ? '${_getPrefix(tx)}${addCommasToIntegerPart(FiatUtil.calculateFiatAmount(tx.amount!, bitcoinPriceKrw).toDouble().abs())} ${CurrencyCode.KRW.code}'
+                                  ? '${_getPrefix(tx)}${addCommasToIntegerPart(FiatUtil.calculateFiatAmount(tx.amount, bitcoinPriceKrw).toDouble().abs())} ${CurrencyCode.KRW.code}'
                                   : '',
                               style: CoconutTypography.body3_12_Number
                                   .setColor(CoconutColors.gray500),
@@ -764,7 +764,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
     }
 
     DateTime? timeStamp =
-        _viewModel.transactionList?.last.transaction!.timestamp!;
+        _viewModel.transactionList?.last.transaction!.timestamp;
     if (timeStamp == null) return '';
 
     DateTime now = DateTime.now();
@@ -800,7 +800,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
     String prefix = _getPrefix(tx) == '-' ? '' : '+';
     Color color = prefix == '+' ? CoconutColors.cyan : CoconutColors.primary;
 
-    return Text('$prefix${satoshiToBitcoinString(tx.amount!)}',
+    return Text('$prefix${satoshiToBitcoinString(tx.amount)}',
         style: CoconutTypography.heading2_28_NumberBold
             .copyWith(fontSize: 24, color: color));
   }
@@ -810,8 +810,8 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
       return '';
     }
 
-    if (tx.blockHeight != null && tx.blockHeight != 0 && blockHeight != 0) {
-      final confirmationCount = blockHeight - tx.blockHeight! + 1;
+    if (tx.blockHeight != 0 && blockHeight != 0) {
+      final confirmationCount = blockHeight - tx.blockHeight + 1;
       if (confirmationCount > 0) {
         return '$confirmationCount ';
       }

--- a/lib/screens/wallet_detail/transaction_fee_bumping_screen.dart
+++ b/lib/screens/wallet_detail/transaction_fee_bumping_screen.dart
@@ -438,8 +438,8 @@ class _TransactionFeeBumpingScreenState
             children: [
               Text(
                 t.transaction_fee_bumping_screen.total_fee(
-                  fee: addCommasToIntegerPart(
-                      widget.transaction.fee!.toDouble()),
+                  fee:
+                      addCommasToIntegerPart(widget.transaction.fee.toDouble()),
                   vb: addCommasToIntegerPart(
                       widget.transaction.vSize.toDouble()),
                 ),

--- a/lib/utils/transaction_util.dart
+++ b/lib/utils/transaction_util.dart
@@ -10,19 +10,19 @@ import 'package:flutter/material.dart';
 class TransactionUtil {
   static TransactionStatus? getStatus(TransactionRecord tx) {
     if (tx.transactionType == TransactionType.received.name) {
-      if (tx.blockHeight == 0 || tx.blockHeight == null) {
+      if (tx.blockHeight == 0) {
         return TransactionStatus.receiving;
       }
       return TransactionStatus.received;
     }
     if (tx.transactionType == TransactionType.sent.name) {
-      if (tx.blockHeight == 0 || tx.blockHeight == null) {
+      if (tx.blockHeight == 0) {
         return TransactionStatus.sending;
       }
       return TransactionStatus.sent;
     }
     if (tx.transactionType == TransactionType.self.name) {
-      if (tx.blockHeight == 0 || tx.blockHeight == null) {
+      if (tx.blockHeight == 0) {
         return TransactionStatus.selfsending;
       }
       return TransactionStatus.self;

--- a/lib/utils/transaction_util.dart
+++ b/lib/utils/transaction_util.dart
@@ -9,19 +9,19 @@ import 'package:flutter/material.dart';
 
 class TransactionUtil {
   static TransactionStatus? getStatus(TransactionRecord tx) {
-    if (tx.transactionType == TransactionType.received.name) {
+    if (tx.transactionType == TransactionType.received) {
       if (tx.blockHeight == 0) {
         return TransactionStatus.receiving;
       }
       return TransactionStatus.received;
     }
-    if (tx.transactionType == TransactionType.sent.name) {
+    if (tx.transactionType == TransactionType.sent) {
       if (tx.blockHeight == 0) {
         return TransactionStatus.sending;
       }
       return TransactionStatus.sent;
     }
-    if (tx.transactionType == TransactionType.self.name) {
+    if (tx.transactionType == TransactionType.self) {
       if (tx.blockHeight == 0) {
         return TransactionStatus.selfsending;
       }

--- a/lib/widgets/card/transaction_item_card.dart
+++ b/lib/widgets/card/transaction_item_card.dart
@@ -141,8 +141,8 @@ class TransactionItemCard extends StatelessWidget {
       case TransactionStatus.received:
         return Text(
           currentUnit == Unit.btc
-              ? '+${satoshiToBitcoinString(tx.amount!)}'
-              : '+${addCommasToIntegerPart(tx.amount!.toDouble())}',
+              ? '+${satoshiToBitcoinString(tx.amount)}'
+              : '+${addCommasToIntegerPart(tx.amount.toDouble())}',
           style: Styles.body1Number.merge(
             const TextStyle(
               color: MyColors.white,
@@ -157,8 +157,8 @@ class TransactionItemCard extends StatelessWidget {
       case TransactionStatus.sending:
         return Text(
           currentUnit == Unit.btc
-              ? satoshiToBitcoinString(tx.amount!)
-              : addCommasToIntegerPart(tx.amount!.toDouble()),
+              ? satoshiToBitcoinString(tx.amount)
+              : addCommasToIntegerPart(tx.amount.toDouble()),
           style: Styles.body1Number.merge(
             const TextStyle(
               color: MyColors.white,

--- a/test/mock/transaction_mock.dart
+++ b/test/mock/transaction_mock.dart
@@ -15,7 +15,7 @@ class TransactionMock {
     String? memo,
     int amount = 1000000,
     int fee = 10000,
-    int vSize = 250,
+    double vSize = 250,
     DateTime? createdAt,
   }) {
     return TransactionRecord(

--- a/test/mock/transaction_mock.dart
+++ b/test/mock/transaction_mock.dart
@@ -22,7 +22,7 @@ class TransactionMock {
       transactionHash ?? testTxHash,
       timestamp ?? DateTime.now(),
       blockHeight ?? 0,
-      transactionType.name,
+      transactionType,
       memo,
       amount,
       fee,

--- a/test/providers/node_provider/transaction_manager_test.dart
+++ b/test/providers/node_provider/transaction_manager_test.dart
@@ -189,10 +189,8 @@ void main() {
       expect(updatedTx!.blockHeight, blockHeight);
       expect(updatedTx.timestamp, isNotNull);
       final updatedTimestamp = updatedTx.timestamp;
-      if (updatedTimestamp != null) {
-        expect(updatedTimestamp.millisecondsSinceEpoch ~/ 1000,
-            blockTimestamp.millisecondsSinceEpoch ~/ 1000);
-      }
+      expect(updatedTimestamp.millisecondsSinceEpoch ~/ 1000,
+          blockTimestamp.millisecondsSinceEpoch ~/ 1000);
     });
   });
 


### PR DESCRIPTION
- vSize 값이 int라서 정확한 feeRate을 계산하기 어려운 문제 수정
- 로직 상 non-null이 보장 가능한 프로퍼티들 중에서 nullable로 사용된 프로퍼티 수정
- transactionType Enum값을 사용하고 Realm에 저장할 때만 String으로 저장하도록 수정
- Realm
  - 위에서 수정된 타입 대응
  - WalletBase에 안쓰는 프로퍼티 삭제
  