### PR TITLE
[209/213] 확장공개키로 추가하는 경우, MFP 입력 허용하기

### DIFF
--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -175,6 +175,13 @@ wallet_add_input_screen:
     - "· Keys 탭 - 키 선택 - Key spec 정보"
     - "[ddde01df/84'/0'/0']xpubSbsnWbx.." #AOS
     - "[ddde01df/84h/0h/0h]xpubSbsnWbx..." #iOS
+  mfp_title: "마스터 핑거프린트 입력"
+  mfp_description_title: "마스터 핑거프린트(Master Fingerprint)"
+  mfp_description_texts:
+    - "보기 전용 지갑을 식별할 때 필요한 고유 값이예요."
+    - "입력한 정보만으로는 이 값을 자동으로 알 수 없기 때문에, 안전하고 정확한 지갑 연결을 위해 직접 입력해주셔야 해요."
+  mfp_input_placeholder: "f75f7ab5"
+  mfp_skip: "건너뛰기"
 
 # lib/screens/review
 negative_feedback_screen:

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -178,8 +178,9 @@ wallet_add_input_screen:
   mfp_title: "마스터 핑거프린트 입력"
   mfp_description_title: "마스터 핑거프린트(Master Fingerprint)"
   mfp_description_texts:
-    - "보기 전용 지갑을 식별할 때 필요한 고유 값이예요."
+    - "보기 전용 지갑을 식별할 때 필요한 고유 값이에요."
     - "입력한 정보만으로는 이 값을 자동으로 알 수 없기 때문에, 안전하고 정확한 지갑 연결을 위해 직접 입력해주셔야 해요."
+    - "이 정보가 없으면 보내기 기능을 사용하실 수 없어요."
   mfp_input_placeholder: "f75f7ab5"
   mfp_skip: "건너뛰기"
 

