### PR TITLE
[218] 지갑 추가 - 다른 네트워크의 QR 스캔 시 에러메시지 개선

### DIFF
--- a/lib/screens/home/wallet_add_scanner_screen.dart
+++ b/lib/screens/home/wallet_add_scanner_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_add_scanner_view_model.dart';
@@ -222,9 +223,15 @@ class _WalletAddScannerScreenState extends State<WalletAddScannerScreen> {
     } catch (e) {
       vibrateLightDouble();
       if (mounted) {
+        String errorMessage = t.wallet_add_input_screen.format_error_text;
+        if (e.toString().contains("network type")) {
+          errorMessage = NetworkType.currentNetworkType == NetworkType.mainnet
+              ? t.wallet_add_input_screen.mainnet_wallet_error_text
+              : t.wallet_add_input_screen.testnet_wallet_error_text;
+        }
         _showErrorDialog(
           t.alert.wallet_add.add_failed,
-          e.toString(),
+          errorMessage,
         );
       }
       // TODO: remove rethrow; after test


### PR DESCRIPTION
### 변경사항
feat(wallet_add_scanner_screen): qr 지갑추가 실패시 에러메시지 처리(기본 문구, 네트워크가 다른 경우)

### 테스트 방법
1. 지갑추가 - 키스톤 - QR 코드 스캔하여 테스트

### 테스트 시나리오
1. 비트코인 네트워크를 지원하지 않는 월렛 추가(메타마스크) - '확인할 수 없는 형식이에요' 문구 확인
2. 메인넷 지갑 추가(넌척) - '테스트넷 지갑이 아니에요' 문구 확인
3. 테스트넷 지갑 추가(스패로우) - 정상 추가 확인

<img src="https://github.com/user-attachments/assets/b856ecff-4879-44e8-8027-accc867a3280" width="300px" />

https://github.com/user-attachments/assets/364b6ada-fbde-4a25-a70c-2c1a38e8ad47  

https://github.com/user-attachments/assets/de7dbcd8-1e6f-4149-8cb1-c8f63546b772

#218 
