### PR TITLE
[272] 지갑 동기화중 삭제 시 ScriptStatus 삭제 안되는 오류 수정

### DIFF
--- a/lib/repository/realm/subscription_repository.dart
+++ b/lib/repository/realm/subscription_repository.dart
@@ -45,12 +45,6 @@ class SubscriptionRepository extends BaseRepository {
       await realm.writeAsync(() {
         final wallet = realm.find<RealmWalletBase>(walletId);
         if (wallet == null) {
-          realm.deleteMany<RealmScriptStatus>(
-            realm.query<RealmScriptStatus>(
-              r'walletId == $0',
-              [walletId],
-            ),
-          );
           return;
         }
 

--- a/test/mock/script_status_mock.dart
+++ b/test/mock/script_status_mock.dart
@@ -4,11 +4,11 @@ import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 
 class ScriptStatusMock {
   static ScriptStatus createMockScriptStatus(WalletListItemBase walletItem, int index,
-      {bool isChange = false}) {
+      {bool isChange = false, String? status}) {
     final address = walletItem.walletBase.getAddress(index, isChange: isChange);
     return ScriptStatus(
         scriptPubKey: address,
-        status: Hash.sha256(address),
+        status: status ?? Hash.sha256(address),
         timestamp: DateTime.now(),
         derivationPath: '${walletItem.walletBase.derivationPath}/${isChange ? '1' : '0'}/$index',
         address: address,

--- a/test/repository/realm/subscription_repository_test.dart
+++ b/test/repository/realm/subscription_repository_test.dart
@@ -1,0 +1,333 @@
+import 'package:coconut_wallet/enums/wallet_enums.dart';
+import 'package:coconut_wallet/model/node/script_status.dart';
+import 'package:coconut_wallet/model/wallet/singlesig_wallet_list_item.dart';
+import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/repository/realm/subscription_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../mock/script_status_mock.dart';
+import '../../mock/wallet_mock.dart';
+import 'test_realm_manager.dart';
+
+void main() {
+  late TestRealmManager realmManager;
+  late SubscriptionRepository subscriptionRepository;
+  SinglesigWalletListItem testWalletItem = WalletMock.createSingleSigWalletItem();
+
+  setUp(() async {
+    // 테스트 실행 전 셋업
+    realmManager = await setupTestRealmManager();
+    subscriptionRepository = SubscriptionRepository(realmManager);
+
+    // 테스트용 지갑 생성
+    realmManager.realm.write(() {
+      realmManager.realm.add(RealmWalletBase(
+          testWalletItem.id,
+          testWalletItem.colorIndex,
+          testWalletItem.iconIndex,
+          testWalletItem.descriptor,
+          testWalletItem.name,
+          WalletType.singleSignature.name));
+    });
+  });
+
+  tearDown(() {
+    // 테스트 실행 후 정리
+    realmManager.reset();
+    realmManager.dispose();
+  });
+
+  group('updateScriptStatusList 테스트', () {
+    test('새로운 스크립트 상태 추가 테스트', () async {
+      // Given
+      final newScriptStatuses = [
+        ScriptStatusMock.createMockScriptStatus(testWalletItem, 0),
+        ScriptStatusMock.createMockScriptStatus(testWalletItem, 1),
+      ];
+
+      final beforeStatuses = realmManager.realm.query<RealmScriptStatus>(
+        r'walletId == $0',
+        [testWalletItem.id],
+      ).toList();
+
+      expect(beforeStatuses.length, 0);
+
+      // When
+      final result = await subscriptionRepository.updateScriptStatusList(
+        testWalletItem.id,
+        newScriptStatuses,
+      );
+
+      // Then
+      expect(result.isSuccess, true);
+
+      final savedStatuses = realmManager.realm.query<RealmScriptStatus>(
+        r'walletId == $0',
+        [testWalletItem.id],
+      ).toList();
+
+      expect(savedStatuses.length, 2);
+
+      final firstStatus = savedStatuses
+          .firstWhere((status) => status.scriptPubKey == newScriptStatuses[0].scriptPubKey);
+      expect(firstStatus.status, newScriptStatuses[0].status);
+
+      final secondStatus = savedStatuses
+          .firstWhere((status) => status.scriptPubKey == newScriptStatuses[1].scriptPubKey);
+      expect(secondStatus.status, newScriptStatuses[1].status);
+    });
+
+    test('기존 스크립트 상태 업데이트 테스트', () async {
+      // Given
+      final mockScriptStatus = ScriptStatusMock.createMockScriptStatus(testWalletItem, 0);
+      final existingStatus = RealmScriptStatus(
+        mockScriptStatus.scriptPubKey,
+        "oldStatus",
+        testWalletItem.id,
+        DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      realmManager.realm.write(() {
+        realmManager.realm.add(existingStatus);
+      });
+
+      final updatedScriptStatuses = [
+        ScriptStatusMock.createMockScriptStatus(testWalletItem, 0, status: "newStatus"),
+      ];
+
+      // When
+      final result = await subscriptionRepository.updateScriptStatusList(
+        testWalletItem.id,
+        updatedScriptStatuses,
+      );
+
+      // Then
+      expect(result.isSuccess, true);
+
+      final updatedStatus =
+          realmManager.realm.find<RealmScriptStatus>(mockScriptStatus.scriptPubKey);
+      expect(updatedStatus?.status, "newStatus");
+      expect(updatedStatus?.scriptPubKey, mockScriptStatus.scriptPubKey);
+    });
+
+    test('업데이트 필요 없는 경우 테스트', () async {
+      // Given
+      final mockScriptStatus = ScriptStatusMock.createMockScriptStatus(testWalletItem, 0);
+      final existingStatus = RealmScriptStatus(
+        mockScriptStatus.scriptPubKey,
+        mockScriptStatus.status!,
+        testWalletItem.id,
+        DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      realmManager.realm.write(() {
+        realmManager.realm.add(existingStatus);
+      });
+
+      final sameScriptStatuses = [
+        mockScriptStatus,
+      ];
+
+      // When
+      final result = await subscriptionRepository.updateScriptStatusList(
+        testWalletItem.id,
+        sameScriptStatuses,
+      );
+
+      // Then
+      expect(result.isSuccess, true);
+
+      final unchangedStatus =
+          realmManager.realm.find<RealmScriptStatus>(mockScriptStatus.scriptPubKey);
+      expect(unchangedStatus?.status, mockScriptStatus.status);
+    });
+
+    test('지갑이 삭제된 경우 관련 스크립트 상태 삭제 테스트', () async {
+      // Given
+      final mockScriptStatus = ScriptStatusMock.createMockScriptStatus(testWalletItem, 0);
+      final existingStatus = RealmScriptStatus(
+        mockScriptStatus.scriptPubKey,
+        mockScriptStatus.status!,
+        testWalletItem.id,
+        DateTime.now(),
+      );
+      realmManager.realm.write(() {
+        realmManager.realm.add(existingStatus);
+      });
+
+      final wallet = realmManager.realm.find<RealmWalletBase>(testWalletItem.id);
+      realmManager.realm.write(() {
+        realmManager.realm.delete(wallet!);
+      });
+
+      final scriptStatuses = [
+        ScriptStatusMock.createMockScriptStatus(testWalletItem, 0, status: "newStatus"),
+      ];
+
+      // When
+      final result = await subscriptionRepository.updateScriptStatusList(
+        testWalletItem.id,
+        scriptStatuses,
+      );
+
+      // Then
+      expect(result.isSuccess, true);
+
+      final deletedStatuses = realmManager.realm.query<RealmScriptStatus>(
+        r'walletId == $0',
+        [testWalletItem.id],
+      ).toList();
+      expect(deletedStatuses.length, 0);
+    });
+
+    test('추가와 업데이트가 혼합된 경우 테스트', () async {
+      // Given
+      final existingMockStatus = ScriptStatusMock.createMockScriptStatus(testWalletItem, 0);
+      final existingStatus = RealmScriptStatus(
+        existingMockStatus.scriptPubKey,
+        "oldStatus",
+        testWalletItem.id,
+        DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      realmManager.realm.write(() {
+        realmManager.realm.add(existingStatus);
+      });
+
+      final mixedScriptStatuses = [
+        ScriptStatusMock.createMockScriptStatus(testWalletItem, 0, status: "updatedStatus"),
+        ScriptStatusMock.createMockScriptStatus(testWalletItem, 1, status: "newStatus"),
+      ];
+
+      // When
+      final result = await subscriptionRepository.updateScriptStatusList(
+        testWalletItem.id,
+        mixedScriptStatuses,
+      );
+
+      // Then
+      expect(result.isSuccess, true);
+
+      final updatedStatus =
+          realmManager.realm.find<RealmScriptStatus>(existingMockStatus.scriptPubKey);
+      expect(updatedStatus?.status, "updatedStatus");
+
+      final newMockStatus = mixedScriptStatuses[1];
+      final newStatus = realmManager.realm.find<RealmScriptStatus>(newMockStatus.scriptPubKey);
+      expect(newStatus?.status, "newStatus");
+
+      final allStatuses = realmManager.realm.query<RealmScriptStatus>(
+        r'walletId == $0',
+        [testWalletItem.id],
+      ).toList();
+      expect(allStatuses.length, 2);
+    });
+
+    test('빈 스크립트 상태 목록 처리 테스트', () async {
+      // Given
+      final emptyScriptStatuses = <ScriptStatus>[];
+
+      // When
+      final result = await subscriptionRepository.updateScriptStatusList(
+        testWalletItem.id,
+        emptyScriptStatuses,
+      );
+
+      // Then
+      expect(result.isSuccess, true);
+
+      final savedStatuses = realmManager.realm.query<RealmScriptStatus>(
+        r'walletId == $0',
+        [testWalletItem.id],
+      ).toList();
+      expect(savedStatuses.length, 0);
+    });
+
+    test('동일한 scriptPubKey에 대한 status 변경 감지 테스트', () async {
+      // Given
+      final originalMockStatus =
+          ScriptStatusMock.createMockScriptStatus(testWalletItem, 0, status: "originalStatus");
+      final existingStatus = RealmScriptStatus(
+        originalMockStatus.scriptPubKey,
+        "originalStatus",
+        testWalletItem.id,
+        DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      realmManager.realm.write(() {
+        realmManager.realm.add(existingStatus);
+      });
+
+      final updatedMockStatus =
+          ScriptStatusMock.createMockScriptStatus(testWalletItem, 0, status: "changedStatus");
+
+      // When
+      final result = await subscriptionRepository.updateScriptStatusList(
+        testWalletItem.id,
+        [updatedMockStatus],
+      );
+
+      // Then
+      expect(result.isSuccess, true);
+
+      final changedStatus =
+          realmManager.realm.find<RealmScriptStatus>(originalMockStatus.scriptPubKey);
+      expect(changedStatus?.status, "changedStatus");
+      expect(changedStatus?.walletId, testWalletItem.id);
+    });
+
+    test('여러 스크립트에 대한 부분적 업데이트 테스트', () async {
+      // Given: 여러 기존 스크립트 상태 저장
+      final existingMock1 =
+          ScriptStatusMock.createMockScriptStatus(testWalletItem, 0, status: "status1");
+      final existingMock2 =
+          ScriptStatusMock.createMockScriptStatus(testWalletItem, 1, status: "status2");
+      final existingMock3 =
+          ScriptStatusMock.createMockScriptStatus(testWalletItem, 2, status: "status3");
+
+      realmManager.realm.write(() {
+        realmManager.realm.addAll([
+          RealmScriptStatus(
+              existingMock1.scriptPubKey, "status1", testWalletItem.id, DateTime.now()),
+          RealmScriptStatus(
+              existingMock2.scriptPubKey, "status2", testWalletItem.id, DateTime.now()),
+          RealmScriptStatus(
+              existingMock3.scriptPubKey, "status3", testWalletItem.id, DateTime.now()),
+        ]);
+      });
+
+      // 일부만 업데이트 (인덱스 1만 변경, 0과 2는 동일)
+      final partialUpdateStatuses = [
+        existingMock1, // 동일한 상태
+        ScriptStatusMock.createMockScriptStatus(testWalletItem, 1,
+            status: "updatedStatus2"), // 변경된 상태
+        existingMock3, // 동일한 상태
+      ];
+
+      // When: 스크립트 상태 업데이트 실행
+      final result = await subscriptionRepository.updateScriptStatusList(
+        testWalletItem.id,
+        partialUpdateStatuses,
+      );
+
+      // Then: 성공 결과 확인
+      expect(result.isSuccess, true);
+
+      // 변경되지 않은 상태들 확인
+      final unchangedStatus1 =
+          realmManager.realm.find<RealmScriptStatus>(existingMock1.scriptPubKey);
+      expect(unchangedStatus1?.status, "status1");
+
+      final unchangedStatus3 =
+          realmManager.realm.find<RealmScriptStatus>(existingMock3.scriptPubKey);
+      expect(unchangedStatus3?.status, "status3");
+
+      // 변경된 상태 확인
+      final changedStatus2 = realmManager.realm.find<RealmScriptStatus>(existingMock2.scriptPubKey);
+      expect(changedStatus2?.status, "updatedStatus2");
+
+      // 전체 개수 확인
+      final allStatuses = realmManager.realm.query<RealmScriptStatus>(
+        r'walletId == $0',
+        [testWalletItem.id],
+      ).toList();
+      expect(allStatuses.length, 3);
+    });
+  });
+}


### PR DESCRIPTION
### 1. 변경 사항

- 지갑 동기화 로직 중 ScriptStatus를 저장하는 단계에서 지갑이 삭제됐는지 한 번 더 확인
- 삭제됐다면 저장하지 않도록 수정
- 이전에 삭제된 지갑의 데이터가 있는 경우 해당 데이터를 삭제하고 다시 새로 추가하도록 수정

### 2. 테스트 방법

```bash
flutter test --concurrency=1 ./test/repository/realm/subscription_repository_test.dart
```

1. 테스트 코드 수행
2. 지갑 동기화 중 삭제 - 동일한 지갑 다시 추가 - 데이터 동기화 잘 됐는지 확인

### 이슈

- #272
