### PR TITLE
[194] 지갑 추가 및 정보 화면 UI 수정

### DIFF
--- a/lib/screens/home/wallet_add_scanner_screen.dart
+++ b/lib/screens/home/wallet_add_scanner_screen.dart
@@ -192,49 +192,42 @@ class _WalletAddScannerScreenState extends State<WalletAddScannerScreen> {
         case WalletSyncResult.existingWalletNoUpdate:
           {
             vibrateLightDouble();
-            CustomDialogs.showCustomAlertDialog(context,
-                title: t.alert.wallet_add.update_failed,
-                message: t.alert.wallet_add.update_failed_description(
+            _showErrorDialog(
+                t.alert.wallet_add.update_failed,
+                t.alert.wallet_add.update_failed_description(
                     name: TextUtils.ellipsisIfLonger(
                   _viewModel.getWalletName(addResult.walletId!),
                   maxLength: 15,
-                )), onConfirm: () {
-              _isProcessing = false;
-              Navigator.pop(context);
-            });
+                )));
+
             break;
           }
         case WalletSyncResult.existingName:
           vibrateLightDouble();
           if (mounted) {
-            CustomDialogs.showCustomAlertDialog(context,
-                title: t.alert.wallet_add.duplicate_name,
-                message: t.alert.wallet_add.duplicate_name_description, onConfirm: () {
-              _isProcessing = false;
-              Navigator.pop(context);
-            });
+            _showErrorDialog(
+              t.alert.wallet_add.duplicate_name,
+              t.alert.wallet_add.duplicate_name_description,
+            );
           }
         case WalletSyncResult.existingWalletUpdateImpossible:
           vibrateLightDouble();
           if (mounted) {
-            CustomDialogs.showCustomAlertDialog(context,
-                title: t.alert.wallet_add.already_exist,
-                message: t.alert.wallet_add.already_exist_description(
-                    name: TextUtils.ellipsisIfLonger(_viewModel.getWalletName(addResult.walletId!),
-                        maxLength: 15)), onConfirm: () {
-              _isProcessing = false;
-              Navigator.pop(context);
-            });
+            _showErrorDialog(
+              t.alert.wallet_add.already_exist,
+              t.alert.wallet_add.already_exist_description(
+                  name: TextUtils.ellipsisIfLonger(_viewModel.getWalletName(addResult.walletId!),
+                      maxLength: 15)),
+            );
           }
       }
     } catch (e) {
       vibrateLightDouble();
       if (mounted) {
-        CustomDialogs.showCustomAlertDialog(context,
-            title: t.alert.wallet_add.add_failed, message: e.toString(), onConfirm: () {
-          _isProcessing = false;
-          Navigator.pop(context);
-        });
+        _showErrorDialog(
+          t.alert.wallet_add.add_failed,
+          e.toString(),
+        );
       }
       // TODO: remove rethrow; after test
       //rethrow;
@@ -271,6 +264,29 @@ class _WalletAddScannerScreenState extends State<WalletAddScannerScreen> {
       _isProcessing = false;
       Navigator.pop(context);
     });
+  }
+
+  void _showErrorDialog(String title, String description) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return CoconutPopup(
+          title: title,
+          backgroundColor: CoconutColors.black.withOpacity(0.7),
+          description: description,
+          descriptionPadding: const EdgeInsets.only(left: 16, right: 16, top: 12, bottom: 12),
+          insetPadding: const EdgeInsets.symmetric(
+            horizontal: 50,
+          ),
+          rightButtonColor: CoconutColors.white,
+          rightButtonTextStyle: CoconutTypography.body2_14,
+          onTapRight: () {
+            _isProcessing = false;
+            Navigator.pop(context);
+          },
+        );
+      },
+    );
   }
 
   String _getAppBarTitle() => switch (widget.importSource) {

--- a/lib/screens/wallet_detail/wallet_info_edit_bottom_sheet.dart
+++ b/lib/screens/wallet_detail/wallet_info_edit_bottom_sheet.dart
@@ -30,6 +30,13 @@ class _WalletInfoEditBottomSheetState extends State<WalletInfoEditBottomSheet> {
   }
 
   @override
+  void initState() {
+    super.initState();
+
+    _textFieldFocusNode.requestFocus();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<WalletInfoEditViewModel>(
       create: (context) => WalletInfoEditViewModel(
@@ -108,9 +115,11 @@ class _WalletInfoEditBottomSheetState extends State<WalletInfoEditBottomSheet> {
                               focusNode: _textFieldFocusNode,
                               onChanged: (text) {},
                               backgroundColor: CoconutColors.white.withOpacity(0.15),
+                              errorColor: CoconutColors.hotPink,
+                              placeholderColor: CoconutColors.gray700,
                               activeColor: CoconutColors.white,
-                              maxLength: 15,
                               cursorColor: CoconutColors.white,
+                              maxLength: 15,
                               errorText: viewModel.isNameDuplicated || viewModel.isSameAsCurrentName
                                   ? t.wallet_info_screen.duplicated_name
                                   : '',

--- a/lib/screens/wallet_detail/wallet_info_screen.dart
+++ b/lib/screens/wallet_detail/wallet_info_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
@@ -49,15 +50,16 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
       ),
       child: Consumer<WalletInfoViewModel>(
         builder: (_, viewModel, child) {
-          return Scaffold(
-            backgroundColor: CoconutColors.black,
-            appBar: CoconutAppBar.build(
-                title: t.wallet_info_screen.title(name: viewModel.walletName), context: context),
-            body: SafeArea(
-              child: SingleChildScrollView(
-                child: Stack(
-                  children: [
-                    Column(
+          return Stack(
+            children: [
+              Scaffold(
+                backgroundColor: CoconutColors.black,
+                appBar: CoconutAppBar.build(
+                    title: t.wallet_info_screen.title(name: viewModel.walletName),
+                    context: context),
+                body: SafeArea(
+                  child: SingleChildScrollView(
+                    child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
                         Padding(
@@ -242,40 +244,40 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
                         ),
                       ],
                     ),
-                    Positioned(
-                      top: _walletTooltipIconPosition.dy - _tooltipTopPadding,
-                      right: MediaQuery.of(context).size.width -
-                          _walletTooltipIconPosition.dx -
-                          (_walletTooltipIconRenderBox == null
-                              ? 0
-                              : _walletTooltipIconRenderBox!.size.width) -
-                          10,
-                      child: CoconutToolTip(
-                        width: MediaQuery.sizeOf(context).width,
-                        isBubbleClipperSideLeft: false,
-                        tooltipType: CoconutTooltipType.placement,
-                        richText: RichText(
-                          text: TextSpan(
-                            text: widget.isMultisig
-                                ? t.tooltip.multisig_wallet(
-                                    total: viewModel.multisigTotalSignerCount,
-                                    count: viewModel.multisigRequiredSignerCount)
-                                : t.tooltip.mfp,
-                            style: CoconutTypography.body3_12.setColor(CoconutColors.black).merge(
-                                  const TextStyle(
-                                    height: 1.3,
-                                  ),
-                                ),
-                          ),
-                        ),
-                        onTapRemove: _removeTooltip,
-                        isPlacementTooltipVisible: _tooltipRemainingTime > 0,
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
               ),
-            ),
+              Positioned(
+                top: _tooltipTopPadding,
+                right: MediaQuery.of(context).size.width -
+                    _walletTooltipIconPosition.dx -
+                    (_walletTooltipIconRenderBox == null
+                        ? 0
+                        : _walletTooltipIconRenderBox!.size.width) -
+                    10,
+                child: CoconutToolTip(
+                  width: MediaQuery.sizeOf(context).width,
+                  isBubbleClipperSideLeft: false,
+                  tooltipType: CoconutTooltipType.placement,
+                  richText: RichText(
+                    text: TextSpan(
+                      text: widget.isMultisig
+                          ? t.tooltip.multisig_wallet(
+                              total: viewModel.multisigTotalSignerCount,
+                              count: viewModel.multisigRequiredSignerCount)
+                          : t.tooltip.mfp,
+                      style: CoconutTypography.body3_12.setColor(CoconutColors.black).merge(
+                            const TextStyle(
+                              height: 1.3,
+                            ),
+                          ),
+                    ),
+                  ),
+                  onTapRemove: _removeTooltip,
+                  isPlacementTooltipVisible: _tooltipRemainingTime > 0,
+                ),
+              ),
+            ],
           );
         },
       ),
@@ -303,7 +305,14 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
           _walletTooltipKey.currentContext?.findRenderObject() as RenderBox?;
       if (_walletTooltipIconRenderBox != null) {
         _walletTooltipIconPosition = _walletTooltipIconRenderBox!.localToGlobal(Offset.zero);
-        _tooltipTopPadding = MediaQuery.paddingOf(context).top + kToolbarHeight - 8;
+        _tooltipTopPadding =
+            _walletTooltipIconPosition.dy + _walletTooltipIconRenderBox!.size.height;
+
+        debugPrint('MediaQuery.paddingOf(context).top = ${MediaQuery.paddingOf(context).top}');
+        debugPrint('kToolbarHeight = $kToolbarHeight');
+        debugPrint(
+            '_walletTooltipIconRenderBox!.size.height: ${_walletTooltipIconRenderBox!.size.height}');
+        debugPrint('_tooltipTopPadding: $_tooltipTopPadding');
       }
     } catch (e) {
       debugPrint('Tooltip position initialization failed: $e');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,7 +77,7 @@ dependencies:
   coconut_design_system: 
     git:
       url: https://github.com/noncelab/coconut_design_system.git
-      ref: main
+      ref: fix/appbar-height-dialog-padding
   realm: ^20.0.0
   cryptography: ^2.7.0
   slang: ^4.4.1


### PR DESCRIPTION
### **변경 사항**
외부지갑이름 수정 화면
- 바텀시트를 열었을 때 키보드도 함께 올라오도록 수정
- 앱바 영역에서 leadingIcon 패딩을 vertical,horizontal 동일하게 설정

스캔화면 다이얼로그
- CustomDialogs -> CoconutPopup으로 교체
- 다이얼로그 모서리 부분에 일부가 비치는 현상 해결

### **추후 작업**
CDS branch: fix/appbar-height-dialog-padding 머지 된 후 pubspec에 CDS 브랜치 main으로 변경

<table>
  <tr>
    <div align="center">
  <img 
    src="https://github.com/user-attachments/assets/335496b0-511e-4925-88bd-951263bc6c90"
    width="300"
  >
<img 
    src="https://github.com/user-attachments/assets/d9a08cb7-d950-4a80-837a-77bc1bdb181d"
    width="300"
  >
</div>
  </tr>
 <tr>
    <div align="center">
<img 
    src="https://github.com/user-attachments/assets/f15e012b-a56c-404c-b673-6090d7ba7d7a"
    width="300"
  >
  <img 
    src="https://github.com/user-attachments/assets/79f8e144-1756-4d2f-a59b-df0981b86d65"
    width="300"
  >
</div>
  </tr>
</table>

#180 