### PR TITLE
fix(wallet-add-screen): 버그 수정 및 ui 수정

### DIFF
--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:coconut_design_system/coconut_design_system.dart';
-import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_add_input_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
@@ -36,7 +35,9 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
   bool get isDescriptorAdding => _inputController.text.contains('['); // 대괄호 입력시 descriptor 입력을 가정
 
   Future<void> _addWallet(WalletAddInputViewModel viewModel) async {
+    _closeKeyboard();
     if (_isProcessing) return;
+
     _isProcessing = true;
     context.loaderOverlay.show();
     await Future.delayed(const Duration(seconds: 2));
@@ -215,7 +216,7 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                                               CoconutLayout.spacing_100w,
                                               Text(
                                                   t.wallet_add_input_screen.wallet_description_text,
-                                                  style: CoconutTypography.body3_12)
+                                                  style: CoconutTypography.body2_14)
                                             ],
                                           ),
                                         ),
@@ -253,7 +254,6 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                         ),
                         FixedBottomButton(
                           onButtonClicked: () {
-                            _closeKeyboard();
                             if (isDescriptorAdding) {
                               _addWallet(viewModel);
                             } else {

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -278,6 +278,8 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
   }
 
   void showMfpInputBottomSheet(WalletAddInputViewModel viewModel) {
+    _closeKeyboard();
+
     showModalBottomSheet(
       context: context,
       builder: (context) {

--- a/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
+++ b/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
@@ -50,6 +50,7 @@ class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSh
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
+      behavior: HitTestBehavior.translucent,
       onTap: () => FocusScope.of(context).unfocus(),
       child: SingleChildScrollView(
         child: Column(
@@ -111,7 +112,7 @@ class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSh
                               ),
                               CoconutLayout.spacing_100w,
                               Text(t.wallet_add_input_screen.mfp_description_title,
-                                  style: CoconutTypography.body3_12)
+                                  style: CoconutTypography.body2_14_Bold)
                             ],
                           ),
                           CoconutLayout.spacing_200h,
@@ -188,6 +189,7 @@ class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSh
                         flex: 4,
                         child: CoconutButton(
                           onPressed: () {
+                            FocusScope.of(context).unfocus();
                             widget.onSkip();
                             Navigator.pop(context);
                           },
@@ -206,6 +208,7 @@ class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSh
                         flex: 6,
                         child: CoconutButton(
                           onPressed: () {
+                            FocusScope.of(context).unfocus();
                             widget.onComplete(_mfpController.text);
                             Navigator.pop(context);
                           },

--- a/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
+++ b/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
@@ -23,7 +23,10 @@ class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSh
   @override
   void initState() {
     super.initState();
-    _mfpFocusNode.requestFocus();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await Future.delayed(const Duration(milliseconds: 300));
+      _mfpFocusNode.requestFocus();
+    });
     _mfpController.addListener(() {
       if (_mfpController.text.length < 8) {
         setState(() {
@@ -189,7 +192,9 @@ class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSh
                         flex: 4,
                         child: CoconutButton(
                           onPressed: () {
-                            FocusScope.of(context).unfocus();
+                            WidgetsBinding.instance.addPostFrameCallback((_) {
+                              FocusScope.of(context).unfocus();
+                            });
                             widget.onSkip();
                             Navigator.pop(context);
                           },
@@ -208,7 +213,9 @@ class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSh
                         flex: 6,
                         child: CoconutButton(
                           onPressed: () {
-                            FocusScope.of(context).unfocus();
+                            WidgetsBinding.instance.addPostFrameCallback((_) {
+                              FocusScope.of(context).unfocus();
+                            });
                             widget.onComplete(_mfpController.text);
                             Navigator.pop(context);
                           },

--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -25,21 +25,22 @@ class DescriptorUtil {
         ? descriptor.substring(descriptor.indexOf('(') + 1, descriptor.lastIndexOf(')'))
         : descriptor;
 
-    // 대괄호 [fingerprint/derivationPath] 추출
-    final regex = RegExp(r'\[([0-9a-fA-F]{8})/([0-9]+' r"')" r'(?:/[0-9]+' r"')*]");
+    // // 대괄호 [fingerprint/derivationPath] 추출
+    final squareBracket =
+        innerDescriptor.substring(innerDescriptor.indexOf('[') + 1, innerDescriptor.indexOf(']'));
 
-    final match = regex.firstMatch(innerDescriptor);
-    if (match == null || match.groupCount < 2) {
+    final path = squareBracket.split('/');
+
+    if (path.isEmpty || path.length < 2) {
       throw const FormatException('Invalid descriptor format');
     }
 
-    //final fingerprint = match.group(1)!;
-    final purposeWithHardenedMark = match.group(2)!;
+    final purposeWithHardenedMark = path[1];
     return purposeWithHardenedMark;
   }
 
   static void validatePurpose(String purpose) {
-    if (purpose != "84'") {
+    if (purpose != "84'" && purpose != '84h') {
       throw FormatException("purpose $purpose is not supported");
     }
   }

--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -25,9 +25,15 @@ class DescriptorUtil {
         ? descriptor.substring(descriptor.indexOf('(') + 1, descriptor.lastIndexOf(')'))
         : descriptor;
 
-    // // 대괄호 [fingerprint/derivationPath] 추출
-    final squareBracket =
-        innerDescriptor.substring(innerDescriptor.indexOf('[') + 1, innerDescriptor.indexOf(']'));
+    // 대괄호 [fingerprint/derivationPath] 추출
+    final startIndex = innerDescriptor.indexOf('[');
+    final endIndex = innerDescriptor.indexOf(']');
+
+    if (startIndex == -1 || endIndex == -1) {
+      throw const FormatException('Invalid descriptor format: missing square brackets');
+    }
+
+    final squareBracket = innerDescriptor.substring(startIndex + 1, endIndex);
 
     final path = squareBracket.split('/');
 

--- a/test/utils/descriptor_util_test.dart
+++ b/test/utils/descriptor_util_test.dart
@@ -45,10 +45,16 @@ void main() {
     });
 
     group('extractPurpose', () {
-      test('올바른 디스크립터에서 purpose를 추출', () {
+      test('올바른 디스크립터에서 purpose를 추출(hardened 기호: \')', () {
         const descriptor =
             "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0";
         expect(DescriptorUtil.extractPurpose(descriptor), "84'");
+      });
+
+      test('올바른 디스크립터에서 purpose를 추출(hardened 기호: h)', () {
+        const descriptor =
+            "wpkh([76223a6f/84h/0h/0h]tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/0/*)#n9g32cn0";
+        expect(DescriptorUtil.extractPurpose(descriptor), "84h");
       });
 
       test('purpose가 없는 디스크립터는 예외 발생', () {


### PR DESCRIPTION
### 변경 사항 

1. `descriptor_util.dart`
    - extractPurpose, validatePurpose 수정(hardened 표기 `'`, `h` 모두 허용) 

2. 직접 입력 화면 bottom sheet 동작 수정
    - ex pub 입력 케이스에서, [완료] 버튼 눌러 mfp 입력 화면으로 전환 시, bottom sheet focus 및 키보드 열림 동작 수정
      (변경 전: 키보드가 닫히고 다시 열리면서, bottomSheet가 키보드의 아래로 내려갔다가 올라오는 동작이 보기 불편함)
      
    - bottomSheet의 버튼을 눌러 지갑을 추가할 때 키보드가 닫히도록 수정 
      (변경 전: _closeKeyboard() 함수를 호출하고 있으나, 실제로 bottomSheet 내부에서 focusNode 변수를 사용하고 있어서 동작하지 않음. 키보드가 열려있는 채로 로딩 인디케이터 노출)
    
3. 도움말 제목 폰트 사이즈 12 > 14

### 테스트 방법

1. 직접 입력 화면 도움말 넌척 케이스대로, Keys 탭에서 Key spec 정보로 추가 시도
    - 지갑 추가 로딩 인디케이터 노출 시 키보드 닫히는지 확인
    
2. 확장 공개키 입력
    - mfp 입력 화면으로 이동 시 동작 확인
    - 건너뛰기 / 완료 버튼 클릭 시 키보드 닫힘 확인
