### PR TITLE
fix(migration): _RealmUtxo isDeleted 추가

### DIFF
--- a/lib/repository/realm/migration/migration.dart
+++ b/lib/repository/realm/migration/migration.dart
@@ -32,9 +32,17 @@ void defaultMigration(Migration migration, int oldVersion) {
     Logger.log('oldVersion: $oldVersion');
     if (oldVersion < 2) resetExceptForWallet(migration.newRealm);
     if (oldVersion < 3) removeIsLatestTxBlockHeightZero(migration.newRealm);
+    if (oldVersion < 4) addIsDeletedToUtxo(migration.newRealm);
   } catch (e, stackTrace) {
-    Logger.log('Migration error: $e\n$stackTrace');
+    Logger.error('Migration error: $e\n$stackTrace');
     rethrow;
+  }
+}
+
+void addIsDeletedToUtxo(Realm realm) {
+  final oldUtxos = realm.all<RealmUtxo>();
+  for (var utxo in oldUtxos) {
+    utxo.isDeleted = false;
   }
 }
 


### PR DESCRIPTION
테스트 방법 
1. 앱 삭제 
2. $ flutter pub run build_runner clean && flutter pub run build_runner build --delete-conflicting-outputs && dart run realm generate
3. develop 브랜치에서 앱 설치 
4. 지갑 추가 
5. 브랜치를 fix/245-migration으로 변경
6. $ flutter pub run build_runner clean && flutter pub run build_runner build --delete-conflicting-outputs && dart run
7. 앱 실행

migration error 안나는지 확인