### PR TITLE
 [#248] 앱 이탈 - 복귀 - 트랜잭션 발생 시 지갑 구독해제/구독 함수 수차례 호출

### DIFF
--- a/lib/providers/node_provider/node_provider.dart
+++ b/lib/providers/node_provider/node_provider.dart
@@ -32,9 +32,7 @@ class NodeProvider extends ChangeNotifier {
   int get port => _port;
   bool get ssl => _ssl;
 
-  bool _needSubscribeWallets = false;
-
-  bool get needSubscribe => _needSubscribeWallets;
+  bool needSubscribeWallets = false;
 
   /// 정상적으로 연결된 후 다시 연결이 끊겼을 떄에만 이 함수가 동작하도록 설계되어 있음.
   /// 최초 [reconnect] 호출은 앱 실행 시 `_checkConnectivity` 에서 호출되어 state 처리 관련된 로직이 일부 비정상적으로 동작함.
@@ -96,7 +94,7 @@ class NodeProvider extends ChangeNotifier {
   Future<Result<bool>> subscribeWallets(
     List<WalletListItemBase> walletItems,
   ) async {
-    _needSubscribeWallets = false;
+    needSubscribeWallets = false;
     return _isolateManager.subscribeWallets(walletItems);
   }
 
@@ -140,7 +138,7 @@ class NodeProvider extends ChangeNotifier {
 
     try {
       SocketConnectionStatus socketConnectionStatus;
-      _needSubscribeWallets = true;
+      needSubscribeWallets = true;
       if (isInitialized && _isolateManager.isInitialized) {
         socketConnectionStatus = await _isolateManager.getSocketConnectionStatus();
         if (socketConnectionStatus != SocketConnectionStatus.terminated) {

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -129,7 +129,8 @@ class WalletProvider extends ChangeNotifier {
     }
 
     // 화면 이탈 후 재연결 시 재구독이 필요한 상황
-    if (_nodeProvider.needSubscribe) {
+    if (_nodeProvider.needSubscribeWallets) {
+      _nodeProvider.needSubscribeWallets = false;
       _subscribeNodeProvider();
     }
 

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -130,7 +130,6 @@ class WalletProvider extends ChangeNotifier {
 
     // 화면 이탈 후 재연결 시 재구독이 필요한 상황
     if (_nodeProvider.needSubscribeWallets) {
-      _nodeProvider.needSubscribeWallets = false;
       _subscribeNodeProvider();
     }
 
@@ -223,6 +222,8 @@ class WalletProvider extends ChangeNotifier {
   }
 
   Future<WalletSubscriptionState?> _subscribeNodeProvider() async {
+    _nodeProvider.needSubscribeWallets = false;
+
     if (!_canSubscribeWallets()) {
       return null;
     }


### PR DESCRIPTION
### 변경사항

- 화면 이탈 후 NodeProvider 이벤트 리스너에 의해 재구독을 시도하지 않도록 수정

### 테스트 방법

- 화면 이탈 ➡️ 다시 복귀 ➡️ 이벤트 발생시키기 (트랜잭션 보내기/받기 모두 상관 없음)

### 이슈

- #248 