### PR TITLE
[269] 배치 트랜잭션 TextField placeholder 오류

### DIFF
--- a/lib/widgets/body/send_address/send_address_amount_body_for_batch.dart
+++ b/lib/widgets/body/send_address/send_address_amount_body_for_batch.dart
@@ -80,9 +80,12 @@ class _SendAddressAmountBodyForBatchState extends State<SendAddressAmountBodyFor
                           },
                           validateAddress: widget.validateAddress,
                           isRemovable: _recipients.length > 2,
-                          addressPlaceholder: t.send_address_screen.address_placeholder,
-                          amountPlaceholder:
-                              '${t.send_address_screen.amount_placeholder} (${t.btc})',
+                          addressPlaceholder: _recipients[index].address.isEmpty
+                              ? t.send_address_screen.address_placeholder
+                              : "",
+                          amountPlaceholder: _recipients[index].amount.isEmpty
+                              ? '${t.send_address_screen.amount_placeholder} (${t.btc})'
+                              : "",
                           isAddressInvalid: _recipients[index].isAddressValid == false ||
                               _recipients[index].isAddressDuplicated == true,
                           isAmountDust: _recipients[index].isAmountDust == true,

--- a/lib/widgets/card/address_and_amount_card.dart
+++ b/lib/widgets/card/address_and_amount_card.dart
@@ -147,8 +147,14 @@ class _AddressAndAmountCardState extends State<AddressAndAmountCard> {
                   iconSize: 14,
                   padding: EdgeInsets.zero,
                   onPressed: _addressController.text.isEmpty
-                      ? _showAddressScanner
-                      : () => _onAddressChanged(''),
+                      ? () {
+                          _addressFocusNode.requestFocus();
+                          _showAddressScanner();
+                        }
+                      : () {
+                          _addressFocusNode.requestFocus();
+                          _onAddressChanged('');
+                        },
                   icon: _addressController.text.isEmpty
                       ? SvgPicture.asset('assets/svg/scan.svg')
                       : SvgPicture.asset(
@@ -177,7 +183,10 @@ class _AddressAndAmountCardState extends State<AddressAndAmountCard> {
                     : IconButton(
                         iconSize: 14,
                         padding: EdgeInsets.zero,
-                        onPressed: () => _onAmountChanged(''),
+                        onPressed: () {
+                          _quantityFocusNode.requestFocus();
+                          _onAmountChanged('');
+                        },
                         icon: SvgPicture.asset(
                           'assets/svg/text-field-clear.svg',
                           colorFilter: ColorFilter.mode(
@@ -277,7 +286,8 @@ class _AddressAndAmountCardState extends State<AddressAndAmountCard> {
     if (scannedAddress != null) {
       _addressController.text = scannedAddress;
       _onAddressChanged(scannedAddress);
-      _quantityFocusNode.requestFocus();
+      await Future.delayed(
+          const Duration(milliseconds: 200), () => _quantityFocusNode.requestFocus());
 
       if (widget.isLastItem) {
         // 마지막 아이템만 화면 복귀 후 스크롤이 되지 않아 추가 처리합니다.


### PR DESCRIPTION
### 변경사항
fix(address_and_amount_card)
- QR코드로 주소 추가할 때, placeholder와 text가 겹치는 이슈 수정
- 우측 버튼 클릭시 포커싱 처리하여 placeholder가 정상적으로 업데이트 되도록 수정
- 받는 사람 3이 추가되어 입력하는 경우, 받는 사람 1 항목의 placeholder가 나오는 이슈 수정

### 테스트 방법
1. 앱 실행하여 확인
<img width="250px" src="https://github.com/user-attachments/assets/5857f2ea-ca9f-4349-ab15-623423f30ee8" />

### 테스트 시나리오
공통 진입 경로: 앱 실행 -> 지갑 선택 -> 보내기 버튼 클릭 -> 상단 오른쪽 여러 주소로 보내기 클릭

TC1. 주소의 scanner 버튼 클릭 -> 주소 QR 스캔 -> 주소 placeholder, text 데이터가 겹치지 않는지 확인, 수량으로 focus 이동하는지 확인
TC2. 받는사람1, 2에 주소와 수량 입력 -> 받는 사람3의 주소 입력 -> 받는 사람1의 placeholder, text 데이터가 겹치지 않는지 확인
TC3. clear/scanner 버튼을 누른 경우, 해당 필드로 포커싱이 되는지 확인
(기존에 placeholder가 업데이트 되지 않는 경우가 있었음)

#269 