### PR TITLE
[258] 스피드앱 라이트닝 인보이스 생성

### DIFF
--- a/lib/services/speed_app_ln_invoice_service.dart
+++ b/lib/services/speed_app_ln_invoice_service.dart
@@ -4,19 +4,25 @@ import 'package:dio/dio.dart';
 class SpeedAppLnInvoiceService {
   final _dio = Dio();
 
-  Future<dynamic> getLnInvoiceOfPow(int amount) async {
+  Future<String> getLnInvoiceOfPow(int amount) async {
     try {
       final speedAppResponse = await _dio.get('https://speed.app/.well-known/lnurlp/powbitcoiner');
+      if (speedAppResponse.data['callback'] == null) {
+        throw Exception("callback is null");
+      }
+
       final lnInvoiceResponse =
           await _dio.get("${speedAppResponse.data['callback']}?amount=$amount");
       if (lnInvoiceResponse.data['status'] == "ERROR") {
-        throw Exception(lnInvoiceResponse.data['reason']);
+        throw Exception(lnInvoiceResponse.data['reason'] ?? "status is ERROR");
+      } else if (lnInvoiceResponse.data['pr'] == null) {
+        throw Exception("pr is null");
       }
 
       return lnInvoiceResponse.data['pr'];
     } catch (e) {
       Logger.log("[ERROR] : $e");
-      throw Exception(e);
+      rethrow;
     }
   }
 }

--- a/lib/services/speed_app_ln_invoice_service.dart
+++ b/lib/services/speed_app_ln_invoice_service.dart
@@ -1,0 +1,22 @@
+import 'package:coconut_wallet/utils/logger.dart';
+import 'package:dio/dio.dart';
+
+class SpeedAppLnInvoiceService {
+  final _dio = Dio();
+
+  Future<dynamic> getLnInvoiceOfPow(int amount) async {
+    try {
+      final speedAppResponse = await _dio.get('https://speed.app/.well-known/lnurlp/powbitcoiner');
+      final lnInvoiceResponse =
+          await _dio.get("${speedAppResponse.data['callback']}?amount=$amount");
+      if (lnInvoiceResponse.data['status'] == "ERROR") {
+        throw Exception(lnInvoiceResponse.data['reason']);
+      }
+
+      return lnInvoiceResponse.data['pr'];
+    } catch (e) {
+      Logger.log("[ERROR] : $e");
+      throw Exception(e);
+    }
+  }
+}

--- a/test/services/speed_app_ln_invoice_service_test.dart
+++ b/test/services/speed_app_ln_invoice_service_test.dart
@@ -1,0 +1,34 @@
+import 'package:coconut_wallet/services/speed_app_ln_invoice_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final SpeedAppLnInvoiceService invoiceService = SpeedAppLnInvoiceService();
+
+  group('SpeedAppLnInvoiceService', () {
+    test('라이트닝 인보이스 주소 얻기', () async {
+      const amounts = [1000, 5000, 10000, 30000, 50000, 100000, 1000000, 3000000, 5000000];
+      for (var amount in amounts) {
+        final invoice = await invoiceService.getLnInvoiceOfPow(amount);
+        expect(invoice.startsWith("lnbc"), true);
+      }
+    });
+
+    test('잘못된 amount 지정한 경우 exception', () async {
+      const amounts = [
+        -100000,
+        -50000,
+        -10000,
+        -5000,
+        -3000,
+        -1000,
+        0,
+        600000000000,
+        800000000000,
+        1000000000000
+      ];
+      for (var amount in amounts) {
+        expect(() => invoiceService.getLnInvoiceOfPow(amount), throwsException);
+      }
+    });
+  });
+}


### PR DESCRIPTION
### 변경사항
feat(ln_invoice_service): 라이트닝 인보이스 주소 생성 로직, 테스트 코드 추가

### 테스트 방법
1. 명령어를 통한 유닛테스트 코드 실행
flutter test  test/services/speed_app_ln_invoice_service_test.dart

### 테스트 시나리오
1. 정상적인 범위의 amount를 입력한 경우, 라이트닝 인보이스 주소가 제대로 생성된다.
2. 비정상적 범위의 amount를 입력한 경우, 오류가 발생한다.

#258 