### PR TITLE
[186] Bug - wallet_add_input_screen UI

### DIFF
--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -188,6 +188,7 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                                       ]
                                     ],
                                   )),
+                              CoconutLayout.spacing_2500h,
                             ],
                           ),
                         ),


### PR DESCRIPTION
### 변경사항
 - 키보드가 올라온 상태에서 '지갑 추가 정보'를 확인할 수 있도록 수정(margin 추가)
 (lib/screens/home/wallet_add_input_screen.dart)

### 테스트 방법
1. 앱 실행 후 지갑 추가 - 직접 입력 페이지 이동하여 확인

### 비고
1. 화면 진입 직후 Text Field 터치 시 포커스가 되지 않는 문제가 있습니다. (불규칙적으로 발생)
=> CoconutTextInput에서 placeholder Text를 클릭한 경우 포커스가 되지 않는 이슈가 있어 CDS에서 수정될 예정입니다(피오)

2. 포커스 된 상태에서 가이드를 펼쳤을 때 안내 사항이 키보드 위 버튼에 가려져 보이지 않습니다.
=> 수정 완료 

#186