### PR TITLE
[262] 라이트닝 후원하기

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,5 +58,10 @@
             <action android:name="android.intent.action.SENDTO" />
             <data android:scheme="mailto" />
         </intent>
+
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="lightning" />
+        </intent>
     </queries>
 </manifest>

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -121,6 +121,13 @@ donation:
   lightning: "라이트닝 후원"
   under_dust_error: "${dust}(더스트) 보다 큰 금액을 입력해 주세요\n"
 
+  # 후원하기 - 라이트닝
+  donation_amount: "후원 금액"
+  ln_invoice: "라이트닝 인보이스"
+  ln_address: "라이트닝 주소"
+  ln_address_pow: "powbitcoiner@speed.app"
+  ln_invoice_api_error: "라이트닝 인보이스 생성에 실패했어요"
+
 # lib/enums
 transaction_enums:
   high_priority: "빠른 전송"

--- a/lib/screens/donation/lightning_donation_info_screen.dart
+++ b/lib/screens/donation/lightning_donation_info_screen.dart
@@ -30,8 +30,7 @@ class _LightningDonationInfoScreenState extends State<LightningDonationInfoScree
   bool _hasLnApp = false;
   bool _isInitialized = false;
 
-  bool get canLaunchLnApp =>
-      Platform.isAndroid && _hasLnInvoice && _hasLnApp; // iOS의 경우 라이트닝앱 선택이 불가능하므로 제외
+  bool get canLaunchLnApp => Platform.isAndroid && _hasLnApp; // iOS의 경우 라이트닝앱 선택이 불가능하므로 제외
 
   @override
   void initState() {
@@ -115,6 +114,7 @@ class _LightningDonationInfoScreenState extends State<LightningDonationInfoScree
                       bottom: Sizes.size30,
                     ),
                     child: CoconutButton(
+                      isActive: _hasLnInvoice,
                       backgroundColor: CoconutColors.white,
                       foregroundColor: CoconutColors.black,
                       pressedTextColor: CoconutColors.gray500,

--- a/lib/screens/donation/lightning_donation_info_screen.dart
+++ b/lib/screens/donation/lightning_donation_info_screen.dart
@@ -1,6 +1,15 @@
+import 'dart:io';
+
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
+import 'package:coconut_wallet/services/speed_app_ln_invoice_service.dart';
+import 'package:coconut_wallet/utils/balance_format_util.dart';
+import 'package:coconut_wallet/utils/logger.dart';
+import 'package:coconut_wallet/widgets/button/copy_text_container.dart';
+import 'package:coconut_wallet/widgets/overlays/coconut_loading_overlay.dart';
+import 'package:coconut_wallet/widgets/qrcode.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class LightningDonationInfoScreen extends StatefulWidget {
   final int donationAmount;
@@ -14,6 +23,49 @@ class LightningDonationInfoScreen extends StatefulWidget {
 }
 
 class _LightningDonationInfoScreenState extends State<LightningDonationInfoScreen> {
+  final SpeedAppLnInvoiceService _lnInvoiceService = SpeedAppLnInvoiceService();
+  final String _lnAppScheme = "lightning";
+  String? _lnInvoice;
+  bool _hasLnInvoice = false;
+  bool _hasLnApp = false;
+  bool _isInitialized = false;
+
+  bool get canLaunchLnApp =>
+      Platform.isAndroid && _hasLnInvoice && _hasLnApp; // iOS의 경우 라이트닝앱 선택이 불가능하므로 제외
+
+  @override
+  void initState() {
+    super.initState();
+    initialize();
+  }
+
+  Future<void> initialize() async {
+    Future.wait([getLnInvoice(), checkLnAppAvailability()]).then((_) {
+      _isInitialized = true;
+      setState(() {});
+    });
+  }
+
+  Future<void> checkLnAppAvailability() async {
+    _hasLnApp = await canLaunchUrl(Uri.parse("$_lnAppScheme:"));
+    Logger.log("_hasLnApp = $_hasLnApp");
+  }
+
+  Future<void> getLnInvoice() async {
+    try {
+      _lnInvoice = await _lnInvoiceService.getLnInvoiceOfPow(widget.donationAmount);
+      _hasLnInvoice = true;
+      Logger.log(_lnInvoice);
+    } catch (e) {
+      _lnInvoice = null;
+      _hasLnInvoice = false;
+      Logger.log(e);
+      if (mounted) {
+        CoconutToast.showWarningToast(context: context, text: t.donation.ln_invoice_api_error);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -21,12 +73,84 @@ class _LightningDonationInfoScreenState extends State<LightningDonationInfoScree
         title: t.donation.donate,
         context: context,
         backgroundColor: CoconutColors.black,
-        isBottom: true,
+        isBottom: false,
       ),
       resizeToAvoidBottomInset: false,
-      body: Container(
-        child: Text('라이트닝 donationAmount${widget.donationAmount}'),
-      ),
+      backgroundColor: CoconutColors.black,
+      body: !_isInitialized
+          ? const CoconutLoadingOverlay()
+          : Padding(
+              padding: const EdgeInsets.only(
+                left: CoconutLayout.defaultPadding,
+                right: CoconutLayout.defaultPadding,
+              ),
+              child: Column(children: [
+                CoconutLayout.spacing_800h,
+                QrCode(qrData: _lnInvoice != null ? _lnInvoice! : t.donation.ln_address_pow),
+                CoconutLayout.spacing_800h,
+                _buildDonationAmountRow(),
+                CoconutLayout.spacing_300h,
+                IgnorePointer(
+                  ignoring: _lnInvoice == null,
+                  child: CopyTextContainer(
+                    text: t.donation.ln_invoice,
+                    middleText: _lnInvoice != null
+                        ? "${_lnInvoice!.substring(0, 7)}... ${_lnInvoice!.substring(_lnInvoice!.length - 7)}"
+                        : null,
+                    textStyle: CoconutTypography.body2_14_Bold,
+                    copyText: _lnInvoice,
+                    showButton: _lnInvoice != null,
+                  ),
+                ),
+                CoconutLayout.spacing_300h,
+                CopyTextContainer(
+                  text: t.donation.ln_address,
+                  middleText: t.donation.ln_address_pow,
+                  textStyle: CoconutTypography.body2_14_Bold,
+                ),
+                const Spacer(),
+                if (canLaunchLnApp)
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      bottom: Sizes.size30,
+                    ),
+                    child: CoconutButton(
+                      backgroundColor: CoconutColors.white,
+                      foregroundColor: CoconutColors.black,
+                      pressedTextColor: CoconutColors.gray500,
+                      pressedBackgroundColor: CoconutColors.gray300,
+                      disabledBackgroundColor: CoconutColors.gray600,
+                      onPressed: () async {
+                        await launchUrl(Uri.parse("$_lnAppScheme:$_lnInvoice"),
+                            mode: LaunchMode.externalApplication);
+                      },
+                      text: t.donation.donate,
+                    ),
+                  ),
+              ]),
+            ),
+    );
+  }
+
+  Widget _buildDonationAmountRow() {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            t.donation.donation_amount,
+            textAlign: TextAlign.start,
+            style: CoconutTypography.body2_14_Bold.setColor(CoconutColors.white),
+          ),
+        ),
+        CoconutLayout.spacing_400w,
+        Text(
+          "${addCommasToIntegerPart(
+            widget.donationAmount.toDouble(),
+          )} ${t.sats}",
+          style: CoconutTypography.body2_14_Number.setColor(CoconutColors.gray400),
+        ),
+        CoconutLayout.spacing_100w,
+      ],
     );
   }
 }

