### PR TITLE
[UI] 태그 색상(gray), '잔돈'툴팁, 숏컷 케밥 아이콘

### DIFF
--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -260,6 +260,7 @@ wallet_list_add_guide_card:
 wallet_list_glossary_shortcut_card:
   any_word_you_dont_know: "모르는 용어가 있으신가요?"
   top_right: "오른쪽 위 "
+  kebab_button: "⋮ 버튼"
   click_to_jump: " - 용어집 또는 여기를 눌러 바로가기"
 
 # lib/widgets/overlays
@@ -366,7 +367,7 @@ tooltip:
     select_wallet: "$name 선택, "
     scan_qr_below: "로 이동하여 아래 QR 코드를 스캔해 주세요."
   address_receiving: "비트코인을 받을 때 사용하는 주소예요. 영어로 Receiving 또는 External이라고 해요."
-  address_change: "다른 사람에게 비트코인을 보내고 남은 비트코인을 거슬러 받는 주소예요. 영어로 Change라고 해요."
+  address_change: "비트코인을 보내고 남으면 거슬러받는 주소예요. 영어로 Change라고 해요."
   utxo: "UTXO란 Unspent Tx Output을 줄인 말로 아직 쓰이지 않은 잔액이란 뜻이에요. 비트코인에는 잔액 개념이 없어요. 지갑에 표시되는 잔액은 UTXO의 총합이라는 것을 알아두세요."
   faucet: "테스트용 비트코인으로 마음껏 테스트 해보세요"
   multisig_wallet: "$total개의 키 중 $count개로 서명해야 하는\n다중 서명 지갑이에요."

--- a/lib/screens/common/tag_bottom_sheet.dart
+++ b/lib/screens/common/tag_bottom_sheet.dart
@@ -190,16 +190,20 @@ class _TagBottomSheetState extends State<TagBottomSheet> {
                   _utxoTags.length,
                   (index) {
                     bool isSelected = _prevSelectedUtxoTagNames.contains(_utxoTags[index].name);
+                    Color foregroundColor = _utxoTags[index].colorIndex != 8
+                        ? CoconutColors.colorPalette[_utxoTags[index].colorIndex]
+                        : CoconutColors
+                            .gray400; // colorIndex == 8(gray)일 때 화면상으로 잘 보이지 않기 때문에 gray400으로 설정
                     return IntrinsicWidth(
                       child: CoconutChip(
                         minWidth: 40,
                         color:
                             CoconutColors.backgroundColorPaletteDark[_utxoTags[index].colorIndex],
                         hasOpacity: true,
-                        borderColor: CoconutColors.colorPalette[_utxoTags[index].colorIndex],
+                        borderColor: foregroundColor,
                         label: '#${_utxoTags[index].name}',
                         labelSize: 12,
-                        labelColor: CoconutColors.colorPalette[_utxoTags[index].colorIndex],
+                        labelColor: foregroundColor,
                         isSelected: isSelected,
                         onTap: () {
                           final tag = _utxoTags[index].name;

--- a/lib/screens/common/tag_bottom_sheet.dart
+++ b/lib/screens/common/tag_bottom_sheet.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/utxo/utxo_tag.dart';
+import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/widgets/button/custom_tag_chip_color_button.dart';
 import 'package:coconut_wallet/widgets/button/custom_underlined_button.dart';
 import 'package:coconut_wallet/widgets/overlays/custom_toast.dart';
@@ -190,10 +191,8 @@ class _TagBottomSheetState extends State<TagBottomSheet> {
                   _utxoTags.length,
                   (index) {
                     bool isSelected = _prevSelectedUtxoTagNames.contains(_utxoTags[index].name);
-                    Color foregroundColor = _utxoTags[index].colorIndex != 8
-                        ? CoconutColors.colorPalette[_utxoTags[index].colorIndex]
-                        : CoconutColors
-                            .gray400; // colorIndex == 8(gray)일 때 화면상으로 잘 보이지 않기 때문에 gray400으로 설정
+                    Color foregroundColor = tagColorPalette[_utxoTags[index]
+                          .colorIndex]; // colorIndex == 8(gray)일 때 화면상으로 잘 보이지 않기 때문에 gray400으로 설정
                     return IntrinsicWidth(
                       child: CoconutChip(
                         minWidth: 40,

--- a/lib/screens/wallet_detail/utxo_detail_screen.dart
+++ b/lib/screens/wallet_detail/utxo_detail_screen.dart
@@ -427,17 +427,23 @@ class _UtxoDetailScreenState extends State<UtxoDetailScreen> {
                   runSpacing: 4,
                   children: List.generate(
                     selectedTags.length,
-                    (index) => IntrinsicWidth(
-                      child: CoconutChip(
-                        minWidth: 40,
-                        color: CoconutColors
-                            .backgroundColorPaletteDark[selectedTags[index].colorIndex],
-                        borderColor: CoconutColors.colorPalette[selectedTags[index].colorIndex],
-                        label: '#${selectedTags[index].name}',
-                        labelSize: 12,
-                        labelColor: CoconutColors.colorPalette[selectedTags[index].colorIndex],
-                      ),
-                    ),
+                    (index) {
+                      Color foregroundColor = selectedTags[index].colorIndex != 8
+                          ? CoconutColors.colorPalette[selectedTags[index].colorIndex]
+                          : CoconutColors
+                              .gray400; // colorIndex == 8(gray)일 때 화면상으로 잘 보이지 않기 때문에 gray400으로 설정
+                      return IntrinsicWidth(
+                        child: CoconutChip(
+                          minWidth: 40,
+                          color: CoconutColors
+                              .backgroundColorPaletteDark[selectedTags[index].colorIndex],
+                          borderColor: foregroundColor,
+                          label: '#${selectedTags[index].name}',
+                          labelSize: 12,
+                          labelColor: foregroundColor,
+                        ),
+                      );
+                    },
                   ),
                 ),
               },

--- a/lib/screens/wallet_detail/utxo_detail_screen.dart
+++ b/lib/screens/wallet_detail/utxo_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:coconut_wallet/providers/transaction_provider.dart';
 import 'package:coconut_wallet/providers/utxo_tag_provider.dart';
 import 'package:coconut_wallet/providers/view_model/wallet_detail/utxo_detail_view_model.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
+import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/widgets/bubble_clipper.dart';
 import 'package:coconut_wallet/widgets/button/copy_text_container.dart';
 import 'package:coconut_wallet/widgets/card/transaction_input_output_card.dart';
@@ -428,10 +429,8 @@ class _UtxoDetailScreenState extends State<UtxoDetailScreen> {
                   children: List.generate(
                     selectedTags.length,
                     (index) {
-                      Color foregroundColor = selectedTags[index].colorIndex != 8
-                          ? CoconutColors.colorPalette[selectedTags[index].colorIndex]
-                          : CoconutColors
-                              .gray400; // colorIndex == 8(gray)일 때 화면상으로 잘 보이지 않기 때문에 gray400으로 설정
+                      Color foregroundColor = tagColorPalette[selectedTags[index]
+                          .colorIndex]; // colorIndex == 8(gray)일 때 화면상으로 잘 보이지 않기 때문에 gray400으로 설정
                       return IntrinsicWidth(
                         child: CoconutChip(
                           minWidth: 40,

--- a/lib/utils/colors_util.dart
+++ b/lib/utils/colors_util.dart
@@ -69,6 +69,19 @@ final List<Color> backgroundColorPalette = [
   CoconutColors.mint.withOpacity(0.18),
 ];
 
+const List<Color> tagColorPalette = [
+  CoconutColors.purple,
+  CoconutColors.tangerine,
+  CoconutColors.yellow,
+  CoconutColors.green,
+  CoconutColors.sky,
+  CoconutColors.pink,
+  CoconutColors.red,
+  CoconutColors.orange,
+  CoconutColors.gray400,
+  CoconutColors.mint,
+];
+
 class ColorUtil {
   static ColorSet getColor(int index) {
     if (index < 0 || index >= colorPalette.length) {

--- a/lib/widgets/card/selectable_utxo_item_card.dart
+++ b/lib/widgets/card/selectable_utxo_item_card.dart
@@ -4,6 +4,7 @@ import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/utxo/utxo_tag.dart';
 import 'package:coconut_wallet/styles.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
+import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/utils/datetime_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
@@ -125,19 +126,21 @@ class _UtxoSelectableCardState extends State<SelectableUtxoItemCard> {
                         runSpacing: 4,
                         children: List.generate(
                           widget.utxoTags?.length ?? 0,
-                          (index) => IntrinsicWidth(
-                            child: CoconutChip(
-                              minWidth: 40,
-                              color: CoconutColors.backgroundColorPaletteDark[
-                                  widget.utxoTags?[index].colorIndex ?? 0],
-                              borderColor: CoconutColors
-                                  .colorPalette[widget.utxoTags?[index].colorIndex ?? 0],
-                              label: '#${widget.utxoTags?[index].name ?? ''}',
-                              labelSize: 12,
-                              labelColor: CoconutColors
-                                  .colorPalette[widget.utxoTags?[index].colorIndex ?? 0],
-                            ),
-                          ),
+                          (index) {
+                            Color foregroundColor =
+                                tagColorPalette[widget.utxoTags?[index].colorIndex ?? 0];
+                            return IntrinsicWidth(
+                              child: CoconutChip(
+                                minWidth: 40,
+                                color: CoconutColors.backgroundColorPaletteDark[
+                                    widget.utxoTags?[index].colorIndex ?? 0],
+                                borderColor: foregroundColor,
+                                label: '#${widget.utxoTags?[index].name ?? ''}',
+                                labelSize: 12,
+                                labelColor: foregroundColor,
+                              ),
+                            );
+                          },
                         ),
                       ),
                     ),

--- a/lib/widgets/card/utxo_item_card.dart
+++ b/lib/widgets/card/utxo_item_card.dart
@@ -90,18 +90,22 @@ class UtxoItemCard extends StatelessWidget {
                     runSpacing: 4,
                     children: List.generate(
                       utxo.tags?.length ?? 0,
-                      (index) => IntrinsicWidth(
-                        child: CoconutChip(
-                          minWidth: 40,
-                          color: CoconutColors
-                              .backgroundColorPaletteDark[utxo.tags?[index].colorIndex ?? 0],
-                          borderColor:
-                              CoconutColors.colorPalette[utxo.tags?[index].colorIndex ?? 0],
-                          label: '#${utxo.tags?[index].name ?? ''}',
-                          labelSize: 12,
-                          labelColor: CoconutColors.colorPalette[utxo.tags?[index].colorIndex ?? 0],
-                        ),
-                      ),
+                      (index) {
+                        Color foregroundColor = utxo.tags?[index].colorIndex != 8
+                            ? CoconutColors.colorPalette[utxo.tags?[index].colorIndex ?? 0]
+                            : CoconutColors.gray400;
+                        return IntrinsicWidth(
+                          child: CoconutChip(
+                            minWidth: 40,
+                            color: CoconutColors
+                                .backgroundColorPaletteDark[utxo.tags?[index].colorIndex ?? 0],
+                            borderColor: foregroundColor,
+                            label: '#${utxo.tags?[index].name ?? ''}',
+                            labelSize: 12,
+                            labelColor: foregroundColor,
+                          ),
+                        );
+                      },
                     ),
                   ),
                 ],

--- a/lib/widgets/card/utxo_item_card.dart
+++ b/lib/widgets/card/utxo_item_card.dart
@@ -2,6 +2,7 @@ import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
+import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/utils/datetime_util.dart';
 import 'package:coconut_wallet/widgets/button/shrink_animation_button.dart';
 import 'package:flutter/material.dart';
@@ -91,9 +92,7 @@ class UtxoItemCard extends StatelessWidget {
                     children: List.generate(
                       utxo.tags?.length ?? 0,
                       (index) {
-                        Color foregroundColor = utxo.tags?[index].colorIndex != 8
-                            ? CoconutColors.colorPalette[utxo.tags?[index].colorIndex ?? 0]
-                            : CoconutColors.gray400;
+                        Color foregroundColor = tagColorPalette[utxo.tags?[index].colorIndex ?? 0];
                         return IntrinsicWidth(
                           child: CoconutChip(
                             minWidth: 40,

--- a/lib/widgets/card/wallet_list_glossary_shortcut_card.dart
+++ b/lib/widgets/card/wallet_list_glossary_shortcut_card.dart
@@ -91,9 +91,9 @@ class _GlossaryShortcutCardState extends State<GlossaryShortcutCard>
                                         CoconutTypography.body2_14.setColor(CoconutColors.gray400),
                                   ),
                                   TextSpan(
-                                    text: '•••',
-                                    style: CoconutTypography.body2_14.copyWith(
-                                        letterSpacing: -2.0, color: CoconutColors.gray400),
+                                    text: t.wallet_list_glossary_shortcut_card.kebab_button,
+                                    style: CoconutTypography.body2_14
+                                        .copyWith(color: CoconutColors.gray400),
                                   ),
                                   TextSpan(
                                     text: t.wallet_list_glossary_shortcut_card.click_to_jump,


### PR DESCRIPTION
### 변경사항
- 태그 colorIndex가 gray일때 화면에 표시되는 borderColor,textColor 수정(gray600 -> gray400)
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/3660545a-8c5c-4f8f-b177-bf9b8a40b7af" width="300"/></td>
    <td><img src="https://github.com/user-attachments/assets/5bc976f0-d0cc-4cb4-a454-8f79e4e63bdb" width="300"/></td>
    <td><img src="https://github.com/user-attachments/assets/0aed2519-c5f5-4396-b868-d888b9ec33ae" width="300"/></td>
<td><img src="https://github.com/user-attachments/assets/8cd6e2dd-1bae-4b20-a66e-26fea8eebaf7" width="300"/></td>
  </tr>
</table>
<br>
- 잔돈 툴팁 문구 변경
<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/59afc0fb-31d6-4c8a-9717-a0a8a76d6c80" width="300"/></td>
  </tr>
</table>
<br>
- 숏컷 문구 미트볼 -> 케밥 아이콘으로 변경
<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/d720efe6-0c31-4fb9-8414-a925a9c8f59a" width="300"/></td>
  </tr>
</table>
