### PR TITLE
fix(btn-disabled): MFP가 지정되지 않은 지갑은 fee bumping 화면으로 이동할 수 없음

### DIFF
--- a/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
@@ -1,6 +1,7 @@
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/enums/network_enums.dart';
 import 'package:coconut_wallet/enums/transaction_enums.dart';
+import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
 import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/providers/connectivity_provider.dart';
 import 'package:coconut_wallet/providers/node_provider/node_provider.dart';
@@ -37,6 +38,9 @@ class TransactionDetailViewModel extends ChangeNotifier {
   TransactionStatus? _transactionStatus = TransactionStatus.receiving;
   bool _isSendType = false;
 
+  bool? _canBumpingTx;
+  bool get canBumpingTx => _canBumpingTx == true;
+
   TransactionDetailViewModel(
       this._walletId,
       this._txHash,
@@ -46,8 +50,19 @@ class TransactionDetailViewModel extends ChangeNotifier {
       this._addressRepository,
       this._connectivityProvider,
       this._sendInfoProvider) {
+    _setCanBumpingTx();
     _initTransactionList();
   }
+
+  void _setCanBumpingTx() {
+    final walletBaseItem = _walletProvider.getWalletById(_walletId);
+    bool isMultisigWallet = walletBaseItem is MultisigWalletListItem;
+    String? masterFingerprint = isMultisigWallet
+        ? null
+        : (walletBaseItem.walletBase as SingleSignatureWallet).keyStore.masterFingerprint;
+    _canBumpingTx = masterFingerprint != null && masterFingerprint != "00000000";
+  }
+
   BlockTimestamp? get currentBlock => _currentBlock;
 
   Utxo? get currentUtxo => _currentUtxo;

--- a/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
@@ -55,12 +55,15 @@ class TransactionDetailViewModel extends ChangeNotifier {
   }
 
   void _setCanBumpingTx() {
-    final walletBaseItem = _walletProvider.getWalletById(_walletId);
-    bool isMultisigWallet = walletBaseItem is MultisigWalletListItem;
-    String? masterFingerprint = isMultisigWallet
-        ? null
-        : (walletBaseItem.walletBase as SingleSignatureWallet).keyStore.masterFingerprint;
-    _canBumpingTx = masterFingerprint != null && masterFingerprint != "00000000";
+    final wallet = _walletProvider.getWalletById(_walletId);
+    if (wallet is MultisigWalletListItem) {
+      _canBumpingTx = true;
+      return;
+    }
+
+    final masterFingerprint =
+        (wallet.walletBase as SingleSignatureWallet).keyStore.masterFingerprint;
+    _canBumpingTx = masterFingerprint != "00000000";
   }
 
   BlockTimestamp? get currentBlock => _currentBlock;

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -511,6 +511,8 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
     if (_viewModel.transactionStatus == null || _viewModel.isSendType == null) {
       return Container();
     }
+    bool canBumpingTx = _viewModel.canBumpingTx;
+
     return Container(
       width: MediaQuery.sizeOf(context).width,
       decoration: BoxDecoration(
@@ -571,6 +573,9 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
                           context: context, text: ErrorCodes.networkError.message);
                       return;
                     }
+
+                    if (!canBumpingTx) return;
+
                     _viewModel.clearSendInfo();
                     Navigator.pushNamed(context, '/transaction-fee-bumping', arguments: {
                       'transaction': tx,
@@ -584,8 +589,9 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
                     padding: const EdgeInsets.all(8.0),
                     child: Text(
                       _viewModel.isSendType! ? t.quick_send : t.quick_receive,
-                      style: CoconutTypography.body2_14.setColor(
-                          _viewModel.isSendType! ? CoconutColors.primary : CoconutColors.cyan),
+                      style: CoconutTypography.body2_14.setColor(_viewModel.isSendType!
+                          ? CoconutColors.primary.withOpacity(canBumpingTx ? 1.0 : 0.5)
+                          : CoconutColors.cyan.withOpacity(canBumpingTx ? 1.0 : 0.5)),
                     ),
                   ),
                 ),

--- a/lib/screens/wallet_detail/wallet_detail_screen.dart
+++ b/lib/screens/wallet_detail/wallet_detail_screen.dart
@@ -386,7 +386,9 @@ class _WalletDetailScreenState extends State<WalletDetailScreen> {
     if (!_viewModel.isMultisigWallet &&
         _viewModel.masterFingerprint == WalletAddService.masterFingerprintPlaceholder) {
       CoconutToast.showToast(
-          context: context, text: t.wallet_detail_screen.toast.no_mfp_wallet_cant_send);
+          isVisibleIcon: true,
+          context: context,
+          text: t.wallet_detail_screen.toast.no_mfp_wallet_cant_send);
       return;
     }
     if (!_checkStateAndShowToast()) return;
@@ -442,7 +444,7 @@ class _WalletDetailScreenState extends State<WalletDetailScreen> {
             });
           },
           walletProvider: _viewModel.walletProvider!,
-          walletItem: _viewModel.walletListBaseItem!,
+          walletItem: _viewModel.walletListBaseItem,
         ));
   }
 }


### PR DESCRIPTION
### 변경사항

- MFP가 지정되지 않은 지갑은 fee bumping 화면으로 이동할 수 없도록 버튼 스타일에 opacity를 적용함.
   <img width="300" alt="스크린샷 2025-05-21 오전 10 32 44" src="https://github.com/user-attachments/assets/3769ee4c-27f7-48ba-952d-647a1c796020" />

  <img width="300" alt="스크린샷 2025-05-21 오전 10 33 23" src="https://github.com/user-attachments/assets/28373f76-3936-4e6a-a33d-e11349f9e077" />

- wallet_detail_screen에서 토스트를 띄워주기 때문에 위와 같이 조치함

   <img width="300" alt="스크린샷 2025-05-21 오전 10 34 47" src="https://github.com/user-attachments/assets/26c293df-459a-41ed-98fb-d57d77b90b6d" />