--- a/lib/screens/donation/lightning_donation_info_screen.dart
+++ b/lib/screens/donation/lightning_donation_info_screen.dart
@@ -106,6 +106,7 @@ class _LightningDonationInfoScreenState extends State<LightningDonationInfoScree
                   text: t.donation.ln_address,
                   middleText: t.donation.ln_address_pow,
                   textStyle: CoconutTypography.body2_14_Bold,
+                  copyText: t.donation.ln_address_pow,
                 ),
                 const Spacer(),
                 if (canLaunchLnApp)

--- a/lib/services/speed_app_ln_invoice_service.dart
+++ b/lib/services/speed_app_ln_invoice_service.dart
@@ -1,0 +1,28 @@
+import 'package:coconut_wallet/utils/logger.dart';
+import 'package:dio/dio.dart';
+
+class SpeedAppLnInvoiceService {
+  final _dio = Dio();
+
+  Future<String> getLnInvoiceOfPow(int amount) async {
+    try {
+      final speedAppResponse = await _dio.get('https://speed.app/.well-known/lnurlp/powbitcoiner');
+      if (speedAppResponse.data['callback'] == null) {
+        throw Exception("callback is null");
+      }
+
+      final lnInvoiceResponse =
+          await _dio.get("${speedAppResponse.data['callback']}?amount=$amount");
+      if (lnInvoiceResponse.data['status'] == "ERROR") {
+        throw Exception(lnInvoiceResponse.data['reason'] ?? "status is ERROR");
+      } else if (lnInvoiceResponse.data['pr'] == null) {
+        throw Exception("pr is null");
+      }
+
+      return lnInvoiceResponse.data['pr'];
+    } catch (e) {
+      Logger.log("[ERROR] : $e");
+      rethrow;
+    }
+  }
+}

