### PR TITLE
[182] _RealmWalletBase 미사용 프로퍼티 삭제

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -46,6 +46,9 @@ Flutter Test를 클릭해주고, Test File 경로를 지정합니다. Additional
 1. `wallet_add_test.dart`
    - 외부 월렛 추가, 삭제, 로드 테스트(공개확장키, 디스크립터)
 
+2. `realm_migration_test.dart`
+   - 스키마 버전, 월렛 여부에 따른 Realm 마이그레이션 테스트
+
 ## 주의사항
 
 - 테스트는 실제 디바이스의 저장소와 보안 기능을 사용합니다.

--- a/integration_test/integration_test_utils.dart
+++ b/integration_test/integration_test_utils.dart
@@ -36,9 +36,9 @@ Future<void> waitForWidgetAndTap(WidgetTester tester, Finder element, String ele
   await tester.pumpAndSettle();
 }
 
-Future<void> setWalletData(bool isEnabled) async {
+Future<void> setWalletData(bool isEnabled, {RealmManager? realmManager}) async {
   if (!isEnabled) return;
-  await addWallets();
+  await addWallets(realmManager: realmManager);
 }
 
 Future<void> skipTutorial(bool skip) async {
@@ -69,7 +69,7 @@ Future<void> _setWalletCount(int count) async {
   prefs.setInt(SharedPrefKeys.kWalletCount, count);
 }
 
-Future<int> addWallets({WalletProvider? walletProvider}) async {
+Future<int> addWallets({WalletProvider? walletProvider, RealmManager? realmManager}) async {
   var singleSigWallet1 = {
     "name": "test1",
     "colorIndex": 0,
@@ -102,9 +102,9 @@ Future<int> addWallets({WalletProvider? walletProvider}) async {
     await walletProvider.syncFromVault(WatchOnlyWallet.fromJson(singleSigWallet2));
     await walletProvider.syncFromVault(WatchOnlyWallet.fromJson(multiSigWallet1));
   } else {
-    var realmManager = RealmManager();
-    var walletRepository = WalletRepository(realmManager);
-    var addressRepository = AddressRepository(realmManager);
+    var realmManagerForSetup = realmManager ?? RealmManager();
+    var walletRepository = WalletRepository(realmManagerForSetup);
+    var addressRepository = AddressRepository(realmManagerForSetup);
 
     var item1 =
         await walletRepository.addSinglesigWallet(WatchOnlyWallet.fromJson(singleSigWallet1));

--- a/integration_test/realm_migration_test.dart
+++ b/integration_test/realm_migration_test.dart
@@ -1,0 +1,104 @@
+import 'package:coconut_wallet/constants/realm_constants.dart';
+import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/repository/realm/realm_manager.dart';
+import 'package:coconut_wallet/repository/secure_storage/secure_storage_repository.dart';
+import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
+import 'package:coconut_wallet/screens/home/wallet_list_screen.dart';
+import 'package:realm/realm.dart';
+import 'integration_test_utils.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:coconut_wallet/main.dart' as app;
+
+/// Realm migration integration test
+///
+/// * 테스트는 어플이 삭제된 상태에서 실행되어야 합니다(기존 앱에서 사용하고 있는 스키마 버전보다 낮은 버전을 설정하여 오류 발생)
+/// * 테스트는 각 테스트별 하나씩 실행되어야 합니다(한번에 테스트시 동일경로 Config를 여러번 open하여 오류 발생)
+///
+/// 실행 명령어:
+/// ```bash
+/// flutter test --plain-name "[Migration O] [Wallet O]" --flavor regtest integration_test/realm_migration_test.dart
+/// flutter test --plain-name "[Migration O] [Wallet X]" --flavor regtest integration_test/realm_migration_test.dart
+/// flutter test --plain-name "[Migration X] [Wallet O]" --flavor regtest integration_test/realm_migration_test.dart
+/// flutter test --plain-name "[Migration X] [Wallet X]" --flavor regtest integration_test/realm_migration_test.dart
+/// ```
+///
+/// 자세한 내용은 README.md 참고
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  late RealmManager realmManager;
+  late Configuration config;
+  late Realm realm;
+
+  void closeRealm() {
+    if (!realm.isClosed) {
+      realm.close();
+    }
+  }
+
+  Future<void> realmDataSetup({required bool migration, required bool wallet}) async {
+    const oldVersion = kRealmVersion - 1;
+    const curVersion = kRealmVersion;
+    config = Configuration.local(
+      realmAllSchemas,
+      schemaVersion: migration ? oldVersion : curVersion,
+    );
+
+    realm = Realm(config);
+    realmManager = RealmManager(realm: realm);
+    realmManager.reset();
+
+    await setWalletData(wallet, realmManager: realmManager);
+    closeRealm();
+  }
+
+  setUp(() async {
+    final prefs = SharedPrefsRepository();
+    await prefs.init();
+    await prefs.clearSharedPref();
+    await SecureStorageRepository().deleteAll();
+  });
+
+  tearDown(() async {
+    closeRealm();
+  });
+
+  group("removeIsLatestTxBlockHeightZero test", () {
+    setUp(() async {
+      await skipTutorial(true);
+    });
+
+    testWidgets('[Migration O] [Wallet O]', (tester) async {
+      // Set realm configuration and Wallet Data
+      await realmDataSetup(migration: true, wallet: true);
+      // The app will use new realm Configuration(kRealmVersion, removeIsLatestTxBlockHeightZero function) for migration
+      await walletListFlow(tester);
+    });
+
+    testWidgets('[Migration O] [Wallet X]', (tester) async {
+      await realmDataSetup(migration: true, wallet: false);
+      await walletListFlow(tester);
+    });
+
+    testWidgets('[Migration X] [Wallet O]', (tester) async {
+      await realmDataSetup(migration: false, wallet: true);
+      await walletListFlow(tester);
+    });
+
+    testWidgets('[Migration X] [Wallet X]', (tester) async {
+      await realmDataSetup(migration: false, wallet: false);
+      await walletListFlow(tester);
+    });
+  });
+}
+
+Future<void> walletListFlow(WidgetTester tester) async {
+  app.main();
+  await tester.pumpAndSettle();
+
+  final Finder walletListScreen = find.byType(WalletListScreen);
+  await waitForWidget(tester, walletListScreen,
+      timeoutMessage: 'walletListScreen not found after 60 seconds');
+  await tester.pumpAndSettle();
+}

--- a/lib/constants/realm_constants.dart
+++ b/lib/constants/realm_constants.dart
@@ -1,1 +1,1 @@
-const int kRealmVersion = 2;
+const int kRealmVersion = 3;

--- a/lib/repository/realm/migration/migration.dart
+++ b/lib/repository/realm/migration/migration.dart
@@ -6,42 +6,45 @@ import 'package:realm/realm.dart';
 /// Realm 마이그레이션 주의사항
 ///
 /// 마이그레이션 동작 순서
-/// 1. [kRealmVersion] 버전이 수정되면 [defaultMigration] 함수가 호출됨
-/// 2. 버전이 다를 경우 지갑 정보를 제외한 나머지 데이터 삭제
-/// 3. 지갑 정보가 달라질 경우 별도 마이그레이션 코드가 필요함
-/// 4. 지갑 정보 이외의 나머지 코드들은 모두 지우고 새로 동기화 (마이그레이션 관리 포인트를 줄이기 위함)
-/// 5. 지갑별 최초 주소 20개가 필요하여 주소 데이터도 지우지 않고 사용 여부, 잔액만 초기화
+/// [kRealmVersion] 버전이 수정되면 [defaultMigration] 함수가 호출됨
+///
+/// 특정 스키마의 속성 추가/삭제: 스키마 버전을 올리면 자동으로 마이그레이션
+/// 특정 스키마의 속성 이름 변경: migration.renameProperty
+/// 특정 스키마 자체를 삭제: migration.deleteType
+/// 기타 마이그레이션: realm 정보를 토대로 수정(기존 속성 타입 변경 등)
+/// https://www.mongodb.com/ko-kr/docs/atlas/device-sdks/sdk/flutter/realm-database/model-data/update-realm-object-schema/#std-label-flutter-automatically-update-schema
+///
+/// [resetExceptForWallet] (1 -> 2)
+/// 1. 지갑 정보를 제외한 나머지 데이터 삭제
+/// 2. 지갑 정보가 달라질 경우 별도 마이그레이션 코드가 필요함
+/// 3. 지갑 정보 이외의 나머지 코드들은 모두 지우고 새로 동기화 (마이그레이션 관리 포인트를 줄이기 위함)
+/// 4. 지갑별 최초 주소 20개가 필요하여 주소 데이터도 지우지 않고 사용 여부, 잔액만 초기화
+///
+/// [removeIsLatestTxBlockHeightZero] (2 -> 3)
+/// 1. RealmWalletBase isLatestTxBlockHeightZero 필드를 삭제합니다.
+///
 void defaultMigration(Migration migration, int oldVersion) {
-  if (canSkipMigration(migration, oldVersion)) {
+  if (oldVersion == kRealmVersion) {
     return;
   }
 
   try {
-    resetExceptForWallet(migration.newRealm);
+    Logger.log('oldVersion: $oldVersion');
+    if (oldVersion < 2) resetExceptForWallet(migration.newRealm);
+    if (oldVersion < 3) removeIsLatestTxBlockHeightZero(migration.newRealm);
   } catch (e, stackTrace) {
     Logger.log('Migration error: $e\n$stackTrace');
     rethrow;
   }
 }
 
-void removeIsLatestTxBlockHeightZero(Migration migration, int oldVersion) {
-  if (canSkipMigration(migration, oldVersion)) {
-    return;
-  }
-
-  try {
-    Logger.log("removeIsLatestTxBlockHeightZero Passed");
-  } catch (e, stackTrace) {
-    Logger.log('Migration error: $e\n$stackTrace');
-    rethrow;
-  }
-}
-
-bool canSkipMigration(Migration migration, int oldVersion) {
-  return oldVersion == kRealmVersion;
+void removeIsLatestTxBlockHeightZero(Realm realm) {
+  Logger.log("removeIsLatestTxBlockHeightZero");
 }
 
 void resetExceptForWallet(Realm realm) {
+  Logger.log("resetExceptForWallet");
+
   // 지갑과 주소는 삭제하지 않으며, 모든 작업을 하나의 트랜잭션 내에서 처리
   realm.all<RealmWalletBase>().forEach((walletBase) {
     walletBase.usedReceiveIndex = -1;

--- a/lib/repository/realm/migration/migration.dart
+++ b/lib/repository/realm/migration/migration.dart
@@ -24,6 +24,19 @@ void defaultMigration(Migration migration, int oldVersion) {
   }
 }
 
+void removeIsLatestTxBlockHeightZero(Migration migration, int oldVersion) {
+  if (canSkipMigration(migration, oldVersion)) {
+    return;
+  }
+
+  try {
+    Logger.log("removeIsLatestTxBlockHeightZero Passed");
+  } catch (e, stackTrace) {
+    Logger.log('Migration error: $e\n$stackTrace');
+    rethrow;
+  }
+}
+
 bool canSkipMigration(Migration migration, int oldVersion) {
   return oldVersion == kRealmVersion;
 }

--- a/lib/repository/realm/model/coconut_wallet_model.dart
+++ b/lib/repository/realm/model/coconut_wallet_model.dart
@@ -32,7 +32,6 @@ class _RealmWalletBase {
   int usedChangeIndex = -1;
   int generatedReceiveIndex = -1;
   int generatedChangeIndex = -1;
-  bool isLatestTxBlockHeightZero = false;
 }
 
 @RealmModel()

--- a/lib/repository/realm/realm_manager.dart
+++ b/lib/repository/realm/realm_manager.dart
@@ -34,7 +34,7 @@ class RealmManager {
               Configuration.local(
                 realmAllSchemas,
                 schemaVersion: kRealmVersion,
-                migrationCallback: defaultMigration,
+                migrationCallback: removeIsLatestTxBlockHeightZero,
               ),
             );
 

--- a/lib/repository/realm/realm_manager.dart
+++ b/lib/repository/realm/realm_manager.dart
@@ -34,7 +34,7 @@ class RealmManager {
               Configuration.local(
                 realmAllSchemas,
                 schemaVersion: kRealmVersion,
-                migrationCallback: removeIsLatestTxBlockHeightZero,
+                migrationCallback: defaultMigration,
               ),
             );
 

--- a/lib/repository/realm/transaction_repository.dart
+++ b/lib/repository/realm/transaction_repository.dart
@@ -121,9 +121,6 @@ class TransactionRepository extends BaseRepository {
           tx.timestamp = blockTimestampMap[fetchedTx.height]!.timestamp;
         }
       }
-
-      // 3. 지갑의 최신 트랜잭션 상태 업데이트
-      realmWalletBase.isLatestTxBlockHeightZero = fetchedTxMap.values.any((tx) => tx.height == 0);
     });
   }
 

--- a/test/repository/realm/realm_migration_test.dart
+++ b/test/repository/realm/realm_migration_test.dart
@@ -1,5 +1,6 @@
 import 'package:coconut_wallet/constants/realm_constants.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/utils/logger.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realm/realm.dart';
 import 'package:coconut_wallet/repository/realm/migration/migration.dart';
@@ -11,6 +12,8 @@ import '../../mock/realm/realm_transaction_mock.dart';
 import '../../mock/realm/realm_utxo_mock.dart';
 
 /// Realm 마이그레이션 테스트
+///
+/// 명령어: flutter test test/repository/realm/realm_migration_test.dart
 ///
 /// 테스트 실행에 필요한 다이나믹 라이브러리가 필요합니다.
 /// `dart run realm install`
@@ -43,9 +46,19 @@ String getUniqueRealmPath(String testName) {
 void main() {
   late Configuration config;
   late Realm realm;
-  const oldVersion = kRealmVersion - 1;
-  const newVersion = kRealmVersion;
   String? testPath;
+
+  void realmSetup({required int initialVersion}) {
+    // 테스트용 Realm 설정
+    config = Configuration.local(
+      realmAllSchemas,
+      schemaVersion: initialVersion,
+      path: testPath,
+    );
+
+    // 새로운 Realm 인스턴스 생성
+    realm = Realm(config);
+  }
 
   setUp(() async {
     // 매 테스트마다 고유한 파일 경로 사용 (타임스탬프 추가)
@@ -56,19 +69,9 @@ void main() {
     if (await file.exists()) {
       await file.delete();
     }
-
-    // 테스트용 Realm 설정
-    config = Configuration.local(
-      realmAllSchemas,
-      schemaVersion: oldVersion,
-      path: testPath,
-    );
-
-    // 새로운 Realm 인스턴스 생성
-    realm = Realm(config);
   });
 
-  tearDown(() async {
+  tearDown(() {
     // Realm 인스턴스 정리
     if (!realm.isClosed) {
       realm.close();
@@ -78,161 +81,151 @@ void main() {
     deleteRealmFiles(testPath!);
   });
 
-  group('removeIsLatestTxBlockHeightZero test', () {
-    test("[Migration O]", () {
-      removeIsLatestTxBlockHeightZeroFlow(realm, newVersion, testPath!);
-    });
-
-    test("[Migration X]", () {
-      removeIsLatestTxBlockHeightZeroFlow(realm, oldVersion, testPath!);
-    });
-  });
-
-  group('defaultMigration 테스트', () {
-    test('버전 변동이 없을 경우 마이그레이션이 실행되지 않아야 함', () {
-      // Given
-      int usedReceiveIndex = 5;
-      int usedChangeIndex = 3;
-
-      realm.write(() {
-        realm.add(RealmWalletBaseMock.getMock(
-            name: 'Test Wallet',
-            usedReceiveIndex: usedReceiveIndex,
-            usedChangeIndex: usedChangeIndex));
-        realm.add(RealmWalletAddressMock.getUsedMock(
-            id: 1, address: 'address1', index: 0, isChange: false));
-        realm.add(RealmWalletAddressMock.getUsedMock(
-            id: 2, address: 'address2', index: 0, isChange: true));
-        realm.add(RealmTransactionMock.getMock());
-        realm.add(RealmUtxoMock.getMock());
+  group('Realm migration test', () {
+    group("[Migration O]", () {
+      test("[0 -> kRealmVersion]", () {
+        realmSetup(initialVersion: 0);
+        migrationFrom0ToLatest(realm, kRealmVersion, testPath!);
       });
 
-      expect(realm.all<RealmWalletBase>().length, 1);
-      var walletBeforeMigration = realm.all<RealmWalletBase>().first;
-      expect(walletBeforeMigration.usedReceiveIndex, usedReceiveIndex);
-      expect(walletBeforeMigration.usedChangeIndex, usedChangeIndex);
-      expect(realm.all<RealmWalletAddress>().length, 2);
-      expect(realm.all<RealmTransaction>().length, 1);
-      expect(realm.all<RealmUtxo>().length, 1);
-
-      // When
-      if (!realm.isClosed) {
-        realm.close();
-      }
-
-      // 직접 resetWithoutWallet 함수를 적용한 후 검증
-      // 이전 버전으로 설정하여 마이그레이션이 실행되도록 함
-      final newRealmConfig = Configuration.local(realmAllSchemas,
-          schemaVersion: oldVersion, migrationCallback: defaultMigration, path: testPath);
-
-      // 마이그레이션이 동작하는 새 Realm 인스턴스 생성 (이 시점에 마이그레이션은 이미 실행됨)
-      final newRealm = Realm(newRealmConfig);
-
-      // Then - 마이그레이션 후 검증
-      // 1. 지갑 정보 유지
-      expect(newRealm.all<RealmWalletBase>().length, 1);
-      final migratedWallet = newRealm.all<RealmWalletBase>().first;
-      expect(migratedWallet.name, 'Test Wallet');
-      expect(migratedWallet.usedReceiveIndex, usedReceiveIndex);
-      expect(migratedWallet.usedChangeIndex, usedChangeIndex);
-
-      // 2. 주소 정보 유지
-      expect(newRealm.all<RealmWalletAddress>().length, 2);
-      final migratedAddress = newRealm.all<RealmWalletAddress>().first;
-      expect(migratedAddress.address, 'address1');
-      expect(migratedAddress.isUsed, true);
-      expect(migratedAddress.confirmed, 1000);
-      expect(migratedAddress.unconfirmed, 500);
-      expect(migratedAddress.total, 1500);
-      final migratedAddress2 = newRealm.all<RealmWalletAddress>().last;
-      expect(migratedAddress2.address, 'address2');
-      expect(migratedAddress2.isUsed, true);
-      expect(migratedAddress2.confirmed, 1000);
-      expect(migratedAddress2.unconfirmed, 500);
-      expect(migratedAddress2.total, 1500);
-
-      // 3. 나머지 정보도 유지
-      expect(newRealm.all<RealmTransaction>().length, 1, reason: '트랜잭션 정보는 유지되어야 함');
-      expect(newRealm.all<RealmUtxo>().length, 1, reason: 'UTXO 정보는 유지되어야 함');
-
-      newRealm.close();
-    });
-
-    test('마이그레이션이 필요한 경우 데이터가 초기화되어야 함', () async {
-      // Given
-      int usedReceiveIndex = 5;
-      int usedChangeIndex = 3;
-
-      realm.write(() {
-        realm.add(RealmWalletBaseMock.getMock(
-            name: 'Test Wallet',
-            usedReceiveIndex: usedReceiveIndex,
-            usedChangeIndex: usedChangeIndex));
-        realm.add(RealmWalletAddressMock.getUsedMock(
-            id: 1, address: 'address1', index: 0, isChange: false));
-        realm.add(RealmWalletAddressMock.getUsedMock(
-            id: 2, address: 'address2', index: 0, isChange: true));
-        realm.add(RealmTransactionMock.getMock());
-        realm.add(RealmUtxoMock.getMock());
+      test('[1 -> kRealmVersion]', () {
+        realmSetup(initialVersion: 1);
+        migrationFrom1toLatest(realm, kRealmVersion, testPath!);
       });
 
-      expect(realm.all<RealmWalletBase>().length, 1);
-      var walletBeforeMigration = realm.all<RealmWalletBase>().first;
-      expect(walletBeforeMigration.usedReceiveIndex, usedReceiveIndex);
-      expect(walletBeforeMigration.usedChangeIndex, usedChangeIndex);
-      expect(realm.all<RealmWalletAddress>().length, 2);
-      expect(realm.all<RealmTransaction>().length, 1);
-      expect(realm.all<RealmUtxo>().length, 1);
+      test("[2 -> kRealmVersion]", () {
+        realmSetup(initialVersion: 2);
+        migrationFrom2toLatest(realm, kRealmVersion, testPath!);
+      });
+    });
 
-      // When
-      if (!realm.isClosed) {
-        realm.close();
-      }
+    group("[Migration X]", () {
+      setUp(() {
+        Logger.log("============ Migration X ============");
+      });
 
-      // 직접 resetWithoutWallet 함수를 적용한 후 검증
-      // 이전 버전으로 설정하여 마이그레이션이 실행되도록 함
-      final newRealmConfig = Configuration.local(realmAllSchemas,
-          schemaVersion: newVersion, migrationCallback: defaultMigration, path: testPath);
+      test("[0 -> 0]", () {
+        realmSetup(initialVersion: 0);
+        migrationFrom0ToLatest(realm, 0, testPath!);
+      });
 
-      // 마이그레이션이 동작하는 새 Realm 인스턴스 생성 (이 시점에 마이그레이션은 이미 실행됨)
-      final newRealm = Realm(newRealmConfig);
+      test('[1 -> 1]', () {
+        realmSetup(initialVersion: 1);
+        migrationFrom1toLatest(realm, 1, testPath!);
+      });
 
-      // Then - 마이그레이션 후 검증
-      // 1. 지갑 정보는 유지되어야 함
-      expect(newRealm.all<RealmWalletBase>().length, 1, reason: '지갑 정보는 유지되어야 함');
-      final migratedWallet = newRealm.all<RealmWalletBase>().first;
-      expect(migratedWallet.name, 'Test Wallet', reason: '지갑 이름은 유지되어야 함');
-
-      // usedReceiveIndex 확인 - 초기화 후에는 -1이어야 함
-      expect(migratedWallet.usedReceiveIndex, -1, reason: 'usedReceiveIndex가 -1로 초기화되어야 함');
-      expect(migratedWallet.usedChangeIndex, -1, reason: 'usedChangeIndex가 -1로 초기화되어야 함');
-
-      // 2. 주소 정보는 유지되지만 초기화되어야 함
-      expect(newRealm.all<RealmWalletAddress>().length, 2, reason: '주소 정보는 유지되어야 함');
-      final migratedAddress = newRealm.all<RealmWalletAddress>().first;
-      expect(migratedAddress.address, 'address1', reason: '주소 값은 유지되어야 함');
-      expect(migratedAddress.isUsed, false, reason: 'isUsed가 false로 초기화되어야 함');
-      expect(migratedAddress.confirmed, 0, reason: 'confirmed가 0으로 초기화되어야 함');
-      expect(migratedAddress.unconfirmed, 0, reason: 'unconfirmed가 0으로 초기화되어야 함');
-      expect(migratedAddress.total, 0, reason: 'total이 0으로 초기화되어야 함');
-      final migratedAddress2 = newRealm.all<RealmWalletAddress>().last;
-      expect(migratedAddress2.address, 'address2', reason: '주소 값은 유지되어야 함');
-      expect(migratedAddress2.isUsed, false, reason: 'isUsed가 false로 초기화되어야 함');
-      expect(migratedAddress2.confirmed, 0, reason: 'confirmed가 0으로 초기화되어야 함');
-      expect(migratedAddress2.unconfirmed, 0, reason: 'unconfirmed가 0으로 초기화되어야 함');
-      expect(migratedAddress2.total, 0, reason: 'total이 0으로 초기화되어야 함');
-
-      // 3. 나머지는 삭제
-      expect(newRealm.all<RealmTransaction>().isEmpty, isTrue, reason: '트랜잭션이 삭제되어야 함');
-      expect(newRealm.all<RealmUtxo>().isEmpty, isTrue, reason: 'UTXO가 삭제되어야 함');
-
-      newRealm.close();
+      test("[2 -> 2]", () {
+        realmSetup(initialVersion: 2);
+        migrationFrom2toLatest(realm, 2, testPath!);
+      });
     });
   });
 }
 
-Future<void> removeIsLatestTxBlockHeightZeroFlow(
-    Realm originalRealm, int newRealmVersion, String newRealmPath) async {
+// migrationFrom2To3 테스트는 기본 검증 코드라 1to2 코드로 검증
+void migrationFrom0ToLatest(Realm originalRealm, int newRealmVersion, String newRealmPath) {
+  migrationFrom1toLatest(originalRealm, newRealmVersion, newRealmPath);
+}
+
+void migrationFrom1toLatest(Realm originalRealm, int newRealmVersion, String newRealmPath) {
+  // Given
+  int usedReceiveIndex = 5;
+  int usedChangeIndex = 3;
+
+  originalRealm.write(() {
+    originalRealm.add(RealmWalletBaseMock.getMock(
+        name: 'Test Wallet', usedReceiveIndex: usedReceiveIndex, usedChangeIndex: usedChangeIndex));
+    originalRealm.add(
+        RealmWalletAddressMock.getUsedMock(id: 1, address: 'address1', index: 0, isChange: false));
+    originalRealm.add(
+        RealmWalletAddressMock.getUsedMock(id: 2, address: 'address2', index: 0, isChange: true));
+    originalRealm.add(RealmTransactionMock.getMock());
+    originalRealm.add(RealmUtxoMock.getMock());
+  });
+
+  expect(originalRealm.all<RealmWalletBase>().length, 1);
+  var walletBeforeMigration = originalRealm.all<RealmWalletBase>().first;
+  expect(walletBeforeMigration.usedReceiveIndex, usedReceiveIndex);
+  expect(walletBeforeMigration.usedChangeIndex, usedChangeIndex);
+  expect(originalRealm.all<RealmWalletAddress>().length, 2);
+  expect(originalRealm.all<RealmTransaction>().length, 1);
+  expect(originalRealm.all<RealmUtxo>().length, 1);
+
+  // When
+  if (!originalRealm.isClosed) {
+    originalRealm.close();
+  }
+
+  // 직접 resetWithoutWallet 함수를 적용한 후 검증
+  // 이전 버전으로 설정하여 마이그레이션이 실행되도록 함
+  final newRealmConfig = Configuration.local(realmAllSchemas,
+      schemaVersion: newRealmVersion, migrationCallback: defaultMigration, path: newRealmPath);
+
+  // 마이그레이션이 동작하는 새 Realm 인스턴스 생성 (이 시점에 마이그레이션은 이미 실행됨)
+  final newRealm = Realm(newRealmConfig);
+
+  if (newRealmVersion > 1) {
+    // Then - 마이그레이션 후 검증
+    // 1. 지갑 정보는 유지되어야 함
+    expect(newRealm.all<RealmWalletBase>().length, 1, reason: '지갑 정보는 유지되어야 함');
+    final migratedWallet = newRealm.all<RealmWalletBase>().first;
+    expect(migratedWallet.name, 'Test Wallet', reason: '지갑 이름은 유지되어야 함');
+
+    // usedReceiveIndex 확인 - 초기화 후에는 -1이어야 함
+    expect(migratedWallet.usedReceiveIndex, -1, reason: 'usedReceiveIndex가 -1로 초기화되어야 함');
+    expect(migratedWallet.usedChangeIndex, -1, reason: 'usedChangeIndex가 -1로 초기화되어야 함');
+
+    // 2. 주소 정보는 유지되지만 초기화되어야 함
+    expect(newRealm.all<RealmWalletAddress>().length, 2, reason: '주소 정보는 유지되어야 함');
+    final migratedAddress = newRealm.all<RealmWalletAddress>().first;
+    expect(migratedAddress.address, 'address1', reason: '주소 값은 유지되어야 함');
+    expect(migratedAddress.isUsed, false, reason: 'isUsed가 false로 초기화되어야 함');
+    expect(migratedAddress.confirmed, 0, reason: 'confirmed가 0으로 초기화되어야 함');
+    expect(migratedAddress.unconfirmed, 0, reason: 'unconfirmed가 0으로 초기화되어야 함');
+    expect(migratedAddress.total, 0, reason: 'total이 0으로 초기화되어야 함');
+    final migratedAddress2 = newRealm.all<RealmWalletAddress>().last;
+    expect(migratedAddress2.address, 'address2', reason: '주소 값은 유지되어야 함');
+    expect(migratedAddress2.isUsed, false, reason: 'isUsed가 false로 초기화되어야 함');
+    expect(migratedAddress2.confirmed, 0, reason: 'confirmed가 0으로 초기화되어야 함');
+    expect(migratedAddress2.unconfirmed, 0, reason: 'unconfirmed가 0으로 초기화되어야 함');
+    expect(migratedAddress2.total, 0, reason: 'total이 0으로 초기화되어야 함');
+
+    // 3. 나머지는 삭제
+    expect(newRealm.all<RealmTransaction>().isEmpty, isTrue, reason: '트랜잭션이 삭제되어야 함');
+    expect(newRealm.all<RealmUtxo>().isEmpty, isTrue, reason: 'UTXO가 삭제되어야 함');
+  } else {
+    // Then - 마이그레이션 후 검증
+    // 1. 지갑 정보 유지
+    expect(newRealm.all<RealmWalletBase>().length, 1);
+    final migratedWallet = newRealm.all<RealmWalletBase>().first;
+    expect(migratedWallet.name, 'Test Wallet');
+    expect(migratedWallet.usedReceiveIndex, usedReceiveIndex);
+    expect(migratedWallet.usedChangeIndex, usedChangeIndex);
+
+    // 2. 주소 정보 유지
+    expect(newRealm.all<RealmWalletAddress>().length, 2);
+    final migratedAddress = newRealm.all<RealmWalletAddress>().first;
+    expect(migratedAddress.address, 'address1');
+    expect(migratedAddress.isUsed, true);
+    expect(migratedAddress.confirmed, 1000);
+    expect(migratedAddress.unconfirmed, 500);
+    expect(migratedAddress.total, 1500);
+    final migratedAddress2 = newRealm.all<RealmWalletAddress>().last;
+    expect(migratedAddress2.address, 'address2');
+    expect(migratedAddress2.isUsed, true);
+    expect(migratedAddress2.confirmed, 1000);
+    expect(migratedAddress2.unconfirmed, 500);
+    expect(migratedAddress2.total, 1500);
+
+    // 3. 나머지 정보도 유지
+    expect(newRealm.all<RealmTransaction>().length, 1, reason: '트랜잭션 정보는 유지되어야 함');
+    expect(newRealm.all<RealmUtxo>().length, 1, reason: 'UTXO 정보는 유지되어야 함');
+  }
+
+  newRealm.close();
+}
+
+void migrationFrom2toLatest(Realm originalRealm, int newRealmVersion, String newRealmPath) {
   originalRealm.write(() {
     originalRealm.add(RealmWalletBaseMock.getMock(
       name: 'Test Wallet1',
@@ -267,9 +260,7 @@ Future<void> removeIsLatestTxBlockHeightZeroFlow(
 
   // Change RealmConfig
   final newRealmConfig = Configuration.local(realmAllSchemas,
-      schemaVersion: newRealmVersion,
-      migrationCallback: removeIsLatestTxBlockHeightZero,
-      path: newRealmPath);
+      schemaVersion: newRealmVersion, migrationCallback: defaultMigration, path: newRealmPath);
   final newRealm = Realm(newRealmConfig);
 
   final testWallet1AfterMigration = newRealm

--- a/test/repository/realm/realm_migration_test.dart
+++ b/test/repository/realm/realm_migration_test.dart
@@ -79,12 +79,12 @@ void main() {
   });
 
   group('removeIsLatestTxBlockHeightZero test', () {
-    test("버전 변동이 없는 경우, 마이그레이션 하지 않음", () {
-      removeIsLatestTxBlockHeightZeroFlow(realm, oldVersion, testPath!);
+    test("[Migration O]", () {
+      removeIsLatestTxBlockHeightZeroFlow(realm, newVersion, testPath!);
     });
 
-    test("버전 변동이 있는 경우, 마이그레이션 실행", () {
-      removeIsLatestTxBlockHeightZeroFlow(realm, newVersion, testPath!);
+    test("[Migration X]", () {
+      removeIsLatestTxBlockHeightZeroFlow(realm, oldVersion, testPath!);
     });
   });
 

--- a/test/repository/realm/transaction_repository_test.dart
+++ b/test/repository/realm/transaction_repository_test.dart
@@ -92,8 +92,7 @@ void main() {
 
       // 지갑의 최근 트랜잭션 상태 플래그 설정
       realmManager.realm.write(() {
-        final wallet = realmManager.realm.find<RealmWalletBase>(testWalletItem.id);
-        wallet!.isLatestTxBlockHeightZero = true;
+        realmManager.realm.find<RealmWalletBase>(testWalletItem.id);
       });
 
       // 트랜잭션 상태 업데이트
@@ -108,7 +107,7 @@ void main() {
       // 업데이트된 트랜잭션 조회
       final updatedTransaction = transactionRepository.getTransactionRecord(
           testWalletItem.id, testTransaction.transactionHash);
-      final wallet = realmManager.realm.find<RealmWalletBase>(testWalletItem.id);
+      realmManager.realm.find<RealmWalletBase>(testWalletItem.id);
 
       // 검증
       expect(updatedTransaction?.blockHeight, blockHeight);
@@ -120,8 +119,6 @@ void main() {
         expect(actualTimestamp.millisecondsSinceEpoch ~/ 1000,
             blockTimestamp.timestamp.millisecondsSinceEpoch ~/ 1000);
       }
-
-      expect(wallet?.isLatestTxBlockHeightZero, false);
     });
   });
 


### PR DESCRIPTION
### 변경사항
 - isLatestTxBlockHeightZero 삭제 테스트 코드 추가(유닛, 통합 테스트)
(test/repository/realm/realm_migration_test.dart, integration_test/realm_migration_test.dart)

 - WalletBase isLatestTxBlockHeightZero 삭제
(lib/repository/realm/model/coconut_wallet_model.dart)

- Realm 스키마 버전 변경(2 -> 3) 및 마이그레이션 함수 변경(removeIsLatestTxBlockHeightZero)
(lib/repository/realm/migration/migration.dart, lib/repository/realm/realm_manager.dart)

### 테스트 방법
1. 유닛 테스트 명령어
flutter test test/repository/realm/realm_migration_test.dart

2. 통합 테스트 명령어
flutter test --plain-name "[Migration X] [Wallet O]" --flavor regtest integration_test/realm_migration_test.dart &&
flutter test --plain-name "[Migration X] [Wallet X]" --flavor regtest integration_test/realm_migration_test.dart &&
flutter test --plain-name "[0 -> kRealmVersion] [Wallet O]" --flavor regtest integration_test/realm_migration_test.dart &&
flutter test --plain-name "[0 -> kRealmVersion] [Wallet X]" --flavor regtest integration_test/realm_migration_test.dart &&
flutter test --plain-name "[1 -> kRealmVersion] [Wallet O]" --flavor regtest integration_test/realm_migration_test.dart &&
flutter test --plain-name "[1 -> kRealmVersion] [Wallet X]" --flavor regtest integration_test/realm_migration_test.dart &&
flutter test --plain-name "[2 -> kRealmVersion] [Wallet O]" --flavor regtest integration_test/realm_migration_test.dart &&
flutter test --plain-name "[2 -> kRealmVersion] [Wallet X]" --flavor regtest integration_test/realm_migration_test.dart

### 테스트 시나리오
1. 유닛 테스트
- 초기 Realm Config 설정 후 지갑 추가/검증
- 새로운 Realm Config 설정 후 기존 지갑 검증(schemaVersion에 따라 마이그레이션 함수 호출)

2. 통합 테스트
- 초기 Realm Config 설정 후 지갑 추가(혹은 추가하지 않음)
- 앱 내에서 새로운 Realm Config 설정 후(RealmManager) WalletListScreen까지 이동

### 비고
테스트 코드 작성을 위해 184-external-wallet-scheme을 기준 브랜치로 설정하고 작업했습니다. 

#182 