### PR TITLE
[164] 네트워크 동시성 오류 수정

### DIFF
--- a/lib/constants/network_constants.dart
+++ b/lib/constants/network_constants.dart
@@ -9,3 +9,6 @@ const int kSocketReconnectDelaySeconds = 10;
 const Duration kElectrumResponseTimeout = Duration(seconds: 60);
 
 const Duration kElectrumPingInterval = Duration(seconds: 20);
+
+/// 트랜잭션 처리 중복 방지를 위한 타임아웃 시간
+const Duration kTransactionProcessingTimeout = Duration(seconds: 30);

--- a/lib/model/node/wallet_update_info.dart
+++ b/lib/model/node/wallet_update_info.dart
@@ -7,10 +7,18 @@ class WalletUpdateInfo {
   UpdateStatus utxo;
   UpdateStatus transaction;
 
+  // 동시성 제어를 위한 카운터 추가
+  int balanceCounter;
+  int utxoCounter;
+  int transactionCounter;
+
   WalletUpdateInfo(this.walletId,
       {this.balance = UpdateStatus.waiting,
       this.transaction = UpdateStatus.waiting,
-      this.utxo = UpdateStatus.waiting});
+      this.utxo = UpdateStatus.waiting,
+      this.balanceCounter = 0,
+      this.utxoCounter = 0,
+      this.transactionCounter = 0});
 
   @override
   bool operator ==(Object other) =>
@@ -25,10 +33,18 @@ class WalletUpdateInfo {
   int get hashCode => Object.hash(walletId, balance, utxo, transaction);
 
   factory WalletUpdateInfo.fromExisting(WalletUpdateInfo existingInfo,
-      {UpdateStatus? balance, UpdateStatus? transaction, UpdateStatus? utxo}) {
+      {UpdateStatus? balance,
+      UpdateStatus? transaction,
+      UpdateStatus? utxo,
+      int? balanceCounter,
+      int? utxoCounter,
+      int? transactionCounter}) {
     return WalletUpdateInfo(existingInfo.walletId,
         balance: balance ?? existingInfo.balance,
         transaction: transaction ?? existingInfo.transaction,
-        utxo: utxo ?? existingInfo.utxo);
+        utxo: utxo ?? existingInfo.utxo,
+        balanceCounter: balanceCounter ?? existingInfo.balanceCounter,
+        utxoCounter: utxoCounter ?? existingInfo.utxoCounter,
+        transactionCounter: transactionCounter ?? existingInfo.transactionCounter);
   }
 }

--- a/lib/model/node/wallet_update_info.dart
+++ b/lib/model/node/wallet_update_info.dart
@@ -7,18 +7,12 @@ class WalletUpdateInfo {
   UpdateStatus utxo;
   UpdateStatus transaction;
 
-  // 동시성 제어를 위한 카운터 추가
-  int balanceCounter;
-  int utxoCounter;
-  int transactionCounter;
-
-  WalletUpdateInfo(this.walletId,
-      {this.balance = UpdateStatus.waiting,
-      this.transaction = UpdateStatus.waiting,
-      this.utxo = UpdateStatus.waiting,
-      this.balanceCounter = 0,
-      this.utxoCounter = 0,
-      this.transactionCounter = 0});
+  WalletUpdateInfo(
+    this.walletId, {
+    this.balance = UpdateStatus.waiting,
+    this.transaction = UpdateStatus.waiting,
+    this.utxo = UpdateStatus.waiting,
+  });
 
   @override
   bool operator ==(Object other) =>
@@ -33,18 +27,10 @@ class WalletUpdateInfo {
   int get hashCode => Object.hash(walletId, balance, utxo, transaction);
 
   factory WalletUpdateInfo.fromExisting(WalletUpdateInfo existingInfo,
-      {UpdateStatus? balance,
-      UpdateStatus? transaction,
-      UpdateStatus? utxo,
-      int? balanceCounter,
-      int? utxoCounter,
-      int? transactionCounter}) {
+      {UpdateStatus? balance, UpdateStatus? transaction, UpdateStatus? utxo}) {
     return WalletUpdateInfo(existingInfo.walletId,
         balance: balance ?? existingInfo.balance,
         transaction: transaction ?? existingInfo.transaction,
-        utxo: utxo ?? existingInfo.utxo,
-        balanceCounter: balanceCounter ?? existingInfo.balanceCounter,
-        utxoCounter: utxoCounter ?? existingInfo.utxoCounter,
-        transactionCounter: transactionCounter ?? existingInfo.transactionCounter);
+        utxo: utxo ?? existingInfo.utxo);
   }
 }

--- a/lib/providers/node_provider/isolate/isolate_manager.dart
+++ b/lib/providers/node_provider/isolate/isolate_manager.dart
@@ -9,6 +9,7 @@ import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/node_provider/balance_manager.dart';
 import 'package:coconut_wallet/providers/node_provider/isolate/isolate_enum.dart';
 import 'package:coconut_wallet/providers/node_provider/network_manager.dart';
+import 'package:coconut_wallet/providers/node_provider/subscription/script_callback_manager.dart';
 import 'package:coconut_wallet/providers/node_provider/subscription_manager.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_manager.dart';
 import 'package:coconut_wallet/providers/node_provider/utxo_manager.dart';
