### PR TITLE
Fix/tx detail state refresh

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/constants/dotenv_keys.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -19,6 +20,10 @@ late final String dbDirectoryPath;
 const methodChannelOS = 'onl.coconut.wallet/os';
 
 void main() {
+  if (kReleaseMode) {
+    debugPrint = (String? message, {int? wrapWidth}) {};
+  }
+
   runZonedGuarded(() async {
     // This app is designed only to work vertically, so we limit
     // orientations to portrait up and down.

--- a/lib/providers/view_model/send/broadcasting_view_model.dart
+++ b/lib/providers/view_model/send/broadcasting_view_model.dart
@@ -2,7 +2,6 @@ import 'dart:collection';
 
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
-import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/providers/node_provider/node_provider.dart';
 import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/transaction_provider.dart';

--- a/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
@@ -675,14 +675,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
 
     final tx = txResult.value;
     final List<TransactionInput> inputList = Transaction.parse(tx).inputs;
-    // d65c61c2792334cf0a8c0d03ac5869f66912ba9de947bca1ace5835c7592c824
     List<Utxo> utxoList = [];
-    final utxos = _utxoRepository.getUtxoStateList(_walletId);
-    // for (var utxo in utxos) {
-    //   if (utxo.transactionHash == _pendingTx.inputAddressList[0].transactionHash) {
-    //     debugPrint('트랜잭션 조회! ${utxo.transactionHash} ${utxo.index}');
-    //   }
-    // }
     for (var input in inputList) {
       var utxo = _utxoRepository.getUtxoState(
           _walletId, makeUtxoId(input.transactionHash, input.index));

--- a/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
@@ -421,7 +421,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
     //     'RBF:: inputSum: $inputSum, outputSum: $outputSum fee current: ${outputSum - inputSum}');
 
     double requiredFee = estimatedVSize * newFeeRate;
-    int remainingFee = (requiredFee - _pendingTx.fee!).toInt();
+    int remainingFee = (requiredFee - _pendingTx.fee).toInt();
     debugPrint(
         '필요 : $requiredFee 기존: ${_pendingTx.fee} 추가할 remainingFee: $remainingFee');
     debugPrint('☑️ 기존 전송 정보');
@@ -498,7 +498,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
 
     // debugPrint('RBF:: 싱글 또는 스윕 >> amount 조정 $externalSendingAmount');
     int adjustedMyOuputAmount =
-        myOutputAmount - (newFee - _pendingTx.fee!).toInt();
+        myOutputAmount - (newFee - _pendingTx.fee).toInt();
     debugPrint('RBF::                        조정 후 $adjustedMyOuputAmount');
 
     if (adjustedMyOuputAmount == 0) {
@@ -674,9 +674,15 @@ class FeeBumpingViewModel extends ChangeNotifier {
     }
 
     final tx = txResult.value;
-    final inputList = Transaction.parse(tx).inputs;
-
+    final List<TransactionInput> inputList = Transaction.parse(tx).inputs;
+    // d65c61c2792334cf0a8c0d03ac5869f66912ba9de947bca1ace5835c7592c824
     List<Utxo> utxoList = [];
+    final utxos = _utxoRepository.getUtxoStateList(_walletId);
+    // for (var utxo in utxos) {
+    //   if (utxo.transactionHash == _pendingTx.inputAddressList[0].transactionHash) {
+    //     debugPrint('트랜잭션 조회! ${utxo.transactionHash} ${utxo.index}');
+    //   }
+    // }
     for (var input in inputList) {
       var utxo = _utxoRepository.getUtxoState(
           _walletId, makeUtxoId(input.transactionHash, input.index));
@@ -731,7 +737,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
 
     double cpfpTxSize = _estimateVirtualByte(transaction);
     double totalFee = (_pendingTx.vSize + cpfpTxSize) * recommendedFeeRate;
-    double cpfpTxFee = totalFee - _pendingTx.fee!.toDouble();
+    double cpfpTxFee = totalFee - _pendingTx.fee.toDouble();
     double cpfpTxFeeRate = cpfpTxFee / cpfpTxSize;
 
     if (cpfpTxFeeRate < recommendedFeeRate || cpfpTxFeeRate < 0) {
@@ -752,7 +758,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
 
     double estimatedVirtualByte = _estimateVirtualByte(transaction);
     double minimumRequiredFee =
-        _pendingTx.fee!.toDouble() + estimatedVirtualByte;
+        _pendingTx.fee.toDouble() + estimatedVirtualByte;
     // double mempoolRecommendedFee = estimatedVirtualByte * recommendedFeeRate;
 
     // if (mempoolRecommendedFee < minimumRequiredFee) {

--- a/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
@@ -218,6 +218,14 @@ class TransactionDetailViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  void _setPreviousTransactionIndex(int newIndex) {
+    _previousTransactionIndex = newIndex;
+  }
+
+  void _setSelectedTransactionIndex(int newIndex) {
+    _selectedTransactionIndex = newIndex;
+  }
+
   void setPreviousTransactionDetail() {
     _previousTransactionDetail =
         TransactionDetail.copy(_transactionList![selectedTransactionIndex]);
@@ -235,6 +243,8 @@ class TransactionDetailViewModel extends ChangeNotifier {
       if (updatedTx.blockHeight != currentTx.blockHeight ||
           updatedTx.transactionHash != currentTx.transactionHash) {
         _initTransactionList();
+        _setPreviousTransactionIndex(0);
+        _setSelectedTransactionIndex(0);
       }
       if (_initViewMoreButtons() == false) {
         _showDialogNotifier.value = true;

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -642,22 +642,23 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
   }
 
   bool _isTransactionStatusPending(TransactionRecord tx) {
+    _timer?.cancel();
+
     if (tx.blockHeight != 0) {
       _timer?.cancel();
       if (_timer != null) {
-        _timer == null;
+        _timer = null;
       }
       return false;
-    } else {
-      _timer?.cancel();
-      // 'n분 째' 최신화를 위한 타이머, pending 상태인 tx일 때만 타이머가 작동합니다.
-      _timer = Timer.periodic(const Duration(seconds: 30), (timer) {
-        if (mounted) {
-          setState(() {});
-        }
-      });
-      return true;
     }
+
+    // 'n분 째' 최신화를 위한 타이머, pending 상태인 tx일 때만 타이머가 작동합니다.
+    _timer = Timer.periodic(const Duration(seconds: 30), (timer) {
+      if (mounted) {
+        setState(() {});
+      }
+    });
+    return true;
   }
 
   Widget _pendingWidget(TransactionRecord tx) {

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -139,7 +139,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
                         CoconutLayout.spacing_100h,
                         Center(
                             child: FiatPrice(
-                                satoshiAmount: tx.amount!.abs(),
+                                satoshiAmount: tx.amount.abs(),
                                 textStyle: CoconutTypography.body2_14_Number
                                     .setColor(CoconutColors.gray500))),
                         CoconutLayout.spacing_400h,

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -428,11 +428,6 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
       _loadCompletedListener();
       _animationController.value = 1.0;
     });
-    _timer = Timer.periodic(const Duration(seconds: 30), (timer) {
-      if (mounted) {
-        setState(() {});
-      }
-    });
   }
 
   void _updateAnimation() {
@@ -639,7 +634,21 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
   }
 
   bool _isTransactionStatusPending(TransactionRecord tx) {
-    return tx.blockHeight == 0;
+    if (tx.blockHeight != 0) {
+      _timer?.cancel();
+      if (_timer != null) {
+        _timer == null;
+      }
+      return false;
+    } else {
+      _timer?.cancel();
+      _timer = Timer.periodic(const Duration(seconds: 30), (timer) {
+        if (mounted) {
+          setState(() {});
+        }
+      });
+      return true;
+    }
   }
 
   Widget _pendingWidget(TransactionRecord tx) {

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -58,6 +58,9 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
   late Animation<Offset> _slideInAnimation;
   late Animation<Offset> _slideOutAnimation;
 
+  int tInputCountToShow = 0;
+  int tOutputCountToShow = 0;
+
   bool isAnimating = false; // 애니메이션 실행 중 여부 확인
 
   @override
@@ -300,7 +303,8 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
 
   Widget _buildTransactionDetail(int index) {
     final transactionDetail = _viewModel.transactionList![index];
-
+    tInputCountToShow = transactionDetail.inputCountToShow;
+    tOutputCountToShow = transactionDetail.outputCountToShow;
     return Column(
       key: ValueKey(_viewModel
           .transactionList![_viewModel.selectedTransactionIndex]
@@ -311,7 +315,8 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
         ListView.builder(
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
-          itemCount: transactionDetail.inputCountToShow,
+          itemCount: _viewModel.previousInputCountToShow ??
+              transactionDetail.inputCountToShow,
           padding: EdgeInsets.zero,
           itemBuilder: (context, index) {
             final address = _viewModel.getInputAddress(index);
@@ -334,9 +339,9 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
           },
         ),
         Visibility(
-          visible: _viewModel
-              .transactionList![_viewModel.selectedTransactionIndex]
-              .canSeeMoreInputs,
+          visible: _viewModel.previousCanSeeMoreInputs ??
+              _viewModel.transactionList![_viewModel.selectedTransactionIndex]
+                  .canSeeMoreInputs,
           child: Center(
             child: CustomUnderlinedButton(
               text: t.view_more,
@@ -363,7 +368,8 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
         ListView.builder(
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
-          itemCount: transactionDetail.outputCountToShow,
+          itemCount: _viewModel.previousOutputCountToShow ??
+              transactionDetail.outputCountToShow,
           padding: EdgeInsets.zero,
           itemBuilder: (context, index) {
             final address = _viewModel.getOutputAddress(index);
@@ -386,7 +392,8 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
           },
         ),
         Visibility(
-          visible: transactionDetail.canSeeMoreOutputs,
+          visible: _viewModel.previousCanSeeMoreOutputs ??
+              transactionDetail.canSeeMoreOutputs,
           child: Center(
             child: CustomUnderlinedButton(
               text: t.view_more,
@@ -520,6 +527,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
                           isSelected:
                               _viewModel.selectedTransactionIndex == index,
                           onTap: () {
+                            _viewModel.resetPreviousCountValues();
                             _changeTransaction(index);
                           },
                         ),
@@ -642,6 +650,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
       return false;
     } else {
       _timer?.cancel();
+      // 'n분 째' 최신화를 위한 타이머, pending 상태인 tx일 때만 타이머가 작동합니다.
       _timer = Timer.periodic(const Duration(seconds: 30), (timer) {
         if (mounted) {
           setState(() {});


### PR DESCRIPTION
- Pending 상태에서 transaction_detail 화면에 머물러 있을 때 confirm 되면 발생하던 out of range 에러 해결
- 'n분 째' 갱신용 타이머에 의해 화면이 30초간격으로 갱신되는 현상 -> 표시중인 input/output 개수 초기화, '더보기'버튼 표시 여부 초기화 되는 현상이 발생 -> 이 현상을 해결했습니다. pending상태가 아니라면(blockheight != 0) 타이머는 작동하지 않습니다.