### PR TITLE
[267] 배치 트랜잭션 수량 입력 필드 스크롤 가능

### DIFF
--- a/lib/widgets/card/address_and_amount_card.dart
+++ b/lib/widgets/card/address_and_amount_card.dart
@@ -75,6 +75,7 @@ class _AddressAndAmountCardState extends State<AddressAndAmountCard> {
       String? placeholderText,
       bool isError = false,
       String? errorText,
+      int? maxLines,
       EdgeInsets? padding,
       double? height = 52}) {
     focusNode.addListener(() {
@@ -91,6 +92,7 @@ class _AddressAndAmountCardState extends State<AddressAndAmountCard> {
               left: CoconutLayout.defaultPadding,
               top: CoconutLayout.defaultPadding,
               bottom: CoconutLayout.defaultPadding),
+      maxLines: maxLines,
       textInputAction: TextInputAction.done,
       activeColor: CoconutColors.gray100,
       cursorColor: CoconutColors.gray100,
@@ -185,6 +187,7 @@ class _AddressAndAmountCardState extends State<AddressAndAmountCard> {
                               BlendMode.srcIn),
                         ),
                       ),
+                maxLines: 1,
                 placeholderText: widget.amountPlaceholder,
                 isError: widget.isAmountDust,
                 errorText: widget.isAmountDust


### PR DESCRIPTION
### 변경사항
fix(address_and_amount_card): 수량 필드 스크롤 되지 않도록 수정

<img width="250px" src="https://github.com/user-attachments/assets/5faef302-edab-4a31-8af2-d697c771d6f2" />

### 테스트 방법
1. 앱 실행하여 확인

### 테스트 시나리오
1. 앱 실행 -> 지갑 선택 -> 보내기 버튼 클릭 -> 상단 오른쪽 여러 주소로 보내기 클릭
2. 받는 사람 카드에서 주소 필드는 '여러 줄', 수량 필드는 '1줄'로 입력되는지 확인(두 경우 모두 스크롤 불가) 

#267 