### PR TITLE
[196] Bug - 월렛 삭제시 없는 스키마를 참조하는 문제

### DIFF
--- a/lib/repository/realm/wallet_repository.dart
+++ b/lib/repository/realm/wallet_repository.dart
@@ -148,7 +148,7 @@ class WalletRepository extends BaseRepository {
     final realmExternalWalletResults = walletBase.walletType == WalletType.singleSignature.name
         ? realm.query<RealmExternalWallet>('id == $walletId')
         : null;
-    final realmExternalWallet = realmExternalWalletResults?.first;
+    final realmExternalWallet = realmExternalWalletResults?.firstOrNull;
 
     await realm.writeAsync(() {
       realm.delete(walletBase);


### PR DESCRIPTION
### 변경사항
 - 단일서명지갑 삭제시 연결된 외부지갑 스키마가 있는 경우에만 삭제
(lib/repository/realm/wallet_repository.dart)

### 테스트 방법
1. 코코넛 지갑 추가 이후 정상적으로 삭제가 되는지 확인
 
#196 