### PR TITLE
fix(account-in-path): 0이 아닌 account 허용하도록 수정

### DIFF
--- a/lib/utils/descriptor_util.dart
+++ b/lib/utils/descriptor_util.dart
@@ -3,6 +3,13 @@ import 'package:coconut_wallet/utils/logger.dart';
 
 class DescriptorUtil {
   static const String allowedDescriptorFunction = 'wpkh';
+  static const _fingerprint = r"[0-9a-fA-F]{8}";
+  static const _purposeCoin = r"/84(?:'|h)/(?:1|0)(?:'|h)";
+  static const _account = r"/\d+(?:'|h)";
+  static const _xpubPrefix = r"(tpub|vpub|xpub|zpub)";
+  static const _base58 = r"[1-9A-HJ-NP-Za-km-z]{107,108}";
+
+  static const _basePath = "$_fingerprint$_purposeCoin$_account";
 
   static String? getDescriptorFunction(String descriptor) {
     final match = RegExp(r'^(wpkh|wsh|sh|pkh|multi|sortedmulti|tr)\(').firstMatch(descriptor);
@@ -72,13 +79,20 @@ class DescriptorUtil {
 
   static void validateNativeSegwitDescriptor(String descriptor) {
     final regexWpkhFormatWithoutChecksum = RegExp(
-      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107,108}\)$",
+      r"^wpkh\(\[" + _basePath + r"\]" + _xpubPrefix + _base58 + r"\)$",
     );
+
     final regexWpkhFormatWithChecksumPath = RegExp(
-      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107,108}/<\d+;\d+>\/\*\)$",
+      r"^wpkh\(\[" + _basePath + r"\]" + _xpubPrefix + _base58 + r"/<\d+;\d+>/\*\)$",
     );
+
     final regexWpkhFormatWithChecksum = RegExp(
-      r"^wpkh\(\[[0-9a-fA-F]{8}/84(?:'|h)/(?:1|0)(?:'|h)/0(?:'|h)\](tpub|vpub|xpub|zpub)[1-9A-HJ-NP-Za-km-z]{107,108}/<\d+;\d+>\/\*\)#([A-Za-z0-9]{8})$",
+      r"^wpkh\(\[" +
+          _basePath +
+          r"\]" +
+          _xpubPrefix +
+          _base58 +
+          r"/<\d+;\d+>/\*\)#([A-Za-z0-9]{8})$",
     );
 
     if (!(regexWpkhFormatWithoutChecksum.hasMatch(descriptor) ||

--- a/test/utils/descriptor_util_test.dart
+++ b/test/utils/descriptor_util_test.dart
@@ -79,6 +79,53 @@ void main() {
       });
     });
 
+    group('validateNativeSegwitDescriptor', () {
+      test('account 0인 올바른 네이티브 세그윗 디스크립터 검증', () {
+        // 체크섬이 없는 기본 형식
+        const descriptor =
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF)";
+        expect(() => DescriptorUtil.validateNativeSegwitDescriptor(descriptor), returnsNormally);
+
+        // 체크섬 경로가 있는 형식
+        const descriptorWithPath =
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/<0;1>/*)";
+        expect(() => DescriptorUtil.validateNativeSegwitDescriptor(descriptorWithPath),
+            returnsNormally);
+
+        // 체크섬이 있는 형식
+        const descriptorWithChecksum =
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/<0;1>/*)#n9g32cn0";
+        expect(() => DescriptorUtil.validateNativeSegwitDescriptor(descriptorWithChecksum),
+            returnsNormally);
+      });
+
+      test('account가 1인 올바른 네이티브 세그윗 디스크립터 검증', () {
+        const descriptorAccount1 =
+            "wpkh([C49BB3CF/84'/0'/1']zpub6qdvhrsV9g78eZtKZxKu2faGwtVj3fpxeM7VM585upfiDK88Upf2KRiJ29VXWpFt7dMxiBkRhqVwB4RP1LwcnzBv1pRGwKVj36wgwF6U4Bw/<0;1>/*)#r293md9j";
+        expect(() => DescriptorUtil.validateNativeSegwitDescriptor(descriptorAccount1),
+            returnsNormally);
+      });
+
+      test('잘못된 네이티브 세그윗 디스크립터 검증', () {
+        // 잘못된 함수 (sh 대신 wpkh)
+        const invalidFunction =
+            "sh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF)";
+        expect(
+            () => DescriptorUtil.validateNativeSegwitDescriptor(invalidFunction), throwsException);
+
+        // 잘못된 경로 형식
+        const invalidPath =
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/<invalid>/*)";
+        expect(() => DescriptorUtil.validateNativeSegwitDescriptor(invalidPath), throwsException);
+
+        // 8글자가 아닌 체크섬
+        const invalidChecksum =
+            "wpkh([76223a6f/84'/0'/0']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF/<0;1>/*)#not8words";
+        expect(
+            () => DescriptorUtil.validateNativeSegwitDescriptor(invalidChecksum), throwsException);
+      });
+    });
+
     group('hasDescriptorChecksum', () {
       test('체크섬이 있는 디스크립터 확인', () {
         const descriptor =


### PR DESCRIPTION
- 디스크립터 regex 리팩토링

Pororo님 버그 제보: account 0이 아닌 path가 포함된 경우 '확인할 수 없는 형식이에요'