### PR TITLE
[219] 지갑추가 - 직접 입력 에러메시지 불일치

### DIFF
--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -54,8 +54,7 @@ class WalletAddInputViewModel extends ChangeNotifier {
   }
 
   void _validateXpubPrefixSupport(String xpub) {
-    final allowedPrefixes =
-        NetworkType.currentNetworkType.isTestnet ? ["vpub", "tpub"] : ["xpub", "zpub"];
+    final allowedPrefixes = ["vpub", "tpub", "xpub", "zpub"];
     final prefix = xpub.substring(0, 4).toLowerCase();
 
     if (!allowedPrefixes.contains(prefix)) {

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_add_input_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
@@ -246,6 +247,26 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                                       ]
                                     ],
                                   )),
+
+                              /// 테스트 후 삭제
+                              GestureDetector(
+                                onTap: () {
+                                  var newNetworkType =
+                                      NetworkType.currentNetworkType == NetworkType.mainnet
+                                          ? NetworkType.regtest
+                                          : NetworkType.mainnet;
+                                  NetworkType.setNetworkType(newNetworkType);
+                                  _handleInput(context);
+                                },
+                                child: Container(
+                                    color: Colors.green,
+                                    width: 100,
+                                    height: 100,
+                                    child: Text(
+                                        NetworkType.currentNetworkType == NetworkType.mainnet
+                                            ? "현재 메인넷"
+                                            : "현재 테스트넷")),
+                              ),
                             ],
                           ),
                         ),

--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -35,13 +35,11 @@ class DescriptorUtil {
 
     //final fingerprint = match.group(1)!;
     final purposeWithHardenedMark = match.group(2)!;
-    final purpose = purposeWithHardenedMark.replaceAll("'", ""); // 숫자만 추출
-
-    return purpose;
+    return purposeWithHardenedMark;
   }
 
   static void validatePurpose(String purpose) {
-    if (purpose != '84') {
+    if (purpose != "84'") {
       throw FormatException("purpose $purpose is not supported");
     }
   }
@@ -67,13 +65,13 @@ class DescriptorUtil {
 
   static void validateNativeSegwitDescriptor(String descriptor) {
     final regexWpkhFormatWithoutChecksum = RegExp(
-      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](vpub|ypub|zpub|xpub|tpub)[1-9A-HJ-NP-Za-km-z]{107}\)$",
+      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107}\)$",
     );
     final regexWpkhFormatWithChecksumPath = RegExp(
-      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](vpub|ypub|zpub|xpub|tpub)[1-9A-HJ-NP-Za-km-z]{107}/<\d+;\d+>\/\*\)$",
+      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107}/<\d+;\d+>\/\*\)$",
     );
     final regexWpkhFormatWithChecksum = RegExp(
-      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](vpub|ypub|zpub|xpub|tpub)[1-9A-HJ-NP-Za-km-z]{107}/<\d+;\d+>\/\*\)#([A-Za-z0-9]{8})$",
+      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107}/<\d+;\d+>\/\*\)#([A-Za-z0-9]{8})$",
     );
 
     if (!(regexWpkhFormatWithoutChecksum.hasMatch(descriptor) ||

--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -65,18 +65,19 @@ class DescriptorUtil {
 
   static void validateNativeSegwitDescriptor(String descriptor) {
     final regexWpkhFormatWithoutChecksum = RegExp(
-      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107}\)$",
+      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107,108}\)$",
     );
     final regexWpkhFormatWithChecksumPath = RegExp(
-      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107}/<\d+;\d+>\/\*\)$",
+      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107,108}/<\d+;\d+>\/\*\)$",
     );
     final regexWpkhFormatWithChecksum = RegExp(
-      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107}/<\d+;\d+>\/\*\)#([A-Za-z0-9]{8})$",
+      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107,108}/<\d+;\d+>\/\*\)#([A-Za-z0-9]{8})$",
     );
 
     if (!(regexWpkhFormatWithoutChecksum.hasMatch(descriptor) ||
         regexWpkhFormatWithChecksumPath.hasMatch(descriptor) ||
         regexWpkhFormatWithChecksum.hasMatch(descriptor))) {
+      Logger.log("Invalid format error: $descriptor");
       throw Exception("Invalid format error");
     }
   }