--- a/integration_test/wallet_add_test.dart
+++ b/integration_test/wallet_add_test.dart
@@ -176,8 +176,8 @@ Future<void> validateDuplicatedExternalWalletAddFailed(
   // fix: 첫 테스트에서만 Connectivity 리스너가 호출되는 문제가 있다. 두 번째 테스트부터 임의로 함수를 호출하여 isolate.subscribeWallets가 호출되도록 한다.
   //walletProvider.setIsNetworkOn(true);
 
-  final walletFromExtendedPubKey =
-      WalletAddService().createExtendedPublicKeyWallet(singleSigWallet1ExtendedPublicKey, 'zpub');
+  final walletFromExtendedPubKey = WalletAddService()
+      .createExtendedPublicKeyWallet(singleSigWallet1ExtendedPublicKey, 'zpub', null);
 
   var pubKeyWalletAddResult = await walletProvider.syncFromThirdParty(walletFromExtendedPubKey);
   expect(pubKeyWalletAddResult.result, WalletSyncResult.existingWalletUpdateImpossible);

--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -14,6 +14,7 @@ class WalletAddInputViewModel extends ChangeNotifier {
   String? validExtendedPublicKey;
   String? validDescriptor;
   String? errorMessage;
+  String? masterFingerPrint;
 
   WalletAddInputViewModel(this._walletProvider);
 
@@ -87,7 +88,8 @@ class WalletAddInputViewModel extends ChangeNotifier {
   Future<ResultOfSyncFromVault> addWalletFromExtendedPublicKey(String extendedPublicKey) async {
     final name = getNextThirdPartyWalletName(
         importSource, _walletProvider.walletItemList.map((e) => e.name).toList());
-    final wallet = _walletAddService.createExtendedPublicKeyWallet(extendedPublicKey, name);
+    final wallet =
+        _walletAddService.createExtendedPublicKeyWallet(extendedPublicKey, name, masterFingerPrint);
     return await _walletProvider.syncFromThirdParty(wallet);
   }
 

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -4,6 +4,7 @@ import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_add_input_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
+import 'package:coconut_wallet/screens/home/wallet_add_mfp_input_bottom_sheet.dart';
 import 'package:coconut_wallet/utils/text_utils.dart';
 import 'package:coconut_wallet/utils/vibration_util.dart';
 import 'package:coconut_wallet/widgets/button/fixed_bottom_button.dart';
@@ -31,7 +32,9 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
   bool _hasAddedListener = false;
   bool _isProcessing = false;
 
-  Future<void> _onButtonPressed(WalletAddInputViewModel viewModel) async {
+  bool get isDescriptorAdding => _inputController.text.contains('['); // 대괄호 입력시 descriptor 입력을 가정
+
+  Future<void> _addWallet(WalletAddInputViewModel viewModel) async {
     if (_isProcessing) return;
     _isProcessing = true;
     context.loaderOverlay.show();
@@ -86,7 +89,7 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
   }
 
   void _closeKeyboard() {
-    FocusScope.of(context).unfocus();
+    FocusManager.instance.primaryFocus?.unfocus();
   }
 
   void _handleInput(BuildContext context) {
@@ -101,7 +104,7 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
 
     setState(() {
       _isButtonEnabled = viewModel.isValidCharacters(_inputController.text) &&
-          (_inputController.text.contains("[") // 대괄호 입력시 descriptor 입력을 가정
+          (isDescriptorAdding
               ? viewModel.normalizeDescriptor(_inputController.text)
               : viewModel.isExtendedPublicKey(_inputController.text));
       _isError = !_isButtonEnabled;
@@ -247,7 +250,15 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                           ),
                         ),
                         FixedBottomButton(
-                          onButtonClicked: () => _onButtonPressed(viewModel),
+                          onButtonClicked: () {
+                            _closeKeyboard();
+                            if (isDescriptorAdding) {
+                              _addWallet(viewModel);
+                            } else {
+                              // 확장공개키의 경우에는 Master Finger Print를 추가로 입력받는다.
+                              showMfpInputBottomSheet(viewModel);
+                            }
+                          },
                           text: t.complete,
                           showGradient: true,
                           gradientPadding:
@@ -262,6 +273,31 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
             ),
           );
         }));
+  }
+
+  void showMfpInputBottomSheet(WalletAddInputViewModel viewModel) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return Padding(
+          padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+          child: WalletAddMfpInputBottomSheet(
+            onSkip: () {
+              viewModel.masterFingerPrint = null;
+              _addWallet(viewModel);
+            },
+            onComplete: (text) {
+              viewModel.masterFingerPrint = text;
+              _addWallet(viewModel);
+            },
+          ),
+        );
+      },
+      backgroundColor: CoconutColors.black,
+      isScrollControlled: true,
+      enableDrag: true,
+      useSafeArea: true,
+    );
   }
 
   Widget _buildWalletInfo(

--- a/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
+++ b/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
@@ -1,0 +1,220 @@
+import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_wallet/localization/strings.g.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+
+class WalletAddMfpInputBottomSheet extends StatefulWidget {
+  final Function(String) onComplete;
+  final VoidCallback onSkip;
+
+  const WalletAddMfpInputBottomSheet({super.key, required this.onComplete, required this.onSkip});
+
+  @override
+  State<WalletAddMfpInputBottomSheet> createState() => _WalletAddMfpInputBottomSheetState();
+}
+
+class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSheet> {
+  final TextEditingController _mfpController = TextEditingController();
+  final FocusNode _mfpFocusNode = FocusNode();
+  final mfpRegex = RegExp("[0-9a-fA-F]{8}");
+  bool _isError = false;
+  bool _isButtonEnabled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _mfpFocusNode.requestFocus();
+    _mfpController.addListener(() {
+      if (_mfpController.text.length < 8) {
+        setState(() {
+          _isButtonEnabled = false;
+          _isError = false;
+        });
+        return;
+      }
+
+      setState(() {
+        _isButtonEnabled = mfpRegex.hasMatch(_mfpController.text);
+        _isError = !_isButtonEnabled;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _mfpController.dispose();
+    _mfpFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: SingleChildScrollView(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: Sizes.size8, vertical: Sizes.size8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.close, color: CoconutColors.white),
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                  Text(
+                    t.wallet_add_input_screen.mfp_title,
+                    style: CoconutTypography.body1_16,
+                  ),
+                  Visibility(
+                    visible: false,
+                    maintainSize: true,
+                    maintainAnimation: true,
+                    maintainState: true,
+                    maintainSemantics: false,
+                    maintainInteractivity: false,
+                    child: IconButton(
+                      icon: const Icon(Icons.close, color: CoconutColors.white),
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: Sizes.size16,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                      padding: const EdgeInsets.all(CoconutStyles.radius_200),
+                      decoration: const BoxDecoration(
+                        color: CoconutColors.gray800,
+                        borderRadius: BorderRadius.all(Radius.circular(CoconutStyles.radius_200)),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              SvgPicture.asset(
+                                'assets/svg/circle-warning.svg',
+                                colorFilter:
+                                    const ColorFilter.mode(CoconutColors.white, BlendMode.srcIn),
+                              ),
+                              CoconutLayout.spacing_100w,
+                              Text(t.wallet_add_input_screen.mfp_description_title,
+                                  style: CoconutTypography.body3_12)
+                            ],
+                          ),
+                          CoconutLayout.spacing_200h,
+                          Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: Sizes.size8),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(t.wallet_add_input_screen.mfp_description_texts[0],
+                                      style: CoconutTypography.body3_12),
+                                  Text(t.wallet_add_input_screen.mfp_description_texts[1],
+                                      style: CoconutTypography.body3_12),
+                                ],
+                              )),
+                        ],
+                      )),
+                  CoconutLayout.spacing_600h,
+                  CoconutTextField(
+                      height: Sizes.size52,
+                      padding:
+                          const EdgeInsets.only(bottom: 0, left: Sizes.size14, right: Sizes.size14),
+                      textAlign: TextAlign.left,
+                      backgroundColor: CoconutColors.gray800,
+                      errorColor: CoconutColors.hotPink,
+                      cursorColor: CoconutColors.white,
+                      activeColor: CoconutColors.white,
+                      placeholderColor: CoconutColors.gray700,
+                      controller: _mfpController,
+                      focusNode: _mfpFocusNode,
+                      maxLines: 1,
+                      maxLength: 8,
+                      fontFamily: 'SpaceGrotesk',
+                      textInputAction: TextInputAction.done,
+                      onChanged: (text) {},
+                      isError: _isError,
+                      isLengthVisible: true,
+                      errorText: t.wallet_add_input_screen.format_error_text,
+                      placeholderText: t.wallet_add_input_screen.mfp_input_placeholder,
+                      suffix: IconButton(
+                        iconSize: 14,
+                        padding: EdgeInsets.zero,
+                        onPressed: () {
+                          setState(() {
+                            _mfpController.text = '';
+                          });
+                        },
+                        icon: SvgPicture.asset(
+                          'assets/svg/text-field-clear.svg',
+                          colorFilter: ColorFilter.mode(
+                              _isError
+                                  ? CoconutColors.hotPink
+                                  : _mfpController.text.isNotEmpty
+                                      ? CoconutColors.white
+                                      : CoconutColors.gray700,
+                              BlendMode.srcIn),
+                        ),
+                      )),
+                  CoconutLayout.spacing_500h,
+                  Row(
+                    children: [
+                      Expanded(
+                        flex: 4,
+                        child: CoconutButton(
+                          onPressed: () {
+                            widget.onSkip();
+                            Navigator.pop(context);
+                          },
+                          textStyle: CoconutTypography.body2_14,
+                          disabledBackgroundColor: CoconutColors.gray800,
+                          disabledForegroundColor: CoconutColors.gray700,
+                          isActive: true,
+                          backgroundColor: CoconutColors.gray350,
+                          foregroundColor: CoconutColors.black,
+                          pressedTextColor: CoconutColors.black,
+                          text: t.wallet_add_input_screen.mfp_skip,
+                        ),
+                      ),
+                      CoconutLayout.spacing_200w,
+                      Expanded(
+                        flex: 6,
+                        child: CoconutButton(
+                          onPressed: () {
+                            widget.onComplete(_mfpController.text);
+                            Navigator.pop(context);
+                          },
+                          disabledBackgroundColor: CoconutColors.gray800,
+                          disabledForegroundColor: CoconutColors.gray700,
+                          isActive: _isButtonEnabled,
+                          backgroundColor: CoconutColors.white,
+                          foregroundColor: CoconutColors.black,
+                          pressedTextColor: CoconutColors.black,
+                          text: t.complete,
+                        ),
+                      ),
+                    ],
+                  ),
+                  CoconutLayout.spacing_600h,
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
+++ b/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
@@ -120,10 +120,22 @@ class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSh
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  Text(t.wallet_add_input_screen.mfp_description_texts[0],
-                                      style: CoconutTypography.body3_12),
-                                  Text(t.wallet_add_input_screen.mfp_description_texts[1],
-                                      style: CoconutTypography.body3_12),
+                                  RichText(
+                                    text: TextSpan(
+                                      text: t.wallet_add_input_screen.mfp_description_texts[0],
+                                      style: CoconutTypography.body3_12,
+                                      children: [
+                                        TextSpan(
+                                            text:
+                                                "\n${t.wallet_add_input_screen.mfp_description_texts[1]}",
+                                            style: CoconutTypography.body3_12),
+                                        TextSpan(
+                                            text:
+                                                " ${t.wallet_add_input_screen.mfp_description_texts[2]}",
+                                            style: CoconutTypography.body3_12_Bold)
+                                      ],
+                                    ),
+                                  ),
                                 ],
                               )),
                         ],

--- a/lib/services/wallet_add_service.dart
+++ b/lib/services/wallet_add_service.dart
@@ -16,9 +16,10 @@ class WalletAddService {
     return createWalletFromUR(ur: ur, name: name, walletImportSource: WalletImportSource.keystone);
   }
 
-  WatchOnlyWallet createExtendedPublicKeyWallet(String extendedPublicKey, String name) {
-    final singleSigWallet =
-        SingleSignatureWallet.fromExtendedPublicKey(AddressType.p2wpkh, extendedPublicKey, '-');
+  WatchOnlyWallet createExtendedPublicKeyWallet(
+      String extendedPublicKey, String name, String? masterFingerPrint) {
+    final singleSigWallet = SingleSignatureWallet.fromExtendedPublicKey(
+        AddressType.p2wpkh, extendedPublicKey, masterFingerPrint ?? '-');
     return WatchOnlyWallet(name, 0, 0, singleSigWallet.descriptor, null, null,
         WalletImportSource.extendedPublicKey.name);
   }


### PR DESCRIPTION
### 변경사항
 - 확장공개키를 통한 지갑추가시 mfp를 추가로 입력받도록 처리
 - 지갑추가 로딩중에 텍스트 입력 막도록 수정
(lib/screens/home/wallet_add_input_screen.dart)
 - 마스터 핑크프린트 입력 바텀시트 추가
(lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart)

### 테스트 방법
1. 지갑추가 - 직접 입력 - 디스크립터/확장공개키 입력

### 테스트 시나리오
TC1: 디스크립터 입력후 완료 버튼 클릭, 지갑 추가 
TC2: 확장공개키 입력후 완료 버튼 클릭, MFP 바텀시트가 나온다. 
    - 건너뛰기 클릭시 지갑이 추가된다(지갑정보 확인시 MFP '-')
    - MFP 입력후 완료 버튼 클릭시 지갑이 추가된다(지갑정보 MFP 확인)

#209 #213 