@@ -66,8 +67,14 @@ class IsolateManager {
         BalanceManager(electrumService, isolateStateManager, addressRepository, walletRepository);
     final UtxoManager utxoManager = UtxoManager(electrumService, isolateStateManager,
         utxoRepository, transactionRepository, addressRepository);
-    final TransactionManager transactionManager = TransactionManager(electrumService,
-        isolateStateManager, transactionRepository, utxoManager, addressRepository);
+    final ScriptCallbackManager scriptCallbackManager = ScriptCallbackManager();
+    final TransactionManager transactionManager = TransactionManager(
+        electrumService,
+        isolateStateManager,
+        transactionRepository,
+        utxoManager,
+        addressRepository,
+        scriptCallbackManager);
     final NetworkManager networkManager = NetworkManager(electrumService);
     final SubscriptionManager subscriptionManager = SubscriptionManager(
       electrumService,
@@ -77,6 +84,7 @@ class IsolateManager {
       utxoManager,
       addressRepository,
       subscribeRepository,
+      scriptCallbackManager,
     );
 
     final isolateHandler = IsolateHandler(

--- a/lib/providers/node_provider/state_manager.dart
+++ b/lib/providers/node_provider/state_manager.dart
@@ -91,7 +91,7 @@ class NodeStateManager implements StateManagerInterface {
     );
   }
 
-  /// 지갑의 업데이트 정보를 추가합니다.
+  /// 지갑의 동기화 상태 증가 및 상태 업데이트
   @override
   void addWalletSyncState(int walletId, UpdateElement updateType) {
     final existingInfo = _state.registeredWallets[walletId];
@@ -104,14 +104,18 @@ class NodeStateManager implements StateManagerInterface {
       walletUpdateInfo = WalletUpdateInfo.fromExisting(existingInfo);
     }
 
+    // 카운터 증가 및 상태 업데이트
     switch (updateType) {
       case UpdateElement.balance:
+        walletUpdateInfo.balanceCounter++;
         walletUpdateInfo.balance = UpdateStatus.syncing;
         break;
       case UpdateElement.transaction:
+        walletUpdateInfo.transactionCounter++;
         walletUpdateInfo.transaction = UpdateStatus.syncing;
         break;
       case UpdateElement.utxo:
+        walletUpdateInfo.utxoCounter++;
         walletUpdateInfo.utxo = UpdateStatus.syncing;
         break;
     }
@@ -126,27 +130,47 @@ class NodeStateManager implements StateManagerInterface {
     );
   }
 
+  /// 지갑의 동기화 상태 감소 및 완료 여부 업데이트
   @override
   void addWalletCompletedState(int walletId, UpdateElement updateType) {
     final existingInfo = _state.registeredWallets[walletId];
 
-    WalletUpdateInfo walletUpdateInfo;
-
+    // 기존 정보가 없으면 아무 작업도 수행하지 않음
     if (existingInfo == null) {
-      walletUpdateInfo = WalletUpdateInfo(walletId);
-    } else {
-      walletUpdateInfo = WalletUpdateInfo.fromExisting(existingInfo);
+      Logger.error('지갑 ID $walletId에 대한 정보가 없어 완료 상태로 변경할 수 없습니다.');
+      return;
     }
 
+    WalletUpdateInfo walletUpdateInfo = WalletUpdateInfo.fromExisting(existingInfo);
+
+    // 카운터 감소 및 상태 업데이트
     switch (updateType) {
       case UpdateElement.balance:
-        walletUpdateInfo.balance = UpdateStatus.completed;
+        if (walletUpdateInfo.balanceCounter > 0) {
+          walletUpdateInfo.balanceCounter--;
+        }
+        // 카운터가 0이 되면 완료 상태로 변경
+        if (walletUpdateInfo.balanceCounter == 0) {
+          walletUpdateInfo.balance = UpdateStatus.completed;
+        }
         break;
       case UpdateElement.transaction:
-        walletUpdateInfo.transaction = UpdateStatus.completed;
+        if (walletUpdateInfo.transactionCounter > 0) {
+          walletUpdateInfo.transactionCounter--;
+        }
+        // 카운터가 0이 되면 완료 상태로 변경
+        if (walletUpdateInfo.transactionCounter == 0) {
+          walletUpdateInfo.transaction = UpdateStatus.completed;
+        }
         break;
       case UpdateElement.utxo:
-        walletUpdateInfo.utxo = UpdateStatus.completed;
+        if (walletUpdateInfo.utxoCounter > 0) {
+          walletUpdateInfo.utxoCounter--;
+        }
+        // 카운터가 0이 되면 완료 상태로 변경
+        if (walletUpdateInfo.utxoCounter == 0) {
+          walletUpdateInfo.utxo = UpdateStatus.completed;
+        }
         break;
     }
 
@@ -160,11 +184,34 @@ class NodeStateManager implements StateManagerInterface {
 
   @override
   void addWalletCompletedAllStates(int walletId) {
-    final updateInfo = WalletUpdateInfo(walletId);
+    final existingInfo = _state.registeredWallets[walletId];
 
-    updateInfo.balance = UpdateStatus.completed;
-    updateInfo.transaction = UpdateStatus.completed;
-    updateInfo.utxo = UpdateStatus.completed;
+    // 기존 정보가 없으면 새 정보 생성
+    if (existingInfo == null) {
+      final updateInfo = WalletUpdateInfo(
+        walletId,
+        balance: UpdateStatus.completed,
+        transaction: UpdateStatus.completed,
+        utxo: UpdateStatus.completed,
+      );
+
+      setState(newUpdatedWallets: {
+        ..._state.registeredWallets,
+        walletId: updateInfo,
+      });
+      return;
+    }
+
+    // 기존 정보가 있는 경우 모든 카운터를 0으로 설정하고 상태를 완료로 변경
+    final updateInfo = WalletUpdateInfo.fromExisting(
+      existingInfo,
+      balance: UpdateStatus.completed,
+      transaction: UpdateStatus.completed,
+      utxo: UpdateStatus.completed,
+      balanceCounter: 0,
+      transactionCounter: 0,
+      utxoCounter: 0,
+    );
 
     setState(newUpdatedWallets: {
       ..._state.registeredWallets,

--- a/lib/providers/node_provider/state_manager.dart
+++ b/lib/providers/node_provider/state_manager.dart
@@ -107,15 +107,12 @@ class NodeStateManager implements StateManagerInterface {
     // 카운터 증가 및 상태 업데이트
     switch (updateType) {
       case UpdateElement.balance:
-        walletUpdateInfo.balanceCounter++;
         walletUpdateInfo.balance = UpdateStatus.syncing;
         break;
       case UpdateElement.transaction:
-        walletUpdateInfo.transactionCounter++;
         walletUpdateInfo.transaction = UpdateStatus.syncing;
         break;
       case UpdateElement.utxo:
-        walletUpdateInfo.utxoCounter++;
         walletUpdateInfo.utxo = UpdateStatus.syncing;
         break;
     }
@@ -146,31 +143,13 @@ class NodeStateManager implements StateManagerInterface {
     // 카운터 감소 및 상태 업데이트
     switch (updateType) {
       case UpdateElement.balance:
-        if (walletUpdateInfo.balanceCounter > 0) {
-          walletUpdateInfo.balanceCounter--;
-        }
-        // 카운터가 0이 되면 완료 상태로 변경
-        if (walletUpdateInfo.balanceCounter == 0) {
-          walletUpdateInfo.balance = UpdateStatus.completed;
-        }
+        walletUpdateInfo.balance = UpdateStatus.completed;
         break;
       case UpdateElement.transaction:
-        if (walletUpdateInfo.transactionCounter > 0) {
-          walletUpdateInfo.transactionCounter--;
-        }
-        // 카운터가 0이 되면 완료 상태로 변경
-        if (walletUpdateInfo.transactionCounter == 0) {
-          walletUpdateInfo.transaction = UpdateStatus.completed;
-        }
+        walletUpdateInfo.transaction = UpdateStatus.completed;
         break;
       case UpdateElement.utxo:
-        if (walletUpdateInfo.utxoCounter > 0) {
-          walletUpdateInfo.utxoCounter--;
-        }
-        // 카운터가 0이 되면 완료 상태로 변경
-        if (walletUpdateInfo.utxoCounter == 0) {
-          walletUpdateInfo.utxo = UpdateStatus.completed;
-        }
+        walletUpdateInfo.utxo = UpdateStatus.completed;
         break;
     }
 
@@ -208,9 +187,6 @@ class NodeStateManager implements StateManagerInterface {
       balance: UpdateStatus.completed,
       transaction: UpdateStatus.completed,
       utxo: UpdateStatus.completed,
-      balanceCounter: 0,
-      transactionCounter: 0,
-      utxoCounter: 0,
     );
 
     setState(newUpdatedWallets: {

--- a/lib/providers/node_provider/subscription/script_callback_manager.dart
+++ b/lib/providers/node_provider/subscription/script_callback_manager.dart
@@ -1,0 +1,122 @@
+import 'package:coconut_wallet/model/node/script_status.dart';
+import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
+import 'package:coconut_wallet/providers/node_provider/subscription/script_handler_util.dart';
+import 'package:coconut_wallet/providers/node_provider/subscription/transaction_processing_state.dart';
+
+class ScriptCallbackManager {
+  /// 스크립트별 트랜잭션 조회 후 콜백 함수 실행 시 선행 트랜잭션 조회 여부 확인용
+  /// 해당 스크립트별 조회가 필요한 트랜잭션 해시 목록이며 값이 비어있으면 해당 스크립트에 대한 콜백 함수는 실행 가능한 상태로 간주함
+  /// key: ScriptKey, value: TxHash 목록
+  final Map<String, List<String>> _scriptDependency = <String, List<String>>{};
+
+  /// 스크립트별 트랜잭션 조회 후 fetchUtxos 콜백 함수
+  /// key: ScriptKey, value: Function
+  final Map<String, Future<void> Function()> _fetchUtxosCallback =
+      <String, Future<void> Function()>{};
+
+  /// 현재 처리 중인 트랜잭션 해시와 처리 시작 시간을 추적하기 위한 맵
+  /// key: "txHash", value: ({DateTime startTime, bool isConfirmed, bool isCompleted})
+  final Map<String, TransactionProcessingState> _processingTransactions = {};
+
+  /// 트랜잭션의 처리 가능 여부를 확인합니다.
+  ///
+  /// 다음 조건 중 하나라도 만족하면 `true`를 반환합니다:
+  /// - 등록된 트랜잭션이 없는 경우
+  /// - 트랜잭션 처리 타임아웃이 지난 경우
+  /// - 트랜잭션이 언컨펌에서 컨펌 상태로 변경된 경우
+  ///
+  /// 위 조건을 만족하지 않으면 `false`를 반환합니다.
+  bool isTransactionProcessable({required String txHash, required bool isConfirmed}) {
+    if (!_processingTransactions.containsKey(txHash)) return true;
+
+    final processInfo = _processingTransactions[txHash]!;
+
+    if (processInfo.isProcessable()) {
+      _processingTransactions.remove(txHash);
+      return true;
+    }
+
+    // 컨펌 여부가 다른 경우는 컨펌된 경우밖에 없음
+    if (processInfo.isConfirmed != isConfirmed) {
+      processInfo.setConfirmed();
+      return true;
+    }
+
+    return false;
+  }
+
+  /// 트랜잭션의 처리를 시작합니다.
+  void registerTransactionProcessing(String txHash, bool isConfirmed) {
+    _processingTransactions[txHash] = TransactionProcessingState(
+      DateTime.now(),
+      isConfirmed,
+      false,
+    );
+  }
+
+  /// fetchUtxos 콜백 함수 등록
+  void registerFetchUtxosCallback(String scriptKey, Future<void> Function() callback) {
+    _fetchUtxosCallback[scriptKey] = callback;
+  }
+
+  /// fetchTransactions 종료 후 반환된 트랜잭션 해시 목록을 기반으로 스크립트 종속성 등록.
+  /// 만약 모든 트랜잭션이 처리 완료되었으면 스크립트 종속성 등록 없이 바로 fetchUtxos 함수 실행
+  Future<void> registerTransactionDependency(
+    WalletListItemBase walletItem,
+    ScriptStatus status,
+    List<String> txHashes,
+  ) async {
+    final scriptKey = getScriptKey(walletItem.id, status.derivationPath);
+
+    // 모든 트랜잭션이 처리 완료되었으면 fetchUtxos 함수 실행
+    if (areAllTransactionsCompleted(txHashes)) {
+      callFetchUtxosCallback(scriptKey);
+      return;
+    }
+
+    final processingTxHashes = txHashes
+        .where((txHash) => !(_processingTransactions[txHash]?.isCompleted ?? false))
+        .toList();
+
+    // 처리 중인 트랜잭션만 종속성으로 등록
+    if (processingTxHashes.isNotEmpty) {
+      _scriptDependency[scriptKey] = processingTxHashes;
+      return;
+    }
+  }
+
+  /// 트랜잭션의 처리를 완료 상태로 변경합니다.
+  void registerTransactionCompletion(String txHash) {
+    if (_processingTransactions.containsKey(txHash)) {
+      _processingTransactions[txHash]!.setCompleted();
+    }
+  }
+
+  /// 모든 스크립트 종속성에서 해당 트랜잭션 해시를 제거
+  void deleteTransactionDependency(String txHash) {
+    for (final scriptKey in _scriptDependency.keys.toList()) {
+      if (_scriptDependency[scriptKey]?.contains(txHash) ?? false) {
+        _scriptDependency[scriptKey]?.remove(txHash);
+
+        // 종속성이 모두 제거되었다면 fetchUtxos 콜백 실행
+        if (_scriptDependency[scriptKey]?.isEmpty ?? false) {
+          callFetchUtxosCallback(scriptKey);
+        }
+      }
+    }
+  }
+
+  /// fetchUtxos 콜백 함수 실행
+  void callFetchUtxosCallback(String scriptKey) {
+    final callback = _fetchUtxosCallback[scriptKey];
+    if (callback != null) {
+      callback();
+      _fetchUtxosCallback.remove(scriptKey);
+    }
+  }
+
+  /// 모든 트랜잭션이 처리 완료되었는지 확인합니다.
+  bool areAllTransactionsCompleted(List<String> txHashes) {
+    return txHashes.every((txHash) => _processingTransactions[txHash]?.isCompleted ?? false);
+  }
+}

--- a/lib/providers/node_provider/subscription/script_event_handler.dart
+++ b/lib/providers/node_provider/subscription/script_event_handler.dart
@@ -107,14 +107,19 @@ class ScriptEventHandler {
     required List<ScriptStatus> scriptStatuses,
   }) async {
     try {
+      final now = DateTime.now();
       // Balance 병렬 처리
       await _balanceManager.fetchScriptBalanceBatch(walletItem, scriptStatuses);
 
       // Transaction 병렬 처리
       _stateManager.addWalletSyncState(walletItem.id, UpdateElement.transaction);
       final transactionFutures = scriptStatuses.map(
-        (status) =>
-            _transactionManager.fetchScriptTransaction(walletItem, status, inBatchProcess: true),
+        (status) => _transactionManager.fetchScriptTransaction(
+          walletItem,
+          status,
+          inBatchProcess: true,
+          now: now,
+        ),
       );
       await Future.wait(transactionFutures);
       _stateManager.addWalletCompletedState(walletItem.id, UpdateElement.transaction);

--- a/lib/providers/node_provider/subscription/script_event_handler.dart
+++ b/lib/providers/node_provider/subscription/script_event_handler.dart
@@ -125,6 +125,10 @@ class ScriptEventHandler {
   }) async {
     try {
       final now = DateTime.now();
+
+      // 지갑 업데이트 상태 초기화
+      _stateManager.initWalletUpdateStatus(walletItem.id);
+
       // Balance 병렬 처리
       await _balanceManager.fetchScriptBalanceBatch(walletItem, scriptStatuses);
 

--- a/lib/providers/node_provider/subscription/script_event_handler.dart
+++ b/lib/providers/node_provider/subscription/script_event_handler.dart
@@ -38,8 +38,6 @@ class ScriptEventHandler {
   Future<void> handleScriptStatusChanged(SubscribeScriptStreamDto dto) async {
     try {
       final now = DateTime.now();
-      Logger.log(
-          'HandleScriptStatusChanged: ${dto.walletItem.name} - ${dto.scriptStatus.derivationPath}');
 
       // 지갑 업데이트 상태 초기화
       _stateManager.initWalletUpdateStatus(dto.walletItem.id);

--- a/lib/providers/node_provider/subscription/script_event_handler.dart
+++ b/lib/providers/node_provider/subscription/script_event_handler.dart
@@ -5,6 +5,8 @@ import 'package:coconut_wallet/model/node/script_status.dart';
 import 'package:coconut_wallet/model/node/subscribe_stream_dto.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/node_provider/balance_manager.dart';
+import 'package:coconut_wallet/providers/node_provider/subscription/script_callback_manager.dart';
+import 'package:coconut_wallet/providers/node_provider/subscription/script_handler_util.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_manager.dart';
 import 'package:coconut_wallet/providers/node_provider/utxo_manager.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
@@ -20,6 +22,7 @@ class ScriptEventHandler {
   final UtxoManager _utxoManager;
   final AddressRepository _addressRepository;
   final Future<Result<bool>> Function(WalletListItemBase walletItem) _subscribeWallet;
+  final ScriptCallbackManager _scriptCallbackManager;
 
   ScriptEventHandler(
     this._stateManager,
@@ -28,6 +31,7 @@ class ScriptEventHandler {
     this._utxoManager,
     this._addressRepository,
     this._subscribeWallet,
+    this._scriptCallbackManager,
   );
 
   /// 스크립트 상태 변경 이벤트 처리
@@ -39,6 +43,12 @@ class ScriptEventHandler {
 
       // 지갑 업데이트 상태 초기화
       _stateManager.initWalletUpdateStatus(dto.walletItem.id);
+
+      //fetchScriptUtxo 함수에서 트랜잭션 정보가 필요함. 따라서 실제 트랜잭션 정보가 모두 처리된 후에 호출되도록 콜백함수 등록
+      _scriptCallbackManager.registerFetchUtxosCallback(
+        getScriptKey(dto.walletItem.id, dto.scriptStatus.derivationPath),
+        () => _utxoManager.fetchScriptUtxo(dto.walletItem, dto.scriptStatus),
+      );
 
       // 스크립트 상태가 변경되었으면 주소 사용 여부 업데이트
       if (dto.scriptStatus.status != null) {
@@ -61,42 +71,36 @@ class ScriptEventHandler {
       // Balance 동기화
       await _balanceManager.fetchScriptBalance(dto.walletItem, dto.scriptStatus);
 
-      // UTXO 동기화 시작 state 업데이트
-      _stateManager.addWalletSyncState(dto.walletItem.id, UpdateElement.utxo);
-      // UTXO 처리를 위한 콜백 함수 정의 (로컬 함수 선언 문법 사용)
-      Future<void> utxoProcessCallback() async {
-        // UTXO 동기화
-        await _utxoManager.fetchScriptUtxo(dto.walletItem, dto.scriptStatus);
+      // Transaction 동기화, 이벤트를 수신한 시점의 시간을 사용하기 위해 now 파라미터 전달
+      final txHashes = await _transactionManager.fetchScriptTransaction(
+        dto.walletItem,
+        dto.scriptStatus,
+        now: now,
+      );
 
-        // 새 스크립트 구독 여부 확인 및 처리
-        if (_needSubscriptionUpdate(
-          dto.walletItem,
-          oldUsedIndex,
-          dto.scriptStatus.isChange,
-        )) {
-          final subResult = await _subscribeWallet(dto.walletItem);
+      _scriptCallbackManager.registerTransactionDependency(
+        dto.walletItem,
+        dto.scriptStatus,
+        txHashes,
+      );
 
-          if (subResult.isSuccess) {
-            Logger.log('Successfully extended script subscription for ${dto.walletItem.name}');
-          } else {
-            Logger.error('Failed to extend script subscription: ${subResult.error}');
-          }
+      // 새 스크립트 구독 여부 확인 및 처리
+      if (_needSubscriptionUpdate(
+        dto.walletItem,
+        oldUsedIndex,
+        dto.scriptStatus.isChange,
+      )) {
+        final subResult = await _subscribeWallet(dto.walletItem);
+
+        if (subResult.isSuccess) {
+          Logger.log('Successfully extended script subscription for ${dto.walletItem.name}');
+        } else {
+          Logger.error('Failed to extend script subscription: ${subResult.error}');
         }
-
-        // 동기화 완료 state 업데이트
-        _stateManager.setState(newConnectionState: MainClientState.waiting);
       }
 
-      // Transaction 동기화를 수행하고, 콜백으로 UTXO 처리를 등록
-      // 트랜잭션 처리 완료 후 UTXO 처리가 자동으로 실행됨
-      await _transactionManager.registerTransactionCallback(
-          dto.walletItem, dto.scriptStatus, utxoProcessCallback);
-
-      // Transaction 동기화, 이벤트를 수신한 시점의 시간을 사용하기 위해 now 파라미터 전달
-      await _transactionManager.fetchScriptTransaction(dto.walletItem, dto.scriptStatus, now: now);
-
-      // 참고: 여기서는 UTXO 처리를 직접 호출하지 않음
-      // UTXO 처리는 트랜잭션 처리가 완료되면 콜백을 통해 자동으로 실행됨
+      // TODO: 동기화 완료 state 업데이트, 이벤트 핸들러간 동시성 제어 필요
+      _stateManager.setState(newConnectionState: MainClientState.waiting);
     } catch (e) {
       Logger.error('Failed to handle script status change: $e');
       // 오류 발생 시에도 상태 초기화

--- a/lib/providers/node_provider/subscription/script_handler_util.dart
+++ b/lib/providers/node_provider/subscription/script_handler_util.dart
@@ -1,0 +1,29 @@
+/// 스크립트 키를 생성합니다.
+///
+/// [walletId] 지갑 ID
+/// [derivationPath] 스크립트 경로
+///
+/// 반환값: 스크립트 키 (형식: '지갑ID:derivationPath')
+String getScriptKey(int walletId, String derivationPath) {
+  return '$walletId:$derivationPath';
+}
+
+/// 주어진 스크립트 키가 특정 지갑 ID에 속하는지 확인합니다.
+///
+/// [scriptKey] 확인할 스크립트 키 (형식: '지갑ID:derivationPath')
+/// [walletId] 확인할 지갑 ID
+///
+/// 반환값: 스크립트 키가 해당 지갑 ID에 속하면 true, 그렇지 않으면 false
+bool isScriptKeyBelongsToWallet(String scriptKey, int walletId) {
+  if (scriptKey.isEmpty) return false;
+
+  final parts = scriptKey.split(':');
+  if (parts.length < 2) return false;
+
+  try {
+    final scriptWalletId = int.parse(parts[0]);
+    return scriptWalletId == walletId;
+  } catch (e) {
+    return false;
+  }
+}

--- a/lib/providers/node_provider/subscription/script_subscriber.dart
+++ b/lib/providers/node_provider/subscription/script_subscriber.dart
@@ -118,7 +118,7 @@ class ScriptSubscriber {
           walletItem.receiveUsedIndex = lastUsedIndex;
         }
 
-        Logger.log('Updated ${isChange ? "change" : "receive"} lastUsedIndex to $lastUsedIndex');
+        // Logger.log('Updated ${isChange ? "change" : "receive"} lastUsedIndex to $lastUsedIndex');
       }
 
       // 사용된 주소가 발견된 경우 스캔 범위 확장
@@ -256,8 +256,8 @@ class ScriptSubscriber {
             walletItem.changeUsedIndex = max(walletItem.changeUsedIndex, derivationIndex);
 
             needsExtension = true;
-            Logger.log(
-                'Status changed for change address at index $derivationIndex: "$currentStatus" -> "$newStatus"');
+            // Logger.log(
+            //     'Status changed for change address at index $derivationIndex: "$currentStatus" -> "$newStatus"');
           }
         } else {
           // 안전하게 현재 최신 상태의 인덱스와 비교
@@ -269,15 +269,15 @@ class ScriptSubscriber {
             walletItem.receiveUsedIndex = max(walletItem.receiveUsedIndex, derivationIndex);
 
             needsExtension = true;
-            Logger.log(
-                'Status changed for receive address at index $derivationIndex: "$currentStatus" -> "$newStatus"');
+            // Logger.log(
+            //     'Status changed for receive address at index $derivationIndex: "$currentStatus" -> "$newStatus"');
           }
         }
 
         // 확장 조건이 충족되면 스캔 범위 확장
         if (needsExtension) {
-          Logger.log(
-              'Triggering extension from onUpdate callback for ${isChange ? "change" : "receive"} index $derivationIndex');
+          // Logger.log(
+          //     'Triggering extension from onUpdate callback for ${isChange ? "change" : "receive"} index $derivationIndex');
           // 추가 주소 구독이 필요한 경우 비동기로 처리
           _extendSubscription(walletItem, isChange, scriptStatusController);
         }

--- a/lib/providers/node_provider/subscription/transaction_processing_state.dart
+++ b/lib/providers/node_provider/subscription/transaction_processing_state.dart
@@ -1,0 +1,33 @@
+import 'package:coconut_wallet/constants/network_constants.dart';
+
+class TransactionProcessingState {
+  final DateTime _startTime;
+  bool _isConfirmed;
+  bool _isCompleted;
+
+  DateTime get startTime => _startTime;
+  bool get isConfirmed => _isConfirmed;
+  bool get isCompleted => _isCompleted;
+
+  TransactionProcessingState(this._startTime, this._isConfirmed, this._isCompleted);
+
+  void setCompleted() {
+    _isCompleted = true;
+  }
+
+  void setConfirmed() {
+    _isConfirmed = true;
+  }
+
+  bool isProcessable() {
+    if (isCompleted) {
+      final timeElapsed = DateTime.now().difference(startTime);
+
+      if (timeElapsed >= kTransactionProcessingTimeout) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/lib/providers/node_provider/subscription_manager.dart
+++ b/lib/providers/node_provider/subscription_manager.dart
@@ -5,6 +5,7 @@ import 'package:coconut_wallet/model/node/script_status.dart';
 import 'package:coconut_wallet/model/node/subscribe_stream_dto.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/node_provider/balance_manager.dart';
+import 'package:coconut_wallet/providers/node_provider/subscription/script_callback_manager.dart';
 import 'package:coconut_wallet/providers/node_provider/subscription/script_event_handler.dart';
 import 'package:coconut_wallet/providers/node_provider/subscription/script_subscriber.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_manager.dart';
@@ -25,6 +26,7 @@ class SubscriptionManager {
   final UtxoManager _utxoManager;
   final AddressRepository _addressRepository;
   final SubscriptionRepository _subscriptionRepository;
+  final ScriptCallbackManager _scriptCallbackManager;
 
   // 구독중인 스크립트 상태 변경을 인지하는 컨트롤러
   late StreamController<SubscribeScriptStreamDto> _scriptStatusController;
@@ -39,6 +41,7 @@ class SubscriptionManager {
     this._utxoManager,
     this._addressRepository,
     this._subscriptionRepository,
+    this._scriptCallbackManager,
   ) {
     _scriptStatusController = StreamController<SubscribeScriptStreamDto>.broadcast();
 
@@ -55,6 +58,7 @@ class SubscriptionManager {
       _utxoManager,
       _addressRepository,
       subscribeWallet,
+      _scriptCallbackManager,
     );
 
     _scriptStatusController.stream.listen(_scriptEventHandler.handleScriptStatusChanged);

--- a/lib/providers/node_provider/transaction/transaction_fetcher.dart
+++ b/lib/providers/node_provider/transaction/transaction_fetcher.dart
@@ -65,6 +65,7 @@ class TransactionFetcher {
     ScriptStatus scriptStatus, {
     DateTime? now,
     bool inBatchProcess = false,
+    void Function()? onComplete,
   }) async {
     if (!inBatchProcess) {
       // Transaction 동기화 시작 state 업데이트
@@ -93,6 +94,7 @@ class TransactionFetcher {
       if (!inBatchProcess) {
         _stateManager.addWalletCompletedState(walletItem.id, UpdateElement.transaction);
       }
+      onComplete?.call();
       return;
     }
 
@@ -247,6 +249,8 @@ class TransactionFetcher {
       // Transaction 업데이트 완료 state 업데이트
       _stateManager.addWalletCompletedState(walletItem.id, UpdateElement.transaction);
     }
+
+    onComplete?.call();
   }
 
   /// 스크립트에 대한 트랜잭션 응답을 가져옵니다.

--- a/lib/providers/node_provider/transaction/transaction_fetcher.dart
+++ b/lib/providers/node_provider/transaction/transaction_fetcher.dart
@@ -127,7 +127,7 @@ class TransactionFetcher {
     // 각 트랜잭션에 대해 사용된 UTXO 상태 업데이트
     for (final fetchedTx in fetchedTransactions) {
       Logger.log(
-          '-------- fetchScriptTransaction 처리중인 트랜잭션: ${fetchedTx.transactionHash} --------');
+          '-------- fetchScriptTransaction에서 처리중인 트랜잭션: ${fetchedTx.transactionHash} --------');
       // 언컨펌 트랜잭션의 경우 새로 브로드캐스트된 트랜잭션이므로 사용된 UTXO 상태 업데이트
       if (unconfirmedFetchedTxHashes.contains(fetchedTx.transactionHash)) {
         // RBF 및 CPFP 감지
@@ -137,7 +137,6 @@ class TransactionFetcher {
         );
         if (sendingRbfInfo != null) {
           sendingRbfInfoMap[fetchedTx.transactionHash] = sendingRbfInfo;
-          Logger.log('[${walletItem.name}] 보내는 RBF 트랜잭션 감지됨: ${fetchedTx.transactionHash}');
         }
 
         final receivingRbfTxHash = await _rbfHandler.detectReceivingRbfTransaction(
@@ -146,7 +145,6 @@ class TransactionFetcher {
         );
         if (receivingRbfTxHash != null) {
           receivingRbfTxHashSet.add(receivingRbfTxHash);
-          Logger.log('[${walletItem.name}] 받는 RBF 트랜잭션 감지됨: ${fetchedTx.transactionHash}');
         }
 
         final cpfpInfo = await _cpfpHandler.detectCpfpTransaction(
@@ -155,7 +153,6 @@ class TransactionFetcher {
         );
         if (cpfpInfo != null) {
           cpfpInfoMap[fetchedTx.transactionHash] = cpfpInfo;
-          Logger.log('CPFP 트랜잭션 감지됨: ${fetchedTx.transactionHash}');
         }
 
         _utxoManager.updateUtxoStatusToOutgoingByTransaction(walletItem.id, fetchedTx);

--- a/lib/providers/node_provider/transaction/transaction_fetcher.dart
+++ b/lib/providers/node_provider/transaction/transaction_fetcher.dart
@@ -79,7 +79,8 @@ class TransactionFetcher {
       return [];
     }
 
-    final newTxHashes = <String>{};
+    /// [ScriptCallbackManager]에서 관리되지 않는 새롭게 처리해야 할 트랜잭션 해시 목록
+    final Set<String> newTxHashes = {};
 
     for (final txFetchResult in txFetchResults) {
       bool isConfirmed = txFetchResult.height > 0;
@@ -232,13 +233,8 @@ class TransactionFetcher {
       _stateManager.addWalletCompletedState(walletItem.id, UpdateElement.transaction);
     }
 
-    for (final txHash in newTxHashes) {
-      // 트랜잭션 처리 완료 상태 등록
-      _scriptCallbackManager.registerTransactionCompletion(txHash);
-
-      // 트랜잭션 처리 완료 후 종속성 제거
-      _scriptCallbackManager.deleteTransactionDependency(txHash);
-    }
+    // 트랜잭션 처리 완료 상태 등록
+    _scriptCallbackManager.registerTransactionCompletion(newTxHashes);
 
     return txFetchResults.map((tx) => tx.transactionHash).toList();
   }

--- a/lib/providers/node_provider/transaction/transaction_manager.dart
+++ b/lib/providers/node_provider/transaction/transaction_manager.dart
@@ -22,6 +22,14 @@ class TransactionManager {
   late final TransactionProcessor _transactionProcessor;
   late final TransactionFetcher _transactionFetcher;
 
+  /// 트랜잭션 처리 상태를 추적하는 맵
+  /// 키: 스크립트 고유 식별자(지갑ID + 경로), 값: 처리 완료 여부
+  final Map<String, bool> _completedTransactions = {};
+
+  /// 트랜잭션 처리 후 호출할 콜백 함수 맵
+  /// 키: 스크립트 고유 식별자(지갑ID + 경로), 값: 콜백 함수 리스트
+  final Map<String, List<Future<void> Function()>> _transactionCallbacks = {};
+
   TransactionManager(
     this._electrumService,
     this._stateManager,
@@ -39,6 +47,54 @@ class TransactionManager {
     );
   }
 
+  /// 스크립트의 고유 식별자를 생성합니다.
+  String _getScriptKey(WalletListItemBase walletItem, ScriptStatus scriptStatus) {
+    return '${walletItem.id}:${scriptStatus.derivationPath}';
+  }
+
+  /// 특정 스크립트의 트랜잭션 처리가 완료되었는지 확인합니다.
+  bool isTransactionProcessComplete(WalletListItemBase walletItem, ScriptStatus scriptStatus) {
+    final scriptKey = _getScriptKey(walletItem, scriptStatus);
+    return _completedTransactions[scriptKey] == true;
+  }
+
+  /// 트랜잭션 처리 후 실행할 콜백을 등록합니다.
+  /// 이미 처리가 완료된 경우 즉시 콜백을 실행합니다.
+  Future<void> registerTransactionCallback(
+    WalletListItemBase walletItem,
+    ScriptStatus scriptStatus,
+    Future<void> Function() callback,
+  ) async {
+    final scriptKey = _getScriptKey(walletItem, scriptStatus);
+
+    // 이미 처리가 완료된 경우 즉시 콜백 실행
+    if (_completedTransactions[scriptKey] == true) {
+      Logger.log('트랜잭션 처리가 완료된 경우 즉시 콜백 실행');
+      await callback();
+      return;
+    }
+
+    // 콜백 등록
+    _transactionCallbacks.putIfAbsent(scriptKey, () => []).add(callback);
+  }
+
+  /// 콜백 실행 및 상태 업데이트
+  Future<void> _executeCallbacks(String scriptKey) async {
+    // 상태 업데이트
+    _completedTransactions[scriptKey] = true;
+
+    // 등록된 콜백이 있으면 실행
+    Logger.log('트랜잭션 처리 완료 후 콜백 실행');
+    if (_transactionCallbacks.containsKey(scriptKey)) {
+      final callbacks = List<Future<void> Function()>.from(_transactionCallbacks[scriptKey]!);
+      _transactionCallbacks.remove(scriptKey);
+
+      await Future.wait(callbacks.map((callback) => callback())).catchError((e) {
+        Logger.error('트랜잭션 콜백 실행 중 오류 발생: $e');
+      });
+    }
+  }
+
   /// 특정 스크립트의 트랜잭션을 조회하고 업데이트합니다.
   Future<void> fetchScriptTransaction(
     WalletListItemBase walletItem,
@@ -46,11 +102,19 @@ class TransactionManager {
     DateTime? now,
     bool inBatchProcess = false,
   }) async {
+    final scriptKey = _getScriptKey(walletItem, scriptStatus);
+
+    // 트랜잭션 처리 시작 전 상태 초기화
+    _completedTransactions[scriptKey] = false;
+
     await _transactionFetcher.fetchScriptTransaction(
       walletItem,
       scriptStatus,
       now: now,
       inBatchProcess: inBatchProcess,
+      onComplete: () {
+        _executeCallbacks(scriptKey);
+      },
     );
   }
 

--- a/lib/providers/node_provider/transaction/transaction_manager.dart
+++ b/lib/providers/node_provider/transaction/transaction_manager.dart
@@ -2,6 +2,7 @@ import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/model/error/app_error.dart';
 import 'package:coconut_wallet/model/node/script_status.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
+import 'package:coconut_wallet/providers/node_provider/subscription/script_callback_manager.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_fetcher.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_processor.dart';
 import 'package:coconut_wallet/providers/node_provider/utxo_manager.dart';
@@ -19,16 +20,9 @@ class TransactionManager {
   final TransactionRepository _transactionRepository;
   final UtxoManager _utxoManager;
   final AddressRepository _addressRepository;
+  final ScriptCallbackManager _scriptCallbackManager;
   late final TransactionProcessor _transactionProcessor;
   late final TransactionFetcher _transactionFetcher;
-
-  /// 트랜잭션 처리 상태를 추적하는 맵
-  /// 키: 스크립트 고유 식별자(지갑ID + 경로), 값: 처리 완료 여부
-  final Map<String, bool> _completedTransactions = {};
-
-  /// 트랜잭션 처리 후 호출할 콜백 함수 맵
-  /// 키: 스크립트 고유 식별자(지갑ID + 경로), 값: 콜백 함수 리스트
-  final Map<String, List<Future<void> Function()>> _transactionCallbacks = {};
 
   TransactionManager(
     this._electrumService,
@@ -36,85 +30,25 @@ class TransactionManager {
     this._transactionRepository,
     this._utxoManager,
     this._addressRepository,
+    this._scriptCallbackManager,
   ) {
     _transactionProcessor = TransactionProcessor(_electrumService, _addressRepository);
-    _transactionFetcher = TransactionFetcher(
-      _electrumService,
-      _transactionRepository,
-      _transactionProcessor,
-      _stateManager,
-      _utxoManager,
-    );
-  }
-
-  /// 스크립트의 고유 식별자를 생성합니다.
-  String _getScriptKey(WalletListItemBase walletItem, ScriptStatus scriptStatus) {
-    return '${walletItem.id}:${scriptStatus.derivationPath}';
-  }
-
-  /// 특정 스크립트의 트랜잭션 처리가 완료되었는지 확인합니다.
-  bool isTransactionProcessComplete(WalletListItemBase walletItem, ScriptStatus scriptStatus) {
-    final scriptKey = _getScriptKey(walletItem, scriptStatus);
-    return _completedTransactions[scriptKey] == true;
-  }
-
-  /// 트랜잭션 처리 후 실행할 콜백을 등록합니다.
-  /// 이미 처리가 완료된 경우 즉시 콜백을 실행합니다.
-  Future<void> registerTransactionCallback(
-    WalletListItemBase walletItem,
-    ScriptStatus scriptStatus,
-    Future<void> Function() callback,
-  ) async {
-    final scriptKey = _getScriptKey(walletItem, scriptStatus);
-
-    // 이미 처리가 완료된 경우 즉시 콜백 실행
-    if (_completedTransactions[scriptKey] == true) {
-      Logger.log('트랜잭션 처리가 완료된 경우 즉시 콜백 실행');
-      await callback();
-      return;
-    }
-
-    // 콜백 등록
-    _transactionCallbacks.putIfAbsent(scriptKey, () => []).add(callback);
-  }
-
-  /// 콜백 실행 및 상태 업데이트
-  Future<void> _executeCallbacks(String scriptKey) async {
-    // 상태 업데이트
-    _completedTransactions[scriptKey] = true;
-
-    // 등록된 콜백이 있으면 실행
-    Logger.log('트랜잭션 처리 완료 후 콜백 실행');
-    if (_transactionCallbacks.containsKey(scriptKey)) {
-      final callbacks = List<Future<void> Function()>.from(_transactionCallbacks[scriptKey]!);
-      _transactionCallbacks.remove(scriptKey);
-
-      await Future.wait(callbacks.map((callback) => callback())).catchError((e) {
-        Logger.error('트랜잭션 콜백 실행 중 오류 발생: $e');
-      });
-    }
+    _transactionFetcher = TransactionFetcher(_electrumService, _transactionRepository,
+        _transactionProcessor, _stateManager, _utxoManager, _scriptCallbackManager);
   }
 
   /// 특정 스크립트의 트랜잭션을 조회하고 업데이트합니다.
-  Future<void> fetchScriptTransaction(
+  Future<List<String>> fetchScriptTransaction(
     WalletListItemBase walletItem,
     ScriptStatus scriptStatus, {
     DateTime? now,
     bool inBatchProcess = false,
   }) async {
-    final scriptKey = _getScriptKey(walletItem, scriptStatus);
-
-    // 트랜잭션 처리 시작 전 상태 초기화
-    _completedTransactions[scriptKey] = false;
-
-    await _transactionFetcher.fetchScriptTransaction(
+    return _transactionFetcher.fetchScriptTransaction(
       walletItem,
       scriptStatus,
       now: now,
       inBatchProcess: inBatchProcess,
-      onComplete: () {
-        _executeCallbacks(scriptKey);
-      },
     );
   }
 

--- a/lib/providers/node_provider/transaction/transaction_processor.dart
+++ b/lib/providers/node_provider/transaction/transaction_processor.dart
@@ -22,7 +22,6 @@ class TransactionProcessor {
     Map<String, int> txBlockHeightMap,
     Map<int, BlockTimestamp> blockTimestampMap, {
     List<Transaction> previousTxs = const [],
-    Future<String> Function(String)? getTransactionHex,
     DateTime? now,
   }) async {
     return Future.wait(txs.map((tx) async {
@@ -32,7 +31,6 @@ class TransactionProcessor {
         txBlockHeightMap,
         blockTimestampMap,
         previousTxs: previousTxs,
-        getTransactionHex: getTransactionHex,
         now: now,
       );
     }));
@@ -45,17 +43,12 @@ class TransactionProcessor {
     Map<String, int> txBlockHeightMap,
     Map<int, BlockTimestamp> blockTimestampMap, {
     List<Transaction> previousTxs = const [],
-    Future<String> Function(String)? getTransactionHex,
     DateTime? now,
   }) async {
     now ??= DateTime.now();
 
-    List<Transaction> prevTxs;
-    if (getTransactionHex != null) {
-      prevTxs = await _electrumService.getPreviousTransactions(tx, existingTxList: previousTxs);
-    } else {
-      prevTxs = previousTxs;
-    }
+    List<Transaction> prevTxs =
+        await _electrumService.getPreviousTransactions(tx, existingTxList: previousTxs);
 
     int blockHeight = txBlockHeightMap[tx.transactionHash] ?? 0;
     final txDetails = processTransactionDetails(tx, prevTxs, walletItemBase);

--- a/lib/providers/node_provider/utxo_manager.dart
+++ b/lib/providers/node_provider/utxo_manager.dart
@@ -34,11 +34,6 @@ class UtxoManager {
     ScriptStatus scriptStatus, {
     bool inBatchProcess = false,
   }) async {
-    if (!inBatchProcess) {
-      // UTXO 동기화 시작 state 업데이트
-      _stateManager.addWalletSyncState(walletItem.id, UpdateElement.utxo);
-    }
-
     // UTXO 목록 조회
     final utxos = await fetchUtxoStateList(walletItem, scriptStatus);
 

--- a/lib/providers/node_provider/utxo_manager.dart
+++ b/lib/providers/node_provider/utxo_manager.dart
@@ -76,8 +76,9 @@ class UtxoManager {
                 timestamp: transactionMap[e.txHash]!.createdAt,
               ))
           .toList();
-    } catch (e) {
+    } catch (e, stackTrace) {
       Logger.error('Failed to get UTXO list: $e');
+      Logger.error('Stack trace: $stackTrace');
       return [];
     }
   }

--- a/lib/providers/view_model/wallet_detail/utxo_list_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_list_view_model.dart
@@ -82,17 +82,8 @@ class UtxoListViewModel extends ChangeNotifier {
   void _onWalletUpdateInfoChanged(WalletUpdateInfo updateInfo) {
     Logger.log('${DateTime.now()}--> 지갑$_walletId 업데이트 체크 (UTXO)');
     if (_prevUpdateStatus != updateInfo.utxo && updateInfo.utxo == UpdateStatus.completed) {
-      Logger.log('_getUtxoAndTagList();');
-
-      // 하나의 트랜잭션으로 여러 스크립트에 대한 이벤트가 발생할 경우에 오류 발생.
-      // 이벤트 리스너 함수들이 모두 완료되지 않은 상태로 state가 업데이트됨.
-      // 결과적으로 화면에서 없어져야 할 UTXO가 남아있거나 새로 생겨야 할 UTXO가 없는 경우가 발생함.
-      // 임시로 지연을 통해 이벤트 리스너가 모두 실행되기 전에 동기화 완료 state가 업데이트되는 것을 방지함.
-      // TODO: 이벤트 리스너에 대해서 동시성 제어 필요함
-      Future.delayed(const Duration(milliseconds: 300), () {
-        _getUtxoAndTagList();
-        notifyListeners();
-      });
+      _getUtxoAndTagList();
+      notifyListeners();
     }
 
     _prevUpdateStatus = updateInfo.utxo;

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -138,12 +138,7 @@ class WalletProvider extends ChangeNotifier {
     _updateIsSyncingIfNeeded(_nodeProvider.state);
     if (_isAnyBalanceUpdating) {
       _walletBalance = fetchWalletBalanceMap();
-
-      /// TODO: NodeProvider의 이벤트 리스너에 대해서 동시성 제어 후 지연 로직 제거
-      /// BalanceManager의 fetchScriptBalance 함수 참고
-      Future.delayed(const Duration(milliseconds: 300), () {
-        notifyListeners();
-      });
+      notifyListeners();
     }
     _updateIsAnyBalanceUpdatingIfNeeded(_nodeProvider.state);
     for (var key in _nodeProvider.state.registeredWallets.keys) {
@@ -568,7 +563,7 @@ class WalletProvider extends ChangeNotifier {
       final utxoSymbol = statusToSymbol(value.utxo);
 
       buffer.writeln(
-          '│ ${key.toString().padRight(7)} │  $balanceSymbol(${value.balanceCounter})  │  $transactionSymbol(${value.transactionCounter})  │  $utxoSymbol(${value.utxoCounter})  │');
+          '│ ${key.toString().padRight(7)} │   $balanceSymbol    │   $transactionSymbol    │   $utxoSymbol    │');
 
       // 마지막 행이 아니면 행 구분선 추가
       if (i < walletKeys.length - 1) {

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -530,7 +530,7 @@ class WalletProvider extends ChangeNotifier {
         case MainClientState.syncing:
           return '🔄 동기화 중';
         case MainClientState.waiting:
-          return '🟢 대기 중 ';
+          return '🟢 대기 중ㅤ';
         case MainClientState.disconnected:
           return '🔴 연결 끊김';
       }
@@ -538,10 +538,12 @@ class WalletProvider extends ChangeNotifier {
 
     final connectionState = _nodeProvider.state.connectionState;
     final connectionStateSymbol = connectionStateToSymbol(connectionState);
+    final buffer = StringBuffer();
 
     if (_nodeProvider.state.registeredWallets.isEmpty) {
-      Logger.log('--> 등록된 지갑이 없습니다.');
-      Logger.log('--> connectionState: $connectionState');
+      buffer.writeln('--> 등록된 지갑이 없습니다.');
+      buffer.writeln('--> connectionState: $connectionState');
+      Logger.log(buffer.toString());
       return;
     }
 
@@ -549,11 +551,12 @@ class WalletProvider extends ChangeNotifier {
     final walletKeys = _nodeProvider.state.registeredWallets.keys.toList();
 
     // 테이블 헤더 출력 (connectionState 포함)
-    Logger.log('┌───────────────────────────────────────┐');
-    Logger.log('│ 연결 상태: $connectionStateSymbol${' ' * (23 - connectionStateSymbol.length)}│');
-    Logger.log('├─────────┬─────────┬─────────┬─────────┤');
-    Logger.log('│ 지갑 ID │  잔액   │  거래   │  UTXO   │');
-    Logger.log('├─────────┼─────────┼─────────┼─────────┤');
+    buffer.writeln('\n');
+    buffer.writeln('┌───────────────────────────────────────┐');
+    buffer.writeln('│ 연결 상태: $connectionStateSymbol${' ' * (23 - connectionStateSymbol.length)}│');
+    buffer.writeln('├─────────┬─────────┬─────────┬─────────┤');
+    buffer.writeln('│ 지갑 ID │  잔액   │  거래   │  UTXO   │');
+    buffer.writeln('├─────────┼─────────┼─────────┼─────────┤');
 
     // 각 지갑 상태 출력
     for (int i = 0; i < walletKeys.length; i++) {
@@ -564,16 +567,17 @@ class WalletProvider extends ChangeNotifier {
       final transactionSymbol = statusToSymbol(value.transaction);
       final utxoSymbol = statusToSymbol(value.utxo);
 
-      Logger.log(
-          '│ ${key.toString().padRight(7)} │   $balanceSymbol    │   $transactionSymbol    │   $utxoSymbol    │');
+      buffer.writeln(
+          '│ ${key.toString().padRight(7)} │  $balanceSymbol(${value.balanceCounter})  │  $transactionSymbol(${value.transactionCounter})  │  $utxoSymbol(${value.utxoCounter})  │');
 
       // 마지막 행이 아니면 행 구분선 추가
       if (i < walletKeys.length - 1) {
-        Logger.log('├─────────┼─────────┼─────────┼─────────┤');
+        buffer.writeln('├─────────┼─────────┼─────────┼─────────┤');
       }
     }
 
-    Logger.log('└─────────┴─────────┴─────────┴─────────┘');
+    buffer.writeln('└─────────┴─────────┴─────────┴─────────┘');
+    Logger.log(buffer.toString());
   }
 }
 

--- a/lib/repository/realm/subscription_repository.dart
+++ b/lib/repository/realm/subscription_repository.dart
@@ -76,13 +76,10 @@ class SubscriptionRepository extends BaseRepository {
           final existingStatus = existingStatusMap[update.scriptPubKey];
 
           if (existingStatus != null && update.status != null) {
-            Logger.log('실제 업데이트 시도: ${update.scriptPubKey} - ${update.status}');
             existingStatus.status = update.status!;
             existingStatus.timestamp = now;
           }
         }
-
-        Logger.log('실제 추가 시도: ${toAddStatuses.length}개');
 
         // 새로운 상태 일괄 추가
         realm.addAll<RealmScriptStatus>(toAddStatuses);

--- a/lib/repository/realm/transaction_repository.dart
+++ b/lib/repository/realm/transaction_repository.dart
@@ -365,9 +365,6 @@ class TransactionRepository extends BaseRepository {
       realm.write(() {
         realm.delete(realmCpfpHistory);
       });
-
-      // 자세한 로깅
-      Logger.log('CPFP 내역 삭제: ${fetchedTx.transactionHash} (컨펌된 트랜잭션)');
     }
   }
 

--- a/lib/screens/home/wallet_list_screen.dart
+++ b/lib/screens/home/wallet_list_screen.dart
@@ -95,7 +95,6 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
           previous.updateIsNetworkOn(connectivityProvider.isNetworkOn);
         }
 
-        debugPrint('update!!!!!!!!!!!!');
         // FIXME: 다른 provider의 변경에 의해서도 항상 호출됨
         return previous..onWalletProviderUpdated(walletProvider);
       },


### PR DESCRIPTION
#### 변경사항

- 이벤트 핸들러가 동시에 같은 트랜잭션을 fetching 하지 않도록 방지
- state 변경 시 임의로 notifyListeners 지연해서 호출하던 코드 삭제
- isolate 에서 state 제어하는 로직에 카운터 추가 

#### 테스트 방법

1. 지갑 리스트, 지갑 상세 화면에서 트랜잭션 발생시키기
2. 잔액이 정상적으로 수정되는지 확인


1. 여러개의 UTXO를 생성하거나 소비하는 등 이벤트 핸들러가 여러개 동작하게 하는 트랜잭션 발생
2. 로그에 아래 로그가 트랜잭션마다 1개씩 출력되는지 확인
  ```log
  -------- fetchScriptTransaction에서 처리중인 트랜잭션: <TX_HASH>
  ```

#### 특이사항
- utxo 목록은 간헐적으로 갱신이 안되는 현상이 있으나 166번 이슈 머지된 후 다시 수정할 예정입니다.


#164