### PR TITLE
fix(replaced-tx): 대체된 트랜잭션 판단 기준에 FeeRate 비교 로직 추가

### DIFF
--- a/lib/providers/node_provider/transaction/transaction_sync_service.dart
+++ b/lib/providers/node_provider/transaction/transaction_sync_service.dart
@@ -116,7 +116,8 @@ class TransactionSyncService {
     );
 
     // 7. 대체된 언컨펌 트랜잭션 삭제
-    await _cleanupStaleUnconfirmedTransactions(walletId);
+    await _cleanupStaleUnconfirmedTransactions(
+        walletId, fetchedTransactionDetails.fetchedTransactions);
 
     // 8. 마무리 단계
     _finalizeTransactionFetch(walletId, newTxHashes, inBatchProcess);
@@ -262,18 +263,44 @@ class TransactionSyncService {
   }
 
   /// 7. 대체된 언컨펌 트랜잭션 삭제
-  Future<void> _cleanupStaleUnconfirmedTransactions(
-    int walletId,
-  ) async {
+  Future<void> _cleanupStaleUnconfirmedTransactions(int walletId, List<Transaction> newTxs) async {
     final unconfirmedTxs = _transactionRepository.getUnconfirmedTransactionRecordList(walletId);
     final toDeleteTxs = <String>[];
 
-    for (final tx in unconfirmedTxs) {
+    for (final localUnconfirmedTxRecord in unconfirmedTxs) {
+      Transaction? unconfirmedTx;
       try {
-        await _electrumService.getTransaction(tx.transactionHash, verbose: true);
+        unconfirmedTx = Transaction.parse(
+            await _electrumService.getTransaction(localUnconfirmedTxRecord.transactionHash));
       } catch (e) {
-        Logger.log('Transaction ${tx.transactionHash} not found, marking for deletion.');
-        toDeleteTxs.add(tx.transactionHash);
+        Logger.log(
+            'Transaction ${localUnconfirmedTxRecord.transactionHash} not found, marking for deletion.');
+        toDeleteTxs.add(localUnconfirmedTxRecord.transactionHash);
+        continue;
+      }
+
+      // 언컨펌 트랜잭션의 모든 인풋을 수집
+      final unconfirmedInputs =
+          unconfirmedTx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
+
+      // 새로운 트랜잭션들을 순회하면서 인풋이 겹치는 것이 있는지 확인
+      for (final newTx in newTxs) {
+        // 새 트랜잭션의 인풋 수집
+        final newTxInputs =
+            newTx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
+
+        // 인풋이 겹치는 것이 있는지 확인 (교집합이 있는지)
+        final overlappingInputs = unconfirmedInputs.intersection(newTxInputs);
+
+        // 겹치는 인풋이 있다면 로컬의 언컨펌 트랜잭션은 대체된 것으로 간주
+        if (overlappingInputs.isNotEmpty) {
+          if (unconfirmedTx.transactionHash != newTx.transactionHash) {
+            toDeleteTxs.add(localUnconfirmedTxRecord.transactionHash);
+            Logger.log(
+                '[$walletId] Transaction ${localUnconfirmedTxRecord.transactionHash} is replaced by ${newTx.transactionHash}');
+          }
+          break; // 대체된 것으로 확인되면 다른 새 트랜잭션과 비교 불필요
+        }
       }
     }
 

--- a/test/providers/node_provider/transaction_sync_service_test.dart
+++ b/test/providers/node_provider/transaction_sync_service_test.dart
@@ -251,7 +251,7 @@ void main() {
 
       // 검증
       verify(electrumService.getHistory(any, testAddress)).called(1);
-      verify(electrumService.getTransaction(mockTx.transactionHash)).called(1);
+      verify(electrumService.getTransaction(mockTx.transactionHash)).called(2);
     });
 
     test('확인된 트랜잭션 처리를 올바르게 하는지 확인', () async {


### PR DESCRIPTION
### 변경사항

- 멤풀에 트랜잭션이 대체되었는지 확인하는 방법 변경
  - 기존: electrum api 에서 verbose 옵션으로 상세 정보를 조회할 수 있으면 멤풀에 존재하는 트랜잭션으로 간주
  - 개선: 트랜잭션의 인풋이 겹치는지, 수수료율이 증가했는지 확인


### 테스트 방법

- RBF 시도 후 Utxo 목록, Tx 내역이 정상적으로 존재하는지 확인

### 이슈

- #243