--- a/lib/services/speed_app_ln_invoice_service.dart
+++ b/lib/services/speed_app_ln_invoice_service.dart
@@ -4,15 +4,16 @@ import 'package:dio/dio.dart';
 class SpeedAppLnInvoiceService {
   final _dio = Dio();
 
-  Future<String> getLnInvoiceOfPow(int amount) async {
+  Future<String> getLnInvoiceOfPow(int sats) async {
     try {
       final speedAppResponse = await _dio.get('https://speed.app/.well-known/lnurlp/powbitcoiner');
       if (speedAppResponse.data['callback'] == null) {
         throw Exception("callback is null");
       }
 
+      int millisats = sats * 1000;
       final lnInvoiceResponse =
-          await _dio.get("${speedAppResponse.data['callback']}?amount=$amount");
+          await _dio.get("${speedAppResponse.data['callback']}?amount=$millisats");
       if (lnInvoiceResponse.data['status'] == "ERROR") {
         throw Exception(lnInvoiceResponse.data['reason'] ?? "status is ERROR");
       } else if (lnInvoiceResponse.data['pr'] == null) {

--- a/lib/widgets/button/copy_text_container.dart
+++ b/lib/widgets/button/copy_text_container.dart
@@ -12,9 +12,20 @@ import 'package:fluttertoast/fluttertoast.dart';
 
 class CopyTextContainer extends StatefulWidget {
   final String text;
+  final String? copyText;
+  final String? middleText;
   final TextAlign? textAlign;
   final TextStyle? textStyle;
-  const CopyTextContainer({super.key, required this.text, this.textAlign, this.textStyle});
+  final bool showButton;
+
+  const CopyTextContainer(
+      {super.key,
+      required this.text,
+      this.copyText,
+      this.middleText,
+      this.textAlign,
+      this.textStyle,
+      this.showButton = true});
 
   static const MethodChannel _channel = MethodChannel(methodChannelOS);
 
@@ -42,7 +53,8 @@ class _CopyTextContainerState extends State<CopyTextContainer> {
           _buttonColor = CoconutColors.gray800;
         });
 
-        Clipboard.setData(ClipboardData(text: widget.text)).then((value) => null);
+        Clipboard.setData(ClipboardData(text: widget.copyText ?? widget.text))
+            .then((value) => null);
         if (Platform.isAndroid) {
           try {
             final int version = await CopyTextContainer._channel.invokeMethod('getSdkVersion');
@@ -90,15 +102,25 @@ class _CopyTextContainerState extends State<CopyTextContainer> {
               ),
             ),
             CoconutLayout.spacing_400w,
-            Container(
-              padding: const EdgeInsets.all(4),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(
-                  CoconutStyles.radius_100,
-                ),
-                color: _buttonColor,
+            if (widget.middleText != null) ...[
+              Text(
+                widget.middleText!,
+                style: CoconutTypography.body2_14_Number.setColor(CoconutColors.gray400),
               ),
-              child: SvgPicture.asset('assets/svg/copy.svg'),
+              CoconutLayout.spacing_200w,
+            ],
+            Opacity(
+              opacity: widget.showButton ? 1.0 : 0.0,
+              child: Container(
+                padding: const EdgeInsets.all(4),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(
+                    CoconutStyles.radius_100,
+                  ),
+                  color: _buttonColor,
+                ),
+                child: SvgPicture.asset('assets/svg/copy.svg'),
+              ),
             )
           ],
         ),

--- a/lib/widgets/qrcode.dart
+++ b/lib/widgets/qrcode.dart
@@ -1,0 +1,43 @@
+import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class QrCode extends StatefulWidget {
+  final String qrData;
+  const QrCode({super.key, required this.qrData});
+
+  @override
+  State<QrCode> createState() => _QrCodeState();
+}
+
+class _QrCodeState extends State<QrCode> {
+  @override
+  Widget build(BuildContext context) {
+    final double qrSize = MediaQuery.of(context).size.width * 275 / 375;
+
+    return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 36),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Stack(
+              children: [
+                Container(
+                  width: qrSize,
+                  height: qrSize,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(CoconutStyles.radius_200),
+                    color: CoconutColors.white,
+                  ),
+                ),
+                QrImageView(
+                  data: widget.qrData,
+                  version: QrVersions.auto,
+                  size: qrSize,
+                ),
+              ],
+            ),
+          ],
+        ));
+  }
+}


### PR DESCRIPTION
### 변경사항
 - 라이트닝 후원하기 페이지 추가
 - copy_text_container 위젯 옵션 추가(중간 텍스트, 버튼 여부, 복사 텍스트)

### 테스트 방법
메인넷 버전으로 실행
1. 월렛 리스트 화면 - 후원하기 버튼 - 사토시 메뉴 선택 - 라이트닝 후원하기 버튼 클릭

### 테스트 시나리오
[성공 케이스]
1. 초기 로딩 이후에 라이트닝 인보이스 QR, 후원금액, 라이트닝 인보이스, 라이트닝 주소 값이 표출됩니다. (QR이 복잡한 경우 라이트닝 정보)
2. 후원하기 버튼은 안드로이드 && 라이트닝앱 여부에 따라 보여주며, 라이트닝 인보이스 값을 받아오지 못한 경우 '비활성화' 처리됩니다. 
3. 후원하기 버튼을 누르면 라이트닝 앱이 실행되어 페이지가 이동됩니다. 
4. QR을 찍으면 라이트닝 인보이스 정보 / 라이트닝 인보이스 복사 버튼, 라이트닝 주소 버튼에 따른 복사 텍스트가 맞아야 합니다.  

[실패 케이스] - 인보이스 처리에 임의로 exception을 처리하여 재현 가능
1. 초기 로딩 이후에 '라이트닝 인보이스 생성에 실패했어요' 토스트, 라이트닝 주소 QR, 후원금액, 라이트닝 인보이스(empty), 라이트닝 주소가 표출됩니다. 
2. 후원하기 버튼은 안드로이드 && 라이트닝앱 여부에 따라 보여주며, 라이트닝 인보이스 값을 받아오지 못한 경우 '비활성화' 처리됩니다.
3. QR을 찍으면 라이트닝 주소 정보 / 라이트닝 인보이스 복사 버튼 클릭 불가 / 라이트닝 주소 버튼에 따른 텍스트가 맞아야 합니다. 

#262 