### PR TITLE
[198/204] 직접 입력 시 포맷 및 네트워크 검사

### DIFF
--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -163,6 +163,7 @@ wallet_add_input_screen:
   invalid_character_error_text: "허용되지 않는 문자가 있어요"
   mainnet_wallet_error_text: "메인넷 지갑이 아니에요"
   testnet_wallet_error_text: "테스트넷 지갑이 아니에요"
+  unsupported_wallet_error_text: "지원하지 않는 지갑이에요"
   wallet_description_text: "지갑 추가 정보를 어디서 찾을 수 있나요?"
   blue_wallet_texts:
     - "· 블루월렛"

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -161,6 +161,8 @@ wallet_add_input_screen:
   placeholder_text: "확장공개키(zpub) 또는 디스크립터를 입력해 주세요"
   format_error_text: "확인할 수 없는 형식이에요"
   invalid_character_error_text: "허용되지 않는 문자가 있어요"
+  mainnet_wallet_error_text: "메인넷 지갑이 아니에요"
+  testnet_wallet_error_text: "테스트넷 지갑이 아니에요"
   wallet_description_text: "지갑 추가 정보를 어디서 찾을 수 있나요?"
   blue_wallet_texts:
     - "· 블루월렛"

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -159,7 +159,8 @@ wallet_add_scanner_screen:
 wallet_add_input_screen:
   app_bar_title_text: "직접 입력"
   placeholder_text: "확장공개키(zpub) 또는 디스크립터를 입력해 주세요"
-  error_text: "확인할 수 없는 형식이에요"
+  format_error_text: "확인할 수 없는 형식이에요"
+  invalid_character_error_text: "허용되지 않는 문자가 있어요"
   wallet_description_text: "지갑 추가 정보를 어디서 찾을 수 있나요?"
   blue_wallet_texts:
     - "· 블루월렛"

--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -19,7 +19,7 @@ class WalletAddInputViewModel extends ChangeNotifier {
 
   bool isExtendedPublicKey(String xpub) {
     try {
-      _validateUnsupportedXpub(xpub);
+      _validateXpubPrefixSupport(xpub);
       SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, xpub, '-');
       validExtendedPublicKey = xpub;
       validDescriptor = null;
@@ -52,15 +52,13 @@ class WalletAddInputViewModel extends ChangeNotifier {
     return isValid;
   }
 
-  void _validateUnsupportedXpub(String xpub) {
-    if (NetworkType.currentNetworkType.isTestnet) {
-      if (xpub.toLowerCase().startsWith("upub")) {
-        throw Exception("[testnet] upub is not supported");
-      }
-    } else {
-      if (xpub.toLowerCase().startsWith("ypub")) {
-        throw Exception("[mainnet] ypub is not supported");
-      }
+  void _validateXpubPrefixSupport(String xpub) {
+    final allowedPrefixes =
+        NetworkType.currentNetworkType.isTestnet ? ["vpub", "tpub"] : ["xpub", "zpub"];
+    final prefix = xpub.substring(0, 4).toLowerCase();
+
+    if (!allowedPrefixes.contains(prefix)) {
+      throw Exception("[${NetworkType.currentNetworkType}] '$prefix' is not supported.");
     }
   }
 

--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
+import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/services/wallet_add_service.dart';
 import 'package:coconut_wallet/utils/descriptor_util.dart';
@@ -12,17 +13,19 @@ class WalletAddInputViewModel extends ChangeNotifier {
   final WalletAddService _walletAddService = WalletAddService();
   String? validExtendedPublicKey;
   String? validDescriptor;
+  String? errorMessage;
 
   WalletAddInputViewModel(this._walletProvider);
 
   bool isExtendedPublicKey(String xpub) {
     try {
-      ExtendedPublicKey.parse(xpub);
+      SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, xpub, '-');
       validExtendedPublicKey = xpub;
       validDescriptor = null;
       return true;
-    } catch (_) {
+    } catch (e) {
       validExtendedPublicKey = validDescriptor = null;
+      _setErrorMessageByError(e);
       return false;
     }
   }
@@ -32,14 +35,31 @@ class WalletAddInputViewModel extends ChangeNotifier {
       validDescriptor = DescriptorUtil.normalizeDescriptor(descriptor);
       validExtendedPublicKey = null;
       return true;
-    } catch (_) {
+    } catch (e) {
       validExtendedPublicKey = validDescriptor = null;
+      _setErrorMessageByError(e);
       return false;
     }
   }
 
   bool isValidCharacters(String text) {
-    return RegExp(r"^[a-zA-Z0-9#*();<>/'`\[\]]+$").hasMatch(text);
+    bool isValid = RegExp(r"^[a-zA-Z0-9#*();<>/'`\[\]]+$").hasMatch(text);
+    if (!isValid) {
+      errorMessage = t.wallet_add_input_screen.invalid_character_error_text;
+      notifyListeners();
+    }
+    return isValid;
+  }
+
+  void _setErrorMessageByError(e) {
+    if (e.toString().contains("network type")) {
+      errorMessage = NetworkType.currentNetworkType == NetworkType.mainnet
+          ? t.wallet_add_input_screen.mainnet_wallet_error_text
+          : t.wallet_add_input_screen.testnet_wallet_error_text;
+    } else {
+      errorMessage = t.wallet_add_input_screen.format_error_text;
+    }
+    notifyListeners();
   }
 
   Future<ResultOfSyncFromVault> addWallet() async {

--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -19,6 +19,7 @@ class WalletAddInputViewModel extends ChangeNotifier {
 
   bool isExtendedPublicKey(String xpub) {
     try {
+      _validateUnsupportedXpub(xpub);
       SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, xpub, '-');
       validExtendedPublicKey = xpub;
       validDescriptor = null;
@@ -51,11 +52,25 @@ class WalletAddInputViewModel extends ChangeNotifier {
     return isValid;
   }
 
+  void _validateUnsupportedXpub(String xpub) {
+    if (NetworkType.currentNetworkType.isTestnet) {
+      if (xpub.toLowerCase().startsWith("upub")) {
+        throw Exception("[testnet] upub is not supported");
+      }
+    } else {
+      if (xpub.toLowerCase().startsWith("ypub")) {
+        throw Exception("[mainnet] ypub is not supported");
+      }
+    }
+  }
+
   void _setErrorMessageByError(e) {
     if (e.toString().contains("network type")) {
       errorMessage = NetworkType.currentNetworkType == NetworkType.mainnet
           ? t.wallet_add_input_screen.mainnet_wallet_error_text
           : t.wallet_add_input_screen.testnet_wallet_error_text;
+    } else if (e.toString().contains("not supported")) {
+      errorMessage = t.wallet_add_input_screen.unsupported_wallet_error_text;
     } else {
       errorMessage = t.wallet_add_input_screen.format_error_text;
     }

--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -39,6 +39,10 @@ class WalletAddInputViewModel extends ChangeNotifier {
     }
   }
 
+  bool isValidCharacters(String text) {
+    return RegExp(r"^[a-zA-Z0-9#*() ;<>/'`\[`\]]+$").hasMatch(text);
+  }
+
   Future<ResultOfSyncFromVault> addWallet() async {
     assert(validExtendedPublicKey != null || validDescriptor != null);
     if (validExtendedPublicKey != null) {

--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -17,6 +17,7 @@ class WalletAddInputViewModel extends ChangeNotifier {
 
   bool isExtendedPublicKey(String xpub) {
     try {
+      xpub = xpub.trim();
       ExtendedPublicKey.parse(xpub);
       validExtendedPublicKey = xpub;
       validDescriptor = null;
@@ -29,7 +30,7 @@ class WalletAddInputViewModel extends ChangeNotifier {
 
   bool normalizeDescriptor(String descriptor) {
     try {
-      validDescriptor = DescriptorUtil.normalizeDescriptor(descriptor);
+      validDescriptor = DescriptorUtil.normalizeDescriptor(descriptor.trim());
       validExtendedPublicKey = null;
       return true;
     } catch (_) {

--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -17,7 +17,6 @@ class WalletAddInputViewModel extends ChangeNotifier {
 
   bool isExtendedPublicKey(String xpub) {
     try {
-      xpub = xpub.trim();
       ExtendedPublicKey.parse(xpub);
       validExtendedPublicKey = xpub;
       validDescriptor = null;
@@ -30,7 +29,7 @@ class WalletAddInputViewModel extends ChangeNotifier {
 
   bool normalizeDescriptor(String descriptor) {
     try {
-      validDescriptor = DescriptorUtil.normalizeDescriptor(descriptor.trim());
+      validDescriptor = DescriptorUtil.normalizeDescriptor(descriptor);
       validExtendedPublicKey = null;
       return true;
     } catch (_) {
@@ -40,7 +39,7 @@ class WalletAddInputViewModel extends ChangeNotifier {
   }
 
   bool isValidCharacters(String text) {
-    return RegExp(r"^[a-zA-Z0-9#*() ;<>/'`\[`\]]+$").hasMatch(text);
+    return RegExp(r"^[a-zA-Z0-9#*();<>/'`\[\]]+$").hasMatch(text);
   }
 
   Future<ResultOfSyncFromVault> addWallet() async {

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_add_input_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
@@ -244,6 +245,26 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                                       ]
                                     ],
                                   )),
+
+                              /// 임시 버튼
+                              GestureDetector(
+                                onTap: () {
+                                  NetworkType.setNetworkType(
+                                      NetworkType.currentNetworkType == NetworkType.mainnet
+                                          ? NetworkType.regtest
+                                          : NetworkType.mainnet);
+                                  _handleInput(context);
+                                  setState(() {});
+                                },
+                                child: Container(
+                                    width: 200,
+                                    height: 100,
+                                    color: Colors.green,
+                                    child: Text(
+                                        NetworkType.currentNetworkType == NetworkType.mainnet
+                                            ? "현재: 메인넷(클릭시 변경)"
+                                            : "현재: 테스트넷(클릭시 변경)")),
+                              ),
                             ],
                           ),
                         ),

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -9,6 +9,7 @@ import 'package:coconut_wallet/utils/vibration_util.dart';
 import 'package:coconut_wallet/widgets/button/fixed_bottom_button.dart';
 import 'package:coconut_wallet/widgets/custom_dialogs.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:loader_overlay/loader_overlay.dart';
 import 'package:provider/provider.dart';
@@ -143,6 +144,9 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                             children: [
                               CoconutLayout.spacing_600h,
                               CoconutTextField(
+                                  textInputFormatter: [
+                                    FilteringTextInputFormatter.deny(RegExp(r'\s+')),
+                                  ],
                                   textAlign: TextAlign.left,
                                   backgroundColor: CoconutColors.gray800,
                                   errorColor: CoconutColors.hotPink,

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -100,10 +100,11 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
     }
 
     setState(() {
-      _isButtonEnabled = viewModel.isExtendedPublicKey(
-            _inputController.text,
-          ) ||
-          viewModel.normalizeDescriptor(_inputController.text);
+      _isButtonEnabled = viewModel.isValidCharacters(_inputController.text) &&
+          (viewModel.isExtendedPublicKey(
+                _inputController.text,
+              ) ||
+              viewModel.normalizeDescriptor(_inputController.text));
       _isError = !_isButtonEnabled;
     });
   }
@@ -156,7 +157,9 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                                   onChanged: (text) {},
                                   isError: _isError,
                                   isLengthVisible: false,
-                                  errorText: t.wallet_add_input_screen.error_text,
+                                  errorText: !viewModel.isValidCharacters(_inputController.text)
+                                      ? t.wallet_add_input_screen.invalid_character_error_text
+                                      : t.wallet_add_input_screen.format_error_text,
                                   placeholderText: t.wallet_add_input_screen.placeholder_text,
                                   suffix: IconButton(
                                     iconSize: 14,

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -102,10 +102,9 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
 
     setState(() {
       _isButtonEnabled = viewModel.isValidCharacters(_inputController.text) &&
-          (viewModel.isExtendedPublicKey(
-                _inputController.text,
-              ) ||
-              viewModel.normalizeDescriptor(_inputController.text));
+          (_inputController.text.contains("[") // 대괄호 입력시 descriptor 입력을 가정
+              ? viewModel.normalizeDescriptor(_inputController.text)
+              : viewModel.isExtendedPublicKey(_inputController.text));
       _isError = !_isButtonEnabled;
     });
   }
@@ -161,9 +160,7 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                                   onChanged: (text) {},
                                   isError: _isError,
                                   isLengthVisible: false,
-                                  errorText: !viewModel.isValidCharacters(_inputController.text)
-                                      ? t.wallet_add_input_screen.invalid_character_error_text
-                                      : t.wallet_add_input_screen.format_error_text,
+                                  errorText: viewModel.errorMessage,
                                   placeholderText: t.wallet_add_input_screen.placeholder_text,
                                   suffix: IconButton(
                                     iconSize: 14,

--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -108,7 +108,8 @@ class DescriptorUtil {
 
     validateNativeSegwitDescriptor(finalDescriptor);
     validateChecksum(finalDescriptor);
-    Descriptor.parse(finalDescriptor, ignoreChecksum: !finalDescriptor.contains("#"));
+    SingleSignatureWallet.fromDescriptor(finalDescriptor,
+        ignoreChecksum: !finalDescriptor.contains("#"));
     return finalDescriptor;
   }
 }

--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -12,8 +12,8 @@ class DescriptorUtil {
   static String wrapWithDescriptorFunction(String descriptor) {
     // Invalid Descriptor Function인 경우 처리를 막는다. ex: invalid(~)
     if (descriptor.contains("(") || descriptor.contains(")")) {
-      Logger.log("Invalid descriptor function");
-      throw const FormatException('Invalid descriptor function');
+      Logger.log('Invalid descriptor function: $descriptor');
+      throw FormatException('Invalid descriptor function: $descriptor');
     }
 
     return '$allowedDescriptorFunction($descriptor)';
@@ -68,21 +68,21 @@ class DescriptorUtil {
   static void validateBracelets(String descriptor) {
     // 중괄호의 수가 각각 1개씩 있어야 한다.
     if ('('.allMatches(descriptor).length != 1 || ')'.allMatches(descriptor).length != 1) {
-      Logger.log("Invalid length of bracelets: $descriptor");
-      throw FormatException("Invalid length of bracelets: $descriptor");
+      Logger.log("Invalid length of () bracelets: $descriptor");
+      throw FormatException("Invalid length of () bracelets: $descriptor");
     }
 
     // 마지막 중괄호 이후 문자 있는지 확인(체크섬이 있는 경우 제외)
     if (!descriptor.contains("#") && descriptor.substring(descriptor.lastIndexOf(')')).length > 1) {
-      Logger.log("Invalid letters after bracelet: $descriptor");
-      throw FormatException("Invalid letters after bracelet: $descriptor");
+      Logger.log("Invalid letters after ) bracelet: $descriptor");
+      throw FormatException("Invalid letters after ) bracelet: $descriptor");
     }
 
     // MFP를 사용하는 경우 wpkh( [ 사이에 문자가 있는지 확인한다.
     if (descriptor.contains('[') &&
         descriptor.substring(descriptor.indexOf('('), descriptor.indexOf('[')).length > 1) {
-      Logger.log("Invalid letters before bracelet: $descriptor");
-      throw FormatException("Invalid letters before bracelet: $descriptor");
+      Logger.log("Invalid letters after ( bracelet: $descriptor");
+      throw FormatException("Invalid letters after ( bracelet: $descriptor");
     }
 
     // 대괄호의 개수가 같아야 하며 각각 2개 이상 존재할 수 없다.
@@ -91,8 +91,8 @@ class DescriptorUtil {
     if (squareBracketStartLength != squareBracketEndLength ||
         squareBracketStartLength > 1 ||
         squareBracketEndLength > 1) {
-      Logger.log("Invalid length of bracelets: $descriptor");
-      throw FormatException("Invalid length of bracelets: $descriptor");
+      Logger.log("Invalid length of [] bracelets: $descriptor");
+      throw FormatException("Invalid length of [] bracelets: $descriptor");
     }
   }
 

--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -59,7 +59,7 @@ class DescriptorUtil {
 
     final finalDescriptor =
         descriptorFunction == null ? wrapWithDescriptorFunction(descriptor) : descriptor;
-    Descriptor.parse(finalDescriptor, ignoreChecksum: !hasDescriptorChecksum(finalDescriptor));
+    Descriptor.parse(finalDescriptor, ignoreChecksum: !finalDescriptor.contains("#"));
     return finalDescriptor;
   }
 }

--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -65,7 +65,7 @@ class DescriptorUtil {
     }
   }
 
-  static void validateBracelets(String descriptor) {
+  static void validateNativeSegwitDescriptor(String descriptor) {
     // 중괄호의 수가 각각 1개씩 있어야 한다.
     if ('('.allMatches(descriptor).length != 1 || ')'.allMatches(descriptor).length != 1) {
       Logger.log("Invalid length of () bracelets: $descriptor");
@@ -106,7 +106,7 @@ class DescriptorUtil {
     final finalDescriptor =
         descriptorFunction == null ? wrapWithDescriptorFunction(descriptor) : descriptor;
 
-    validateBracelets(finalDescriptor);
+    validateNativeSegwitDescriptor(finalDescriptor);
     validateChecksum(finalDescriptor);
     Descriptor.parse(finalDescriptor, ignoreChecksum: !finalDescriptor.contains("#"));
     return finalDescriptor;

--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -42,7 +42,7 @@ class DescriptorUtil {
 
   static void validatePurpose(String purpose) {
     if (purpose != '84') {
-      throw const FormatException('Invalid purpose');
+      throw FormatException("purpose $purpose is not supported");
     }
   }
 
@@ -84,6 +84,7 @@ class DescriptorUtil {
   }
 
   static String normalizeDescriptor(String descriptor) {
+    validatePurpose(extractPurpose(descriptor));
     final descriptorFunction = getDescriptorFunction(descriptor);
     if (descriptorFunction != null) {
       validateDescriptorFunction(descriptorFunction);

--- a/lib/widgets/card/wallet_item_card.dart
+++ b/lib/widgets/card/wallet_item_card.dart
@@ -55,7 +55,10 @@ class WalletItemCard extends StatelessWidget {
           child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 24.0),
               child: Row(children: [
-                WalletItemIcon(walletImportSource: walletImportSource),
+                WalletItemIcon(
+                    walletImportSource: walletImportSource,
+                    iconIndex: iconIndex,
+                    colorIndex: colorIndex),
                 CoconutLayout.spacing_200w,
                 Expanded(
                   child: Column(

--- a/test/utils/descriptor_util_test.dart
+++ b/test/utils/descriptor_util_test.dart
@@ -8,30 +8,30 @@ void main() {
     group('getDescriptorFunction', () {
       test('wpkh 함수 추출', () {
         const descriptor =
-            'wpkh([76223a6f/84"/0"/0"]tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0';
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0";
         expect(DescriptorUtil.getDescriptorFunction(descriptor), 'wpkh');
       });
 
       test('sh 함수 추출', () {
         const descriptor =
-            'sh(wpkh([76223a6f/84"/0"/0"]tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*))';
+            "sh(wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*))";
         expect(DescriptorUtil.getDescriptorFunction(descriptor), 'sh');
       });
 
       test('wsh 함수 추출', () {
-        const descriptor = 'wsh(multi(2,[76223a6f/84"/0"/0"]tpub1,[76223a6f/84"/0"/0"]tpub2))';
+        const descriptor = "wsh(multi(2,[76223a6f/84'/0'/0']tpub1,[76223a6f/84'/0'/0']tpub2))";
         expect(DescriptorUtil.getDescriptorFunction(descriptor), 'wsh');
       });
 
       test('함수가 없는 디스크립터는 null 반환', () {
         const descriptor =
-            '[76223a6f/84"/0"/0"]tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*';
+            "[76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*";
         expect(DescriptorUtil.getDescriptorFunction(descriptor), null);
       });
 
       test('지원하지 않는 함수는 null 반환', () {
         const descriptor =
-            'unknown([76223a6f/84"/0"/0"]tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)';
+            "unknown([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)";
         expect(DescriptorUtil.getDescriptorFunction(descriptor), null);
       });
 
@@ -44,7 +44,7 @@ void main() {
     group('extractPurpose', () {
       test('올바른 디스크립터에서 purpose를 추출', () {
         const descriptor =
-            'wpkh([76223a6f/84\'/0\'/0\']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0';
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0";
         expect(DescriptorUtil.extractPurpose(descriptor), '84');
       });
 
@@ -73,31 +73,31 @@ void main() {
     group('hasDescriptorChecksum', () {
       test('체크섬이 있는 디스크립터 확인', () {
         const descriptor =
-            'wpkh([76223a6f/84\'/0\'/0\']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0';
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0";
         expect(DescriptorUtil.hasDescriptorChecksum(descriptor), true);
       });
 
       test('체크섬이 없는 디스크립터 확인', () {
         const descriptor =
-            'wpkh([76223a6f/84\'/0\'/0\']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)';
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)";
         expect(DescriptorUtil.hasDescriptorChecksum(descriptor), false);
       });
 
       test('잘못된 체크섬 형식 확인', () {
         const descriptor =
-            'wpkh([76223a6f/84\'/0\'/0\']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#invalid';
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#invalid";
         expect(DescriptorUtil.hasDescriptorChecksum(descriptor), false);
       });
 
       test('공백이 있는 디스크립터 처리', () {
         const descriptor =
-            '  wpkh([76223a6f/84\'/0\'/0\']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0  ';
+            "  wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0  ";
         expect(DescriptorUtil.hasDescriptorChecksum(descriptor), true);
       });
     });
 
     group('normalizeDescriptor', () {
-      test('wtttttttt', () {
+      test('wpkh 함수가 있는 디스크립터는 그대로 반환', () {
         const descriptor =
             "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)";
         expect(DescriptorUtil.normalizeDescriptor(descriptor), descriptor);
@@ -134,13 +134,13 @@ void main() {
 
       test('잘못된 purpose를 가진 디스크립터는 예외 발생', () {
         const descriptor =
-            'wpkh([76223a6f/44\'/0\'/0\']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0';
+            "wpkh([76223a6f/44'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0";
         expect(() => DescriptorUtil.normalizeDescriptor(descriptor), throwsException);
       });
 
       test('지원하지 않는 함수는 예외 발생', () {
         const descriptor =
-            'sh([76223a6f/84\'/0\'/0\']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0';
+            "sh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0";
         expect(() => DescriptorUtil.normalizeDescriptor(descriptor), throwsException);
       });
 
@@ -306,68 +306,87 @@ void main() {
       test("NetworkType에 따른 주소가 맞는지 검증(Descriptor)", () {
         // 테스트넷
         var descriptor1 =
-            "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"; // 테스트넷
+            "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)";
         var descriptor2 =
             "wpkh([98C7D774/84'/1'/0']vpub5ZZ1q76vi2LR9PeQDoV13u8TZwsyqKa7yBfD3GnPPvBjVU9ZnBTMkwzCHCVBZaPHDKJNEdMKo8MTyrQ9234idzSG9nHFD6hsUB8HJ14NBg7/<0;1>/*)";
         var descriptor3 =
             "wpkh([98c7d774/84'/1'/0']tpubDDbAxgGSifNq7nDVLi3LfzeqF1GXhx4BM3HwxcdJVqhPLxSjMida9WyJZeV95teMpW4tMA4KFYtcSc7srHjz7uFkx4RQ4T15baqyqBdYTgm/<0;1>/*)";
+        // 메인넷
+        var descriptor4 =
+            "wpkh([33a0cbfd/49'/1'/0']xpub6CorSC5E8wkNboiq84Ndxvm3w4ccSA4MbEva8khZ4a5Cxk8hQYwrsJoPsmL8KsmCeFWzD4irCJdEqcd7kKRi5SAg355pTxTgHW2eVzQu2dd/<0;1>/*)";
 
         NetworkType.setNetworkType(NetworkType.regtest);
-        expect(DescriptorUtil.normalizeDescriptor(descriptor1), isNotEmpty);
-        expect(DescriptorUtil.normalizeDescriptor(descriptor2), isNotEmpty);
-        expect(DescriptorUtil.normalizeDescriptor(descriptor3), isNotEmpty);
+        expect(DescriptorUtil.normalizeDescriptor(descriptor1), isNotEmpty); // o 통과
+        expect(DescriptorUtil.normalizeDescriptor(descriptor2), isNotEmpty); // o 통과
+        expect(DescriptorUtil.normalizeDescriptor(descriptor3), isNotEmpty); // o 통과
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor4),
+            throwsException); // 49 o 지원하지 않는 지갑이에요
 
         NetworkType.setNetworkType(NetworkType.mainnet);
-        expect(() => DescriptorUtil.normalizeDescriptor(descriptor1), throwsException);
-        expect(() => DescriptorUtil.normalizeDescriptor(descriptor2), throwsException);
-        expect(() => DescriptorUtil.normalizeDescriptor(descriptor3), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor1),
+            throwsException); // o 메인넷 지갑이 아니에요
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor2),
+            throwsException); // o 메인넷 지갑이 아니에요
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor3),
+            throwsException); // o 메인넷 지갑이 아니에요
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor4),
+            throwsException); // o 지원하지 않는 지갑이에요
       });
     });
 
     group('SingleSignatureWallet.fromExtendedPublicKey', () {
+      // AddWalletInputViewModel 사용 형태와 동일하게 구성
+      String getDescriptorFromSingleSigWallet(String xpub) {
+        if (NetworkType.currentNetworkType.isTestnet) {
+          if (xpub.toLowerCase().startsWith("upub")) {
+            throw Exception("[testnet] upub is not supported");
+          }
+        } else {
+          if (xpub.toLowerCase().startsWith("ypub")) {
+            throw Exception("[mainnet] ypub is not supported");
+          }
+        }
+        return SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, xpub, '-')
+            .descriptor;
+      }
+
       test("NetworkType에 따른 주소가 맞는지 검증", () {
-        // 테스트넷 t, v
-        var vpub =
-            "vpub5Zqvq9Zcs7aixHKwhyuyctgNQDw12wLv61fSWZz9QwodYLUH5hnSAC53jynrkXdzQKijGMut3KuFB1oGndWp6rDNb56mMqdNyYuKTzM3UyR";
+        // 테스트넷 t, v, u(not supported)
         var tpub =
             "tpubDDt5xij8skd8vfu2ptUKEzCk5HKYuZpyTsJBRuq4WsKHPpmSfExeYm4A2RnpGqu51WVFNtcsVkSPdmX1ctC5am2sPMEvDBvb6xd216itFG6";
-        // 메인넷 x, z
+        var vpub =
+            "vpub5Z6wrDZJQ78faJ3PYfYs7et7ep8d8uCXivpa3cdxw3joZrN2dfkYuP2xfCgFWscYcvQFAHoVDMcPKrmF7ekcrwQiKcn8qQtEBwuqoMSfJte";
+        var upub =
+            "upub5Dcn3jR5giMjX6QnUw6YXzq4xdMPFF4iJajHAqyaVdYbWCmoCsowgQguE5CBB25vDduA2tyygBbM9KojtzCf5W9x8ddCHVodj5igVzJf39j";
+        // 메인넷 x, z, y(not supported)
         var xpub =
             "xpub6DWTSUuTAUfgesiBNhVE34sNkADtvBKuvEht5MmvAxZPeY6jb27ZQKPKnPi2kLwqDbxLmK6zxecLwb2QE2LqhKaaKkVcXfGMX12cF84D74X";
         var zpub =
-            "zpub6sAz3pFHTqkeMU6R3R4UTF4P66WnoRJukTkKe9ZgvyK9kjjC6LSgeShbpodCkAFg2tBxGGJ7syKSiAFXfRAsHnwn4RtThUuL4T9u2EtUh3v";
+            "zpub6rpahWwxVNAsVwTTXvUuZLa2CvWVPWbfeEVn4L2n2oP9x85jyRuNhzsLC9ct82D1y3rWrR2EA2JN35n7G5EfwkcQd8NzpKzyJaz5sCceErG";
+        var ypub =
+            "ypub6XzKPrH3LgdPeeGLhZhHMFUX2xN3StcAj7yZGw8teo1Gu2GWimjp5wDCAwfJ87Z6ZQji6wRfhMwp9oAYYNpf9WvokngaERBV2rvSUcYfaPN";
 
+        // regtest 설정 시
+        // 통과: t, v
+        // 실패: u, x, z, y
         NetworkType.setNetworkType(NetworkType.regtest);
-        expect(
-            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, vpub, '-').descriptor,
-            isNotEmpty);
-        expect(
-            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, tpub, '-').descriptor,
-            isNotEmpty);
-        expect(
-            () => SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, xpub, '-')
-                .descriptor,
-            throwsException);
-        expect(
-            () => SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, zpub, '-')
-                .descriptor,
-            throwsException);
+        expect(getDescriptorFromSingleSigWallet(tpub), isNotEmpty); // o 통과
+        expect(getDescriptorFromSingleSigWallet(vpub), isNotEmpty); // o 통과
+        expect(() => getDescriptorFromSingleSigWallet(upub), throwsException); // o 지원하지 않는 지갑이에요
+        expect(() => getDescriptorFromSingleSigWallet(xpub), throwsException); // o 테스트넷 지갑이 아니에요
+        expect(() => getDescriptorFromSingleSigWallet(zpub), throwsException); // o 테스트넷 지갑이 아니에요
+        expect(() => getDescriptorFromSingleSigWallet(ypub), throwsException); // o 테스트넷 지갑이 아니에요
 
+        // mainnet 설정시
+        // 통과: x, z
+        // 실패: y, t, v, u
         NetworkType.setNetworkType(NetworkType.mainnet);
-        expect(
-            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, xpub, '-').descriptor,
-            isNotEmpty);
-        expect(
-            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, zpub, '-').descriptor,
-            isNotEmpty);
-        expect(
-            () => SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, vpub, '-')
-                .descriptor,
-            throwsException);
-        expect(
-            () => SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, tpub, '-')
-                .descriptor,
-            throwsException);
+        expect(getDescriptorFromSingleSigWallet(xpub), isNotEmpty); // o 통과
+        expect(getDescriptorFromSingleSigWallet(zpub), isNotEmpty); // o 통과
+        expect(() => getDescriptorFromSingleSigWallet(ypub), throwsException); // o 지원하지 않는 지갑이에요
+        expect(() => getDescriptorFromSingleSigWallet(tpub), throwsException); // o 메인넷 지갑이 아니에요
+        expect(() => getDescriptorFromSingleSigWallet(vpub), throwsException); // o 메인넷 지갑이 아니에요
+        expect(() => getDescriptorFromSingleSigWallet(upub), throwsException); // o 메인넷 지갑이 아니에요
       });
 
       test("공개키 테스트 케이스", () {
@@ -394,10 +413,7 @@ void main() {
         ];
 
         for (int i = 0; i < validXpubList.length; ++i) {
-          expect(
-              SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, validXpubList[i], '-')
-                  .descriptor,
-              isNotEmpty);
+          expect(getDescriptorFromSingleSigWallet(validXpubList[i]), isNotEmpty);
         }
 
         var invalidXpubList = [
@@ -414,8 +430,7 @@ void main() {
         int invalidXpubCount = 0;
         for (int i = 0; i < invalidXpubList.length; ++i) {
           try {
-            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, invalidXpubList[i], '-')
-                .descriptor;
+            getDescriptorFromSingleSigWallet(invalidXpubList[i]);
           } catch (e) {
             expect((e is Error) || (e is Exception), true);
             ++invalidXpubCount;

--- a/test/utils/descriptor_util_test.dart
+++ b/test/utils/descriptor_util_test.dart
@@ -1,6 +1,7 @@
 import 'package:coconut_wallet/utils/descriptor_util.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// 명령어: flutter test test/utils/descriptor_util_test.dart
 void main() {
   group('DescriptorUtil', () {
     group('getDescriptorFunction', () {
@@ -103,7 +104,7 @@ void main() {
 
       test('함수가 없는 디스크립터는 wpkh로 감싸짐', () {
         const descriptor =
-            '[38d0b5e1/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*)#uqpyzfuf';
+            '[38d0b5e1/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*';
         expect(DescriptorUtil.normalizeDescriptor(descriptor), 'wpkh($descriptor)');
       });
 
@@ -111,12 +112,36 @@ void main() {
         const descriptor =
             'wpkh([38d0b5e1/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*)#uqpyzfuf';
         expect(DescriptorUtil.normalizeDescriptor(descriptor), descriptor);
+
+        // 잘못된 체크섬 로직 검증(영문, 숫자 8개)
+        const descriptor2 =
+            "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)";
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("$descriptor2#test"), throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("$descriptor2#test2"), throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("$descriptor2#test3"), throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("$descriptor2#AAAA"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor2#AAAAAAAAA"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor2#논스랩"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor2#코코넛"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor2#월렛"), throwsFormatException);
       });
 
       test('체크섬이 없는 디스크립터 처리', () {
         const descriptor =
             'wpkh([38d0b5e1/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*)';
+        const descriptor2 =
+            "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)";
+        const descriptor3 =
+            "[F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*";
+
         expect(DescriptorUtil.normalizeDescriptor(descriptor), descriptor);
+        expect(DescriptorUtil.normalizeDescriptor(descriptor2), isNotEmpty);
+        expect(DescriptorUtil.normalizeDescriptor(descriptor3), isNotEmpty);
       });
 
       test('잘못된 purpose를 가진 디스크립터는 예외 발생', () {
@@ -134,12 +159,191 @@ void main() {
       test('잘못된 형식의 디스크립터는 예외 발생', () {
         const descriptor = 'invalid-descriptor';
         expect(() => DescriptorUtil.normalizeDescriptor(descriptor), throwsFormatException);
+
+        const descriptor2 =
+            "([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)";
+        expect(() => DescriptorUtil.normalizeDescriptor("test$descriptor2"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("1234$descriptor2"), throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("hello$descriptor2"), throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("Nonce$descriptor2"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("labCoconut$descriptor2"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("코코넛월렛$descriptor2"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("POW$descriptor2"), throwsFormatException);
       });
 
       test('ExtendedPublicKey만으로 descriptor 생성', () {
         const descriptor =
             'wpkh([00000000/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*)';
-        expect(() => DescriptorUtil.normalizeDescriptor(descriptor), descriptor);
+        expect(DescriptorUtil.normalizeDescriptor(descriptor), descriptor);
+      });
+
+      test("내부적으로 수정된 Descriptor의 중괄호 개수가 각각 1개여야 한다.", () {
+        const descriptor =
+            "[F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg";
+        // 정상 케이스
+        expect(DescriptorUtil.normalizeDescriptor("wpkh($descriptor)"), isNotEmpty);
+        expect(DescriptorUtil.normalizeDescriptor(descriptor), isNotEmpty);
+
+        // 비정상 케이스
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor((()"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor()())"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor((()))"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(()()($descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh())))((($descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh()(($descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(()()()$descriptor((()"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(((()))$descriptor((()"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh())))$descriptor((()"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub()()()5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATG()()()asJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub((((5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLY)))))gfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub((((5YSvHLY))))gfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub(5)Y(Sv))HLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0'](()))))()(vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
+            throwsFormatException);
+      });
+
+      test("Descriptor의 마지막 중괄호 이후에 문자가 있는 경우", () {
+        const descriptor =
+            "[F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*";
+        // 정상 케이스(체크섬이 있는 경우)
+        expect(DescriptorUtil.normalizeDescriptor("wpkh($descriptor)#k8xga4tv"), isNotEmpty);
+
+        // 비정상 케이스
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)test"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)test2"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)Coconut"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)Wallet"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)POW"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)코코넛"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)논스랩"),
+            throwsFormatException);
+      });
+
+      test("wpkh(와 [ 사이에 문자가 있는 경우", () {
+        const descriptor =
+            "[F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*";
+        // 정상 케이스
+        expect(DescriptorUtil.normalizeDescriptor("wpkh($descriptor)#k8xga4tv"), isNotEmpty);
+
+        // 비정상 케이스
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(test$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(test2$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(Coconut$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(Wallet$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(POW$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(코코넛$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(논스랩$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("논스랩$descriptor"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("포우$descriptor"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("1111$descriptor"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("2222$descriptor"), throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("Coconut$descriptor"), throwsFormatException);
+      });
+
+      test("대괄호 개수가 다르거나 2개 이상인 경우", () {
+        const descriptor =
+            "[F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*";
+        // 정상 케이스
+        expect(DescriptorUtil.normalizeDescriptor("wpkh($descriptor)#k8xga4tv"), isNotEmpty);
+
+        // 비정상 케이스
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor[][])"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor[[]])"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor]]]])"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor[][][]])"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([][]$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([[[[[$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([][][]$descriptor)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([[[[$descriptor]]]])"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([[[[$descriptor[][][)"),
+            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([]]]]$descriptor[[[[)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0'][]]]]]]][][][][]vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfa[][][][]Dn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i2[[[[[[3UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2]]]]]i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub5Y[][[]][]SvHLYg[]][faDn1H][FBxmn[k2i23UF]pNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgf][][[][aDn1HFB[][][]][][][xmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54[][][][]][vXBRz696bSraBPThxNg/<0;1>/*)"),
+            throwsFormatException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor(
+                "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxm]]]]]]]]nk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8[[[[[[[[TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
+            throwsFormatException);
       });
     });
   });

--- a/test/utils/descriptor_util_test.dart
+++ b/test/utils/descriptor_util_test.dart
@@ -1,3 +1,4 @@
+import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/utils/descriptor_util.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -50,12 +51,12 @@ void main() {
       test('purpose가 없는 디스크립터는 예외 발생', () {
         const descriptor =
             'wpkh([76223a6f]tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0';
-        expect(() => DescriptorUtil.extractPurpose(descriptor), throwsFormatException);
+        expect(() => DescriptorUtil.extractPurpose(descriptor), throwsException);
       });
 
       test('잘못된 형식의 디스크립터는 예외 발생', () {
         const descriptor = 'invalid-descriptor';
-        expect(() => DescriptorUtil.extractPurpose(descriptor), throwsFormatException);
+        expect(() => DescriptorUtil.extractPurpose(descriptor), throwsException);
       });
     });
 
@@ -65,7 +66,7 @@ void main() {
       });
 
       test('잘못된 purpose는 예외 발생', () {
-        expect(() => DescriptorUtil.validatePurpose('44'), throwsFormatException);
+        expect(() => DescriptorUtil.validatePurpose('44'), throwsException);
       });
     });
 
@@ -96,89 +97,66 @@ void main() {
     });
 
     group('normalizeDescriptor', () {
-      test('wpkh 함수가 있는 디스크립터는 그대로 반환', () {
+      test('wtttttttt', () {
         const descriptor =
-            'wpkh([38d0b5e1/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*)#uqpyzfuf';
+            "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)";
         expect(DescriptorUtil.normalizeDescriptor(descriptor), descriptor);
       });
 
       test('함수가 없는 디스크립터는 wpkh로 감싸짐', () {
         const descriptor =
-            '[38d0b5e1/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*';
+            "[F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*";
         expect(DescriptorUtil.normalizeDescriptor(descriptor), 'wpkh($descriptor)');
       });
 
       test('체크섬이 있는 디스크립터 처리', () {
-        const descriptor =
-            'wpkh([38d0b5e1/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*)#uqpyzfuf';
-        expect(DescriptorUtil.normalizeDescriptor(descriptor), descriptor);
-
         // 잘못된 체크섬 로직 검증(영문, 숫자 8개)
-        const descriptor2 =
+        const descriptor =
             "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)";
-        expect(
-            () => DescriptorUtil.normalizeDescriptor("$descriptor2#test"), throwsFormatException);
-        expect(
-            () => DescriptorUtil.normalizeDescriptor("$descriptor2#test2"), throwsFormatException);
-        expect(
-            () => DescriptorUtil.normalizeDescriptor("$descriptor2#test3"), throwsFormatException);
-        expect(
-            () => DescriptorUtil.normalizeDescriptor("$descriptor2#AAAA"), throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor2#AAAAAAAAA"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor2#논스랩"), throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor2#코코넛"), throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor2#월렛"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor#test"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor#test2"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor#test3"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor#AAAA"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor#AAAAAAAAA"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor#논스랩"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor#코코넛"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("$descriptor#월렛"), throwsException);
       });
 
       test('체크섬이 없는 디스크립터 처리', () {
         const descriptor =
-            'wpkh([38d0b5e1/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*)';
-        const descriptor2 =
             "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)";
-        const descriptor3 =
+        const descriptor2 =
             "[F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*";
-
-        expect(DescriptorUtil.normalizeDescriptor(descriptor), descriptor);
+        expect(DescriptorUtil.normalizeDescriptor(descriptor), isNotEmpty);
         expect(DescriptorUtil.normalizeDescriptor(descriptor2), isNotEmpty);
-        expect(DescriptorUtil.normalizeDescriptor(descriptor3), isNotEmpty);
       });
 
       test('잘못된 purpose를 가진 디스크립터는 예외 발생', () {
         const descriptor =
             'wpkh([76223a6f/44\'/0\'/0\']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0';
-        expect(() => DescriptorUtil.normalizeDescriptor(descriptor), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor), throwsException);
       });
 
       test('지원하지 않는 함수는 예외 발생', () {
         const descriptor =
             'sh([76223a6f/84\'/0\'/0\']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0';
-        expect(() => DescriptorUtil.normalizeDescriptor(descriptor), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor), throwsException);
       });
 
       test('잘못된 형식의 디스크립터는 예외 발생', () {
         const descriptor = 'invalid-descriptor';
-        expect(() => DescriptorUtil.normalizeDescriptor(descriptor), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor), throwsException);
 
         const descriptor2 =
             "([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)";
-        expect(() => DescriptorUtil.normalizeDescriptor("test$descriptor2"), throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("1234$descriptor2"), throwsFormatException);
-        expect(
-            () => DescriptorUtil.normalizeDescriptor("hello$descriptor2"), throwsFormatException);
-        expect(
-            () => DescriptorUtil.normalizeDescriptor("Nonce$descriptor2"), throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("labCoconut$descriptor2"),
-            throwsFormatException);
-        expect(
-            () => DescriptorUtil.normalizeDescriptor("코코넛월렛$descriptor2"), throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("POW$descriptor2"), throwsFormatException);
-      });
-
-      test('ExtendedPublicKey만으로 descriptor 생성', () {
-        const descriptor =
-            'wpkh([00000000/84\'/1\'/0\']vpub5TmYRnYy8ScbkG2WmearTx1DG91gJC4TM9kRTvSQjgVMGRUdx4vRUD8UHjZn8fJZfjUoBHPnVX1q5AmHJHTHw3CRtHzfK4yqMhAKS93Xb3y/<0;1>/*)';
-        expect(DescriptorUtil.normalizeDescriptor(descriptor), descriptor);
+        expect(() => DescriptorUtil.normalizeDescriptor("test$descriptor2"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("1234$descriptor2"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("hello$descriptor2"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("Nonce$descriptor2"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("labCoconut$descriptor2"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("코코넛월렛$descriptor2"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("POW$descriptor2"), throwsException);
       });
 
       test("내부적으로 수정된 Descriptor의 중괄호 개수가 각각 1개여야 한다.", () {
@@ -189,48 +167,43 @@ void main() {
         expect(DescriptorUtil.normalizeDescriptor(descriptor), isNotEmpty);
 
         // 비정상 케이스
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor((()"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor()())"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor((()))"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(()()($descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh())))((($descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh()(($descriptor)"),
-            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor((()"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor()())"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor((()))"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(()()($descriptor)"), throwsException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("wpkh())))((($descriptor)"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh()(($descriptor)"), throwsException);
         expect(() => DescriptorUtil.normalizeDescriptor("wpkh(()()()$descriptor((()"),
-            throwsFormatException);
+            throwsException);
         expect(() => DescriptorUtil.normalizeDescriptor("wpkh(((()))$descriptor((()"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh())))$descriptor((()"),
-            throwsFormatException);
+            throwsException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("wpkh())))$descriptor((()"), throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub()()()5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATG()()()asJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub((((5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLY)))))gfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub((((5YSvHLY))))gfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub(5)Y(Sv))HLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0'](()))))()(vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg)"),
-            throwsFormatException);
+            throwsException);
       });
 
       test("Descriptor의 마지막 중괄호 이후에 문자가 있는 경우", () {
@@ -240,20 +213,15 @@ void main() {
         expect(DescriptorUtil.normalizeDescriptor("wpkh($descriptor)#k8xga4tv"), isNotEmpty);
 
         // 비정상 케이스
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)test"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)test2"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)Coconut"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)Wallet"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)POW"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)코코넛"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)논스랩"),
-            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)test"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)test2"), throwsException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)Coconut"), throwsException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)Wallet"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)POW"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)코코넛"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor)논스랩"), throwsException);
       });
 
       test("wpkh(와 [ 사이에 문자가 있는 경우", () {
@@ -263,26 +231,20 @@ void main() {
         expect(DescriptorUtil.normalizeDescriptor("wpkh($descriptor)#k8xga4tv"), isNotEmpty);
 
         // 비정상 케이스
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(test$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(test2$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(Coconut$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(Wallet$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(POW$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(코코넛$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(논스랩$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("논스랩$descriptor"), throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("포우$descriptor"), throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("1111$descriptor"), throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("2222$descriptor"), throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(test$descriptor)"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(test2$descriptor)"), throwsException);
         expect(
-            () => DescriptorUtil.normalizeDescriptor("Coconut$descriptor"), throwsFormatException);
+            () => DescriptorUtil.normalizeDescriptor("wpkh(Coconut$descriptor)"), throwsException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("wpkh(Wallet$descriptor)"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(POW$descriptor)"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(코코넛$descriptor)"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh(논스랩$descriptor)"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("논스랩$descriptor"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("포우$descriptor"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("1111$descriptor"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("2222$descriptor"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("Coconut$descriptor"), throwsException);
       });
 
       test("대괄호 개수가 다르거나 2개 이상인 경우", () {
@@ -292,58 +254,174 @@ void main() {
         expect(DescriptorUtil.normalizeDescriptor("wpkh($descriptor)#k8xga4tv"), isNotEmpty);
 
         // 비정상 케이스
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor[][])"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor[[]])"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor]]]])"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor[][][]])"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([][]$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([[[[[$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([][][]$descriptor)"),
-            throwsFormatException);
-        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([[[[$descriptor]]]])"),
-            throwsFormatException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor[][])"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor[[]])"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh($descriptor]]]])"), throwsException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("wpkh($descriptor[][][]])"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([][]$descriptor)"), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor("wpkh([[[[[$descriptor)"), throwsException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("wpkh([][][]$descriptor)"), throwsException);
+        expect(
+            () => DescriptorUtil.normalizeDescriptor("wpkh([[[[$descriptor]]]])"), throwsException);
         expect(() => DescriptorUtil.normalizeDescriptor("wpkh([[[[$descriptor[][][)"),
-            throwsFormatException);
+            throwsException);
         expect(() => DescriptorUtil.normalizeDescriptor("wpkh([]]]]$descriptor[[[[)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0'][]]]]]]][][][][]vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
-                "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfa[][][][]Dn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
-            throwsFormatException);
+                "wpkh([F75F5AB5/30'/1'/0']vpub5YSvHLYgfa[][][][]Dn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i2[[[[[[3UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2]]]]]i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub5Y[][[]][]SvHLYg[]][faDn1H][FBxmn[k2i23UF]pNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgf][][[][aDn1HFB[][][]][][][xmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54[][][][]][vXBRz696bSraBPThxNg/<0;1>/*)"),
-            throwsFormatException);
+            throwsException);
         expect(
             () => DescriptorUtil.normalizeDescriptor(
                 "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxm]]]]]]]]nk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8[[[[[[[[TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"),
-            throwsFormatException);
+            throwsException);
+      });
+
+      test("NetworkType에 따른 주소가 맞는지 검증(Descriptor)", () {
+        // 테스트넷
+        var descriptor1 =
+            "wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)"; // 테스트넷
+        var descriptor2 =
+            "wpkh([98C7D774/84'/1'/0']vpub5ZZ1q76vi2LR9PeQDoV13u8TZwsyqKa7yBfD3GnPPvBjVU9ZnBTMkwzCHCVBZaPHDKJNEdMKo8MTyrQ9234idzSG9nHFD6hsUB8HJ14NBg7/<0;1>/*)";
+        var descriptor3 =
+            "wpkh([98c7d774/84'/1'/0']tpubDDbAxgGSifNq7nDVLi3LfzeqF1GXhx4BM3HwxcdJVqhPLxSjMida9WyJZeV95teMpW4tMA4KFYtcSc7srHjz7uFkx4RQ4T15baqyqBdYTgm/<0;1>/*)";
+
+        NetworkType.setNetworkType(NetworkType.regtest);
+        expect(DescriptorUtil.normalizeDescriptor(descriptor1), isNotEmpty);
+        expect(DescriptorUtil.normalizeDescriptor(descriptor2), isNotEmpty);
+        expect(DescriptorUtil.normalizeDescriptor(descriptor3), isNotEmpty);
+
+        NetworkType.setNetworkType(NetworkType.mainnet);
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor1), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor2), throwsException);
+        expect(() => DescriptorUtil.normalizeDescriptor(descriptor3), throwsException);
+      });
+    });
+
+    group('SingleSignatureWallet.fromExtendedPublicKey', () {
+      test("NetworkType에 따른 주소가 맞는지 검증", () {
+        // 테스트넷 t, v
+        var vpub =
+            "vpub5Zqvq9Zcs7aixHKwhyuyctgNQDw12wLv61fSWZz9QwodYLUH5hnSAC53jynrkXdzQKijGMut3KuFB1oGndWp6rDNb56mMqdNyYuKTzM3UyR";
+        var tpub =
+            "tpubDDt5xij8skd8vfu2ptUKEzCk5HKYuZpyTsJBRuq4WsKHPpmSfExeYm4A2RnpGqu51WVFNtcsVkSPdmX1ctC5am2sPMEvDBvb6xd216itFG6";
+        // 메인넷 x, z
+        var xpub =
+            "xpub6DWTSUuTAUfgesiBNhVE34sNkADtvBKuvEht5MmvAxZPeY6jb27ZQKPKnPi2kLwqDbxLmK6zxecLwb2QE2LqhKaaKkVcXfGMX12cF84D74X";
+        var zpub =
+            "zpub6sAz3pFHTqkeMU6R3R4UTF4P66WnoRJukTkKe9ZgvyK9kjjC6LSgeShbpodCkAFg2tBxGGJ7syKSiAFXfRAsHnwn4RtThUuL4T9u2EtUh3v";
+
+        NetworkType.setNetworkType(NetworkType.regtest);
+        expect(
+            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, vpub, '-').descriptor,
+            isNotEmpty);
+        expect(
+            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, tpub, '-').descriptor,
+            isNotEmpty);
+        expect(
+            () => SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, xpub, '-')
+                .descriptor,
+            throwsException);
+        expect(
+            () => SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, zpub, '-')
+                .descriptor,
+            throwsException);
+
+        NetworkType.setNetworkType(NetworkType.mainnet);
+        expect(
+            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, xpub, '-').descriptor,
+            isNotEmpty);
+        expect(
+            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, zpub, '-').descriptor,
+            isNotEmpty);
+        expect(
+            () => SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, vpub, '-')
+                .descriptor,
+            throwsException);
+        expect(
+            () => SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, tpub, '-')
+                .descriptor,
+            throwsException);
+      });
+
+      test("공개키 테스트 케이스", () {
+        // Test vector xpub 케이스 추가
+        // https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+        var validXpubList = [
+          'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8',
+          'xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw',
+          'xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ',
+          'xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5',
+          'xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV',
+          'xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy',
+          'xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB',
+          'xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH',
+          'xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a',
+          'xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon',
+          'xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL',
+          'xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt',
+          'xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13',
+          'xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y',
+          'xpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxyL6tmgBUAEPrEz92mBXjByMRiJdba9wpnN37RLLAXa',
+          'xpub69AUMk3qDBi3uW1sXgjCmVjJ2G6WQoYSnNHyzkmdCHEhSZ4tBok37xfFEqHd2AddP56Tqp4o56AePAgCjYdvpW2PU2jbUPFKsav5ut6Ch1m',
+          'xpub6BJA1jSqiukeaesWfxe6sNK9CCGaujFFSJLomWHprUL9DePQ4JDkM5d88n49sMGJxrhpjazuXYWdMf17C9T5XnxkopaeS7jGk1GyyVziaMt',
+        ];
+
+        for (int i = 0; i < validXpubList.length; ++i) {
+          expect(
+              SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, validXpubList[i], '-')
+                  .descriptor,
+              isNotEmpty);
+        }
+
+        var invalidXpubList = [
+          'xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6LBpB85b3D2yc8sfvZU521AAwdZafEz7mnzBBsz4wKY5fTtTQBm',
+          'xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Txnt3siSujt9RCVYsx4qHZGc62TG4McvMGcAUjeuwZdduYEvFn',
+          'xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6N8ZMMXctdiCjxTNq964yKkwrkBJJwpzZS4HS2fxvyYUA4q2Xe4',
+          'xpub661no6RGEX3uJkY4bNnPcw4URcQTrSibUZ4NqJEw5eBkv7ovTwgiT91XX27VbEXGENhYRCf7hyEbWrR3FewATdCEebj6znwMfQkhRYHRLpJ ',
+          'xpub661MyMwAuDcm6CRQ5N4qiHKrJ39Xe1R1NyfouMKTTWcguwVcfrZJaNvhpebzGerh7gucBvzEQWRugZDuDXjNDRmXzSZe4c7mnTK97pTvGS8',
+          'DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHGMQzT7ayAmfo4z3gY5KfbrZWZ6St24UVf2Qgo6oujFktLHdHY4',
+          'DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHPmHJiEDXkTiJTVV9rHEBUem2mwVbbNfvT2MTcAqj3nesx8uBf9 ',
+          'xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Q5JXayek4PRsn35jii4veMimro1xefsM58PgBMrvdYre8QyULY',
+        ];
+
+        int invalidXpubCount = 0;
+        for (int i = 0; i < invalidXpubList.length; ++i) {
+          try {
+            SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, invalidXpubList[i], '-')
+                .descriptor;
+          } catch (e) {
+            expect((e is Error) || (e is Exception), true);
+            ++invalidXpubCount;
+          }
+          expect(invalidXpubCount, i + 1);
+        }
       });
     });
   });

--- a/test/utils/descriptor_util_test.dart
+++ b/test/utils/descriptor_util_test.dart
@@ -337,15 +337,14 @@ void main() {
     group('SingleSignatureWallet.fromExtendedPublicKey', () {
       // AddWalletInputViewModel 사용 형태와 동일하게 구성
       String getDescriptorFromSingleSigWallet(String xpub) {
-        if (NetworkType.currentNetworkType.isTestnet) {
-          if (xpub.toLowerCase().startsWith("upub")) {
-            throw Exception("[testnet] upub is not supported");
-          }
-        } else {
-          if (xpub.toLowerCase().startsWith("ypub")) {
-            throw Exception("[mainnet] ypub is not supported");
-          }
+        final allowedPrefixes =
+            NetworkType.currentNetworkType.isTestnet ? ["vpub", "tpub"] : ["xpub", "zpub"];
+        final prefix = xpub.substring(0, 4).toLowerCase();
+
+        if (!allowedPrefixes.contains(prefix)) {
+          throw Exception("[${NetworkType.currentNetworkType}] '$prefix' is not supported.");
         }
+
         return SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, xpub, '-')
             .descriptor;
       }


### PR DESCRIPTION
### 변경사항
- 체크섬 유무를 검사할 때 regex를 사용하지 않고 '#' 문자 여부로 판단(이후 로직은 라이브러리에 맡김)
- 공백 문자열 trim 처리
- 입력 가능한 문자가 아닌 경우 에러메시지 처리(허용하지 않는 문자가 있어요)

### test vector(valid input)
vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg

wpkh([F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg/<0;1>/*)#k8xga4tv

[F75F5AB5/84'/1'/0']vpub5YSvHLYgfaDn1HFBxmnk2i23UFpNBLNJNFGfkdbEtwijtwHHMv5UhH6QATGasJWmRp8TPJfxysxdQxRZ8CQqtu54vXBRz696bSraBPThxNg

### 테스트 방법
1. 직접 입력시 공백 문자열 trim 확인, 허용되지 않은 문자에 대한 에러메시지 확인

<img width="200px" src="https://github.com/user-attachments/assets/057127ca-94ca-4351-9921-c3acd2900d2d" />
<img width="200px" src="https://github.com/user-attachments/assets/8b5a5e90-31a9-4507-9218-72035352ee0a" />

#198 #204