--- a/test/utils/descriptor_util_test.dart
+++ b/test/utils/descriptor_util_test.dart
@@ -316,6 +316,14 @@ void main() {
         // 메인넷
         var descriptor4 =
             "wpkh([33a0cbfd/49'/1'/0']xpub6CorSC5E8wkNboiq84Ndxvm3w4ccSA4MbEva8khZ4a5Cxk8hQYwrsJoPsmL8KsmCeFWzD4irCJdEqcd7kKRi5SAg355pTxTgHW2eVzQu2dd/<0;1>/*)";
+        var descriptor5 =
+            "wpkh([d34db33f/84'/0'/0']zpub6r3x6MdKZ7NpMoPoBJbCVLSvT5zsw2Ne1fBHQ46cT4rKHLR3EBNnNBW8EbnAxTFEJqGKyJ9BeLfnzZcr8NVEXLEgfR1RCypJdzKiSTeKq3k/<0;1>/*)";
+        var descriptor6 =
+            "wpkh([abcdef12/84'/0'/0']zpub6qij8vBzCwAfGpXYiEPYQq1q3K4xZWWC2FwLeEf4Cj5AxhKhT4AHgQkK7Bd98AL14VbUHEzHa2e8Vbg3nTZDX7pFWrgoEqdE4wYiyNC9EpQ/<0;1>/*)";
+        var descriptor7 =
+            "wpkh([12345678/84'/0'/0']xpub6C7Hd6RGti63xR4C6ZfThPB7R8ogQK98j34tf7aWddxY8zA1QXZX5pGgEZHGDWtz7A67MyTof3kY9A1EjD5fSEeL6B7Q8Ko3A8xRy7S12RxE/<0;1>/*)";
+        var descriptor8 =
+            "wpkh([12345678/84'/0'/0']zpub6r3x6MdKZ7NpMoPoBJbCVLSvT5zsw2Ne1fBHQ46cT4rKHLR3EBNnNBW8EbnAxTFEJqGKyJ9BeLfnzZcr8NVEXLEgfR1RCypJdzKiSTeKq3k/<0;1>/*)";
 
         // 성공: 1~3, 실패: 4(purpose 49)
         NetworkType.setNetworkType(NetworkType.regtest);
@@ -324,6 +332,16 @@ void main() {
         expect(DescriptorUtil.normalizeDescriptor(descriptor3), isNotEmpty);
         expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor4),
             t.wallet_add_input_screen.unsupported_wallet_error_text);
+
+        // 실패: 5~8(메인넷 지갑)
+        expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor5),
+            t.wallet_add_input_screen.testnet_wallet_error_text);
+        expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor6),
+            t.wallet_add_input_screen.testnet_wallet_error_text);
+        expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor7),
+            t.wallet_add_input_screen.testnet_wallet_error_text);
+        expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor8),
+            t.wallet_add_input_screen.testnet_wallet_error_text);
 
         // 실패: 1~3(테스트넷 지갑), 4(purpose 49)
         NetworkType.setNetworkType(NetworkType.mainnet);
@@ -335,6 +353,16 @@ void main() {
             t.wallet_add_input_screen.mainnet_wallet_error_text);
         expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor4),
             t.wallet_add_input_screen.unsupported_wallet_error_text);
+
+        // 실패: 5~8
+        expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor5),
+            t.wallet_add_input_screen.format_error_text);
+        expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor6),
+            t.wallet_add_input_screen.format_error_text);
+        expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor7),
+            t.wallet_add_input_screen.format_error_text);
+        expectErrorMessage(() => DescriptorUtil.normalizeDescriptor(descriptor8),
+            t.wallet_add_input_screen.format_error_text);
       });
     });
 
@@ -476,6 +504,7 @@ void expectErrorMessage(VoidCallback func, String errorText) {
   } catch (e) {
     isCaught = true;
     expect(getErrorMessageByError(e), errorText);
+    print(e);
   }
   expect(isCaught, true);
 }

--- a/test/utils/descriptor_util_test.dart
+++ b/test/utils/descriptor_util_test.dart
@@ -47,7 +47,7 @@ void main() {
       test('올바른 디스크립터에서 purpose를 추출', () {
         const descriptor =
             "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0";
-        expect(DescriptorUtil.extractPurpose(descriptor), '84');
+        expect(DescriptorUtil.extractPurpose(descriptor), "84'");
       });
 
       test('purpose가 없는 디스크립터는 예외 발생', () {
@@ -64,11 +64,11 @@ void main() {
 
     group('validatePurpose', () {
       test('올바른 purpose는 예외를 발생시키지 않음', () {
-        expect(() => DescriptorUtil.validatePurpose('84'), returnsNormally);
+        expect(() => DescriptorUtil.validatePurpose("84'"), returnsNormally);
       });
 
       test('잘못된 purpose는 예외 발생', () {
-        expect(() => DescriptorUtil.validatePurpose('44'), throwsException);
+        expect(() => DescriptorUtil.validatePurpose("44'"), throwsException);
       });
     });
 


### PR DESCRIPTION
### 변경사항
fix(wallet_add_input_view_model): 네트워크에 따른 주소가 틀린 경우, 지갑 에러메시지를 표시하도록 수정
feat(descriptor_util_test): 네트워크에 따른 주소에 대한 테스트에서 에러메시지를 검증하도록 수정

### 테스트 방법
1. 명령어를 통한 유닛테스트 코드 실행
flutter test test/utils/descriptor_util_test.dart

2. 지갑추가 - 직접 입력 페이지에서 직접 테스트

### 테스트 시나리오
 - 테스트 코드: NetworkType에 따른 주소가 맞는지 검증 부분 참고 

#219 