### PR TITLE
[174] 수수료 조회 화면에서 로딩이 계속되며 뒤로가기가 안됨

### DIFF
--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -396,7 +396,6 @@ alert:
     broadcasting_failed: "[전송 실패]\n$error"
     insufficient_balance: "잔액이 부족해요"
     minimum_amount: "$bitcoin BTC 부터 전송할 수 있어요"
-    poor_network: "네트워크 상태가 좋지 않아\n처음으로 돌아갑니다."
     insufficient_fee: "[전송 실패]\n수수료율을 높여서\n다시 시도해주세요."
   signed_psbt:
     invalid_qr: "잘못된 QR코드예요.\n다시 확인해 주세요."

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -272,13 +272,11 @@ class _CoconutWalletAppState extends State<CoconutWalletApp> {
               ),
           '/transaction-fee-bumping': (context) => buildScreenWithArguments(
                 context,
-                (args) => CustomLoadingOverlay(
-                  child: TransactionFeeBumpingScreen(
-                    transaction: args['transaction'],
-                    feeBumpingType: args['feeBumpingType'],
-                    walletId: args['walletId'],
-                    walletName: args['walletName'],
-                  ),
+                (args) => TransactionFeeBumpingScreen(
+                  transaction: args['transaction'],
+                  feeBumpingType: args['feeBumpingType'],
+                  walletId: args['walletId'],
+                  walletName: args['walletName'],
                 ),
               ),
           '/unsigned-transaction-qr': (context) => buildScreenWithArguments(
@@ -296,9 +294,7 @@ class _CoconutWalletAppState extends State<CoconutWalletApp> {
                 (args) => CustomLoadingOverlay(child: SendAddressScreen(id: args['id'])),
               ),
           '/send-amount': (context) => const SendAmountScreen(),
-          '/fee-selection': (context) => const CustomLoadingOverlay(
-                child: SendFeeSelectionScreen(),
-              ),
+          '/fee-selection': (context) => const SendFeeSelectionScreen(),
           '/utxo-selection': (context) => const CustomLoadingOverlay(
                 child: SendUtxoSelectionScreen(),
               ),

--- a/lib/app_guard.dart
+++ b/lib/app_guard.dart
@@ -52,6 +52,8 @@ class _AppGuardState extends State<AppGuard> with WidgetsBindingObserver {
       // _showToastAboutNetwork(isNetworkOn);
 
       if (isNetworkOn) {
+        _nodeProvider.reconnect();
+
         /// 네트워크가 꺼졌다가 다시 켜지면 시세를 위한 소켓을 연결함.
         _upbitConnectModel.initUpbitWebSocketService();
       } else {

--- a/lib/constants/network_constants.dart
+++ b/lib/constants/network_constants.dart
@@ -4,8 +4,6 @@ const Duration kHttpConnectionTimeout = Duration(milliseconds: 3000);
 
 const int kSocketMaxConnectionAttempts = 30;
 
-const int kSocketReconnectDelaySeconds = 10;
-
 const Duration kElectrumResponseTimeout = Duration(seconds: 60);
 
 const Duration kElectrumPingInterval = Duration(seconds: 20);

--- a/lib/providers/node_provider/node_provider.dart
+++ b/lib/providers/node_provider/node_provider.dart
@@ -34,6 +34,11 @@ class NodeProvider extends ChangeNotifier {
 
   bool get needSubscribe => _needSubscribeWallets;
 
+  /// 정상적으로 연결된 후 다시 연결이 끊겼을 떄에만 이 함수가 동작하도록 설계되어 있음.
+  /// 최초 [reconnect] 호출은 앱 실행 시 `_checkConnectivity` 에서 호출되어 state 처리 관련된 로직이 일부 비정상적으로 동작함.
+  /// 따라서 최초 호출 1번만 동작을 하지 않도록 함
+  bool _isFirstReconnect = true;
+
   NodeProvider(this._host, this._port, this._ssl, {IsolateManager? isolateManager})
       : _isolateManager = isolateManager ?? IsolateManager() {
     initialize();
@@ -124,17 +129,25 @@ class NodeProvider extends ChangeNotifier {
   }
 
   Future<void> reconnect() async {
+    if (_isFirstReconnect) {
+      _isFirstReconnect = false;
+      return;
+    }
+
     try {
+      SocketConnectionStatus socketConnectionStatus;
       _needSubscribeWallets = true;
       if (isInitialized && _isolateManager.isInitialized) {
-        return;
+        socketConnectionStatus = await _isolateManager.getSocketConnectionStatus();
+        if (socketConnectionStatus != SocketConnectionStatus.terminated) {
+          return;
+        }
       }
 
       _stateSubscription?.cancel();
       _stateSubscription = null;
 
-      final socketConnectionStatus = await _isolateManager.getSocketConnectionStatus();
-
+      socketConnectionStatus = await _isolateManager.getSocketConnectionStatus();
       if (socketConnectionStatus != SocketConnectionStatus.connected) {
         await initialize();
       }

--- a/lib/screens/send/send_fee_selection_screen.dart
+++ b/lib/screens/send/send_fee_selection_screen.dart
@@ -20,6 +20,7 @@ import 'package:coconut_wallet/widgets/contents/fiat_price.dart';
 import 'package:coconut_wallet/widgets/overlays/coconut_loading_overlay.dart';
 import 'package:coconut_wallet/widgets/overlays/custom_toast.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
 
 class SendFeeSelectionScreen extends StatefulWidget {
@@ -81,12 +82,6 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
                 },
                 nextButtonTitle: t.complete,
                 onNextPressed: () {
-                  if (_viewModel.isNetworkOn != true) {
-                    CustomToast.showWarningToast(
-                        context: context, text: ErrorCodes.networkError.message);
-                    return;
-                  }
-
                   int satsPerVb = _customSelected
                       ? _customFeeInfo!.satsPerVb!
                       : feeInfos
@@ -130,9 +125,11 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
 
                         if (viewModel.isNetworkOn == false)
                           _buildFixedTooltip(
-                            tooltipState: CoconutTooltipState.warning,
-                            richText:
-                                RichText(text: TextSpan(text: ErrorCodes.networkError.message)),
+                            tooltipState: CoconutTooltipState.error,
+                            richText: RichText(
+                              text: TextSpan(text: ErrorCodes.networkError.message),
+                            ),
+                            isNetworkError: true,
                           ),
                         if (viewModel.isNetworkOn == true && _isRecommendedFeeFetchSuccess == false)
                           _buildFixedTooltip(
@@ -155,7 +152,7 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
                             richText: RichText(text: TextSpan(text: t.errors.insufficient_balance)),
                           ),
                         Padding(
-                            padding: const EdgeInsets.fromLTRB(12, 16, 12, 0),
+                            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
                             child: Column(
                               children: [
                                 ...List.generate(
@@ -401,7 +398,9 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
   }
 
   Widget _buildFixedTooltip(
-      {required RichText richText, CoconutTooltipState tooltipState = CoconutTooltipState.info}) {
+      {required RichText richText,
+      CoconutTooltipState tooltipState = CoconutTooltipState.info,
+      bool isNetworkError = false}) {
     return Padding(
         padding: const EdgeInsets.symmetric(vertical: 8, horizontal: CoconutLayout.defaultPadding),
         child: CoconutToolTip(
@@ -409,6 +408,15 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
           showIcon: true,
           tooltipType: CoconutTooltipType.fixed,
           tooltipState: tooltipState,
+          icon: isNetworkError
+              ? SvgPicture.asset(
+                  'assets/svg/triangle-warning.svg',
+                  colorFilter: const ColorFilter.mode(
+                    CoconutColors.hotPink,
+                    BlendMode.srcIn,
+                  ),
+                )
+              : null,
         ));
   }
 }

--- a/lib/screens/send/send_fee_selection_screen.dart
+++ b/lib/screens/send/send_fee_selection_screen.dart
@@ -11,7 +11,6 @@ import 'package:coconut_wallet/providers/view_model/send/send_fee_selection_view
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/screens/common/text_field_bottom_sheet.dart';
 import 'package:coconut_wallet/styles.dart';
-import 'package:coconut_wallet/utils/alert_util.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/utils/fiat_util.dart';
 import 'package:coconut_wallet/widgets/appbar/custom_appbar.dart';
@@ -21,7 +20,6 @@ import 'package:coconut_wallet/widgets/contents/fiat_price.dart';
 import 'package:coconut_wallet/widgets/overlays/coconut_loading_overlay.dart';
 import 'package:coconut_wallet/widgets/overlays/custom_toast.dart';
 import 'package:flutter/material.dart';
-import 'package:loader_overlay/loader_overlay.dart';
 import 'package:provider/provider.dart';
 
 class SendFeeSelectionScreen extends StatefulWidget {
@@ -35,7 +33,6 @@ class SendFeeSelectionScreen extends StatefulWidget {
 
 class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
   static const maxFeeLimit = 1000000; // sats, 사용자가 실수로 너무 큰 금액을 수수료로 지불하지 않도록 지정했습니다.
-  final networkOffMessage = t.alert.error_send.poor_network;
   final TextEditingController _customFeeController = TextEditingController();
   List<FeeInfoWithLevel> feeInfos = [
     FeeInfoWithLevel(level: TransactionFeeLevel.fastest),

--- a/lib/screens/send/send_fee_selection_screen.dart
+++ b/lib/screens/send/send_fee_selection_screen.dart
@@ -73,12 +73,6 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
       },
       child: Consumer<SendFeeSelectionViewModel>(
         builder: (context, viewModel, child) {
-          if (!viewModel.isNetworkOn) {
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              _showAlertAndGoHome(networkOffMessage);
-            });
-          }
-
           return Scaffold(
             backgroundColor: CoconutColors.black,
             appBar: CustomAppBar.buildWithNext(
@@ -232,9 +226,6 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_viewModel.isNetworkOn) {
         _startToSetRecommendedFee();
-      } else {
-        _showAlertAndGoHome(networkOffMessage);
-        return;
       }
 
       // TODO:
@@ -398,33 +389,6 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
         }
       }
     }
-  }
-
-  void _showAlertAndGoHome(String message) {
-    if (context.loaderOverlay.visible) {
-      setState(() {
-        _isLoading = false;
-      });
-    }
-
-    showAlertDialog(
-        context: context,
-        content: message,
-        dismissible: false,
-        onClosed: () {
-          Navigator.of(context).pop(); // 다이얼로그 닫기
-
-          // 약간의 지연 후 popUntil 호출
-          Future.delayed(const Duration(milliseconds: 300), () {
-            if (mounted) {
-              Navigator.pushNamedAndRemoveUntil(
-                context,
-                '/',
-                (Route<dynamic> route) => false,
-              );
-            }
-          });
-        });
   }
 
   Future<void> _startToSetRecommendedFee() async {

--- a/lib/widgets/overlays/coconut_loading_overlay.dart
+++ b/lib/widgets/overlays/coconut_loading_overlay.dart
@@ -1,0 +1,22 @@
+import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:flutter/material.dart';
+
+class CoconutLoadingOverlay extends StatelessWidget {
+  final bool applyFullScreen;
+  const CoconutLoadingOverlay({super.key, this.applyFullScreen = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: CoconutColors.black.withOpacity(0.4),
+      padding: applyFullScreen
+          ? EdgeInsets.zero
+          : EdgeInsets.only(
+              bottom: kToolbarHeight + MediaQuery.of(context).padding.top + kToolbarHeight,
+            ),
+      child: const Center(
+        child: CoconutCircularIndicator(),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,7 +73,7 @@ dependencies:
   coconut_design_system: 
     git:
       url: https://github.com/noncelab/coconut_design_system.git
-      ref: feat/17-pulldown-menu-group
+      ref: main
   coconut_lib: ^0.9.2
   realm: ^20.0.0
   cryptography: ^2.7.0


### PR DESCRIPTION
### 변경사항
- (+) 클릭 불가능한 배경 + CoconutCircularIndicator 조합인 CoconutLoadingOverlay 위젯 구현
- (+) 보내기 - 수수료 입력 화면, FeeBumping-수수료 입력 화면: context.loaderOverlay.show / hide 대신 CoconutLoadingOverlay를 visible/invisible 처리

### 테스트 방법
[WalletList-외부지갑카드 확인]
- sendFeeSelectionScreen, transactionFeeBumpingScreen에서 _isLoaing = false 모두 주석처리 후 해당 화면 진입

<table>
  <tr>
    <div align="center">
  <img 
    src="https://github.com/user-attachments/assets/d6595e43-af34-43a0-ad80-bbf49d503653"
    width="300"
  >
</div>
  </tr>
</table>



#174 