### PR TITLE
[294] 수수료율 소수점 2자리까지 직접 입력 가능

### DIFF
--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -411,7 +411,7 @@ errors:
   data_not_found: "데이터가 없습니다."
 
 text_field:
-  enter_fee_with_two_decimal_places: "수수료율은 소수점 두자리까지 입력 가능해요."
+  enter_fee_with_two_decimal_places: "소수점 두자리까지 가능해요 (sats/vb)"
   enter_fee_directly: "직접 입력하기"
   search_mnemonic_word: "영문으로 검색해 보세요"
 

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -411,7 +411,7 @@ errors:
   data_not_found: "데이터가 없습니다."
 
 text_field:
-  enter_fee_as_natural_number: "수수료를 자연수로 입력해 주세요."
+  enter_fee_with_two_decimal_places: "수수료율은 소수점 두자리까지 입력 가능해요."
   enter_fee_directly: "직접 입력하기"
   search_mnemonic_word: "영문으로 검색해 보세요"
 

--- a/lib/model/send/fee_info.dart
+++ b/lib/model/send/fee_info.dart
@@ -16,7 +16,7 @@ class FeeInfoWithLevel extends FeeInfo {
 class FeeInfo {
   int? estimatedFee;
   int? fiatValue;
-  int? satsPerVb;
+  double? satsPerVb;
   bool failedEstimation;
   bool isEstimating;
 

--- a/lib/providers/view_model/send/send_fee_selection_view_model.dart
+++ b/lib/providers/view_model/send/send_fee_selection_view_model.dart
@@ -60,20 +60,20 @@ class SendFeeSelectionViewModel extends ChangeNotifier {
   WalletProvider get walletProvider => _walletProvider;
   NodeProvider get nodeprovider => _nodeProvider;
 
-  int estimateFee(int satsPerVb) {
+  int estimateFee(double satsPerVb) {
     final transaction = _createTransaction(satsPerVb);
 
     if (_isMultisigWallet) {
       final multisigWallet = _walletListItemBase.walletBase as MultisignatureWallet;
-      return transaction.estimateFee(satsPerVb.toDouble(), _walletAddressType,
+      return transaction.estimateFee(satsPerVb, _walletAddressType,
           requiredSignature: multisigWallet.requiredSignature,
           totalSigner: multisigWallet.totalSigner);
     }
 
-    return transaction.estimateFee(satsPerVb.toDouble(), _walletAddressType);
+    return transaction.estimateFee(satsPerVb, _walletAddressType);
   }
 
-  Transaction _createTransaction(int satsPerVb) {
+  Transaction _createTransaction(double satsPerVb) {
     final utxoPool = _walletProvider.getUtxoListByStatus(_walletId, UtxoStatus.unspent);
     final wallet = _walletProvider.getWalletById(_walletId);
     final changeAddress = _walletProvider.getChangeAddress(_walletId);
@@ -131,7 +131,7 @@ class SendFeeSelectionViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void saveFinalSendInfo(int estimatedFee, int satsPerVb) {
+  void saveFinalSendInfo(int estimatedFee, double satsPerVb) {
     double finalAmount =
         _isMaxMode ? UnitUtil.satoshiToBitcoin(_confirmedBalance - estimatedFee) : _amount;
     _sendInfoProvider.setAmount(finalAmount);

--- a/lib/providers/view_model/send/send_utxo_selection_view_model.dart
+++ b/lib/providers/view_model/send/send_utxo_selection_view_model.dart
@@ -209,7 +209,7 @@ class SendUtxoSelectionViewModel extends ChangeNotifier {
 
   RecommendedFeeFetchStatus get recommendedFeeFetchStatus => _recommendedFeeFetchStatus;
   RecommendedFee? get recommendedFees => _recommendedFees;
-  int? get satsPerVb {
+  double? get satsPerVb {
     if (_selectedLevel == null) {
       return _customFeeInfo?.satsPerVb;
     }
@@ -255,8 +255,8 @@ class SendUtxoSelectionViewModel extends ChangeNotifier {
     }
   }
 
-  int estimateFee(int feeRate) {
-    return _transaction.estimateFee(feeRate.toDouble(), _walletBase.addressType,
+  int estimateFee(double feeRate) {
+    return _transaction.estimateFee(feeRate, _walletBase.addressType,
         requiredSignature: _requiredSignature, totalSigner: _totalSigner);
   }
 
@@ -357,11 +357,11 @@ class SendUtxoSelectionViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Transaction _createTransaction(
-      List<UtxoState> utxos, bool isMaxMode, int feeRate, WalletListItemBase walletListItemBase) {
+  Transaction _createTransaction(List<UtxoState> utxos, bool isMaxMode, double feeRate,
+      WalletListItemBase walletListItemBase) {
     if (isMaxMode) {
-      return Transaction.forSweep(utxos, _sendInfoProvider.recipientAddress!, feeRate.toDouble(),
-          walletListItemBase.walletBase);
+      return Transaction.forSweep(
+          utxos, _sendInfoProvider.recipientAddress!, feeRate, walletListItemBase.walletBase);
     }
 
     try {
@@ -373,12 +373,12 @@ class SendUtxoSelectionViewModel extends ChangeNotifier {
           _sendInfoProvider.recipientAddress!,
           _walletProvider.getChangeAddress(_sendInfoProvider.walletId!).derivationPath,
           UnitUtil.bitcoinToSatoshi(_sendInfoProvider.amount!),
-          feeRate.toDouble(),
+          feeRate,
           walletListItemBase.walletBase);
     } catch (e) {
       if (e.toString().contains('Not enough amount for sending. (Fee')) {
-        return Transaction.forSweep(utxos, _sendInfoProvider.recipientAddress!, feeRate.toDouble(),
-            walletListItemBase.walletBase);
+        return Transaction.forSweep(
+            utxos, _sendInfoProvider.recipientAddress!, feeRate, walletListItemBase.walletBase);
       }
       rethrow;
     }
@@ -437,9 +437,9 @@ class SendUtxoSelectionViewModel extends ChangeNotifier {
 
     final recommendedFees = recommendedFeesResult.value;
 
-    feeInfos[0].satsPerVb = recommendedFees.fastestFee;
-    feeInfos[1].satsPerVb = recommendedFees.halfHourFee;
-    feeInfos[2].satsPerVb = recommendedFees.hourFee;
+    feeInfos[0].satsPerVb = recommendedFees.fastestFee.toDouble();
+    feeInfos[1].satsPerVb = recommendedFees.halfHourFee.toDouble();
+    feeInfos[2].satsPerVb = recommendedFees.hourFee.toDouble();
 
     final updateFeeInfoResult = _updateFeeInfoEstimateFee();
     if (updateFeeInfoResult) {
@@ -478,8 +478,8 @@ class SendUtxoSelectionViewModel extends ChangeNotifier {
     return true;
   }
 
-  void _updateFeeRateOfTransaction(int satsPerVb) {
-    _transaction.updateFeeRate(satsPerVb.toDouble(), _walletBase,
+  void _updateFeeRateOfTransaction(double satsPerVb) {
+    _transaction.updateFeeRate(satsPerVb, _walletBase,
         requiredSignature: _requiredSignature, totalSigner: _totalSigner);
   }
 

--- a/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
@@ -712,9 +712,9 @@ class FeeBumpingViewModel extends ChangeNotifier {
     // TODO: 테스트 코드 - 추천수수료 mock
     // final recommendedFees = await DioClient().getRecommendedFee();
 
-    _feeInfos[0].satsPerVb = recommendedFees.fastestFee;
-    _feeInfos[1].satsPerVb = recommendedFees.halfHourFee;
-    _feeInfos[2].satsPerVb = recommendedFees.hourFee;
+    _feeInfos[0].satsPerVb = recommendedFees.fastestFee.toDouble();
+    _feeInfos[1].satsPerVb = recommendedFees.halfHourFee.toDouble();
+    _feeInfos[2].satsPerVb = recommendedFees.hourFee.toDouble();
     _isFeeFetchSuccess = true;
   }
 

--- a/lib/screens/common/text_field_bottom_sheet.dart
+++ b/lib/screens/common/text_field_bottom_sheet.dart
@@ -15,6 +15,8 @@ class TextFieldBottomSheet extends StatefulWidget {
   final String? completeButtonText;
   final TextInputType keyboardType;
   final bool visibleTextLimit;
+  final String Function(String)? formatInput;
+  final int? maxLength;
 
   const TextFieldBottomSheet(
       {super.key,
@@ -24,7 +26,9 @@ class TextFieldBottomSheet extends StatefulWidget {
       this.placeholder = '',
       this.completeButtonText,
       this.keyboardType = TextInputType.text,
-      this.visibleTextLimit = true});
+      this.visibleTextLimit = true,
+      this.formatInput,
+      this.maxLength});
 
   @override
   State<TextFieldBottomSheet> createState() => _TextFieldBottomSheetState();
@@ -124,6 +128,7 @@ class _TextFieldBottomSheetState extends State<TextFieldBottomSheet> {
                       setState(() {
                         _updateText = text;
                       });
+                      _controller.text = text;
                     },
                     onClear: () {
                       setState(() {
@@ -133,6 +138,8 @@ class _TextFieldBottomSheetState extends State<TextFieldBottomSheet> {
                     },
                     placeholder: widget.placeholder,
                     visibleTextLimit: widget.visibleTextLimit,
+                    formatInput: widget.formatInput,
+                    maxLength: widget.maxLength ?? 30,
                   ),
                 ],
               ),

--- a/lib/screens/send/fee_selection_screen.dart
+++ b/lib/screens/send/fee_selection_screen.dart
@@ -6,6 +6,7 @@ import 'package:coconut_wallet/model/send/fee_info.dart';
 import 'package:coconut_wallet/providers/connectivity_provider.dart';
 import 'package:coconut_wallet/screens/common/text_field_bottom_sheet.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
+import 'package:coconut_wallet/utils/text_field_filter_util.dart';
 import 'package:coconut_wallet/widgets/button/custom_underlined_button.dart';
 import 'package:coconut_wallet/widgets/card/send_fee_selection_item_card.dart';
 import 'package:coconut_wallet/widgets/contents/fiat_price.dart';
@@ -156,8 +157,14 @@ class _FeeSelectionScreenState extends State<FeeSelectionScreen> {
                                           onComplete: (text) {
                                             _onCustomFeeRateInput(text);
                                           },
-                                          keyboardType: TextInputType.number,
+                                          keyboardType:
+                                              const TextInputType.numberWithOptions(decimal: true),
                                           visibleTextLimit: false,
+                                          formatInput: (text) {
+                                            String finalText = filterDecimalInput(text, 2);
+                                            return finalText;
+                                          },
+                                          maxLength: 10,
                                         ),
                                       );
                                     },

--- a/lib/screens/send/fee_selection_screen.dart
+++ b/lib/screens/send/fee_selection_screen.dart
@@ -20,7 +20,7 @@ class FeeSelectionScreen extends StatefulWidget {
   static const String feeInfoField = 'feeInfo';
 
   final List<FeeInfoWithLevel> feeInfos;
-  final int Function(int satsPerVb) estimateFee;
+  final int Function(double satsPerVb) estimateFee;
   final int? networkMinimumFeeRate;
   final TransactionFeeLevel? selectedFeeLevel; // null인 경우 직접 입력한 경우
   final FeeInfo? customFeeInfo; // feeRate을 직접 입력한 경우
@@ -43,7 +43,7 @@ class _FeeSelectionScreenState extends State<FeeSelectionScreen> {
   static const int kMaxFeeLimit = 1000000;
   late int? _estimatedFee;
   bool? _isNetworkOn;
-  int? _customSatsPerVb;
+  double? _customSatsPerVb;
 
   TransactionFeeLevel? _selectedFeeLevel;
 
@@ -151,7 +151,8 @@ class _FeeSelectionScreenState extends State<FeeSelectionScreen> {
                                         isScrollControlled: true,
                                         builder: (context) => TextFieldBottomSheet(
                                           title: t.input_directly,
-                                          placeholder: t.text_field.enter_fee_as_natural_number,
+                                          placeholder:
+                                              t.text_field.enter_fee_with_two_decimal_places,
                                           onComplete: (text) {
                                             _onCustomFeeRateInput(text);
                                           },
@@ -208,7 +209,14 @@ class _FeeSelectionScreenState extends State<FeeSelectionScreen> {
       return;
     }
 
-    int customSatsPerVb = int.parse(input);
+    double customSatsPerVb;
+    try {
+      customSatsPerVb = double.parse(input.trim());
+    } catch (_) {
+      _customFeeController.clear();
+      return null;
+    }
+
     if (widget.networkMinimumFeeRate != null && customSatsPerVb < widget.networkMinimumFeeRate!) {
       CoconutToast.showToast(
           isVisibleIcon: true,

--- a/lib/screens/send/send_fee_selection_screen.dart
+++ b/lib/screens/send/send_fee_selection_screen.dart
@@ -14,7 +14,7 @@ import 'package:coconut_wallet/services/model/response/recommended_fee.dart';
 import 'package:coconut_wallet/styles.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/utils/fiat_util.dart';
-import 'package:coconut_wallet/utils/result.dart';
+import 'package:coconut_wallet/utils/text_field_filter_util.dart';
 import 'package:coconut_wallet/widgets/button/custom_underlined_button.dart';
 import 'package:coconut_wallet/widgets/card/send_fee_selection_item_card.dart';
 import 'package:coconut_wallet/widgets/contents/fiat_price.dart';
@@ -185,8 +185,14 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
                                           onComplete: (text) {
                                             _handleCustomFeeInput(text);
                                           },
-                                          keyboardType: TextInputType.number,
+                                          keyboardType:
+                                              const TextInputType.numberWithOptions(decimal: true),
                                           visibleTextLimit: false,
+                                          formatInput: (text) {
+                                            String finalText = filterDecimalInput(text, 2);
+                                            return finalText;
+                                          },
+                                          maxLength: 10,
                                         ),
                                       );
                                     },

--- a/lib/screens/send/send_fee_selection_screen.dart
+++ b/lib/screens/send/send_fee_selection_screen.dart
@@ -10,9 +10,11 @@ import 'package:coconut_wallet/providers/upbit_connect_model.dart';
 import 'package:coconut_wallet/providers/view_model/send/send_fee_selection_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/screens/common/text_field_bottom_sheet.dart';
+import 'package:coconut_wallet/services/model/response/recommended_fee.dart';
 import 'package:coconut_wallet/styles.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/utils/fiat_util.dart';
+import 'package:coconut_wallet/utils/result.dart';
 import 'package:coconut_wallet/widgets/button/custom_underlined_button.dart';
 import 'package:coconut_wallet/widgets/card/send_fee_selection_item_card.dart';
 import 'package:coconut_wallet/widgets/contents/fiat_price.dart';
@@ -81,13 +83,13 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
                 usePrimaryActiveColor: true,
                 nextButtonTitle: t.complete,
                 onNextPressed: () {
-                  int satsPerVb = _customSelected
+                  double finalFeeRate = _customSelected
                       ? _customFeeInfo!.satsPerVb!
                       : feeInfos
                           .firstWhere((element) => element.level == _selectedLevel)
                           .satsPerVb!;
 
-                  _viewModel.saveFinalSendInfo(_estimatedFee!, satsPerVb);
+                  _viewModel.saveFinalSendInfo(_estimatedFee!, finalFeeRate);
                   Navigator.pushNamed(context, '/send-confirm');
                 }),
             body: SafeArea(
@@ -178,7 +180,8 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
                                         isScrollControlled: true,
                                         builder: (context) => TextFieldBottomSheet(
                                           title: t.input_directly,
-                                          placeholder: t.text_field.enter_fee_as_natural_number,
+                                          placeholder:
+                                              t.text_field.enter_fee_with_two_decimal_places,
                                           onComplete: (text) {
                                             _handleCustomFeeInput(text);
                                           },
@@ -227,12 +230,12 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
   }
 
   bool _canGoNext() {
-    int? satsPerVb = _customSelected
+    double? finalFeeRate = _customSelected
         ? _customFeeInfo?.satsPerVb
         : feeInfos.firstWhere((element) => element.level == _selectedLevel).satsPerVb;
 
     return _viewModel.isNetworkOn &&
-        (satsPerVb != null && satsPerVb > 0) &&
+        (finalFeeRate != null && finalFeeRate > 0) &&
         _viewModel.isBalanceEnough(_estimatedFee) &&
         _estimatedFee != null &&
         _estimatedFee! < maxFeeLimit &&
@@ -244,21 +247,20 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
       return;
     }
 
-    int customSatsPerVb;
+    double customSatsPerVb;
     try {
-      customSatsPerVb = int.parse(input.trim());
-      if (_minimumSatsPerVb != null && customSatsPerVb < _minimumSatsPerVb!) {
-        CoconutToast.showToast(
-          isVisibleIcon: true,
-          context: context,
-          text: t.toast.min_fee(
-            minimum: _minimumSatsPerVb!,
-          ),
-        );
-        _customFeeController.clear();
-        return;
-      }
+      customSatsPerVb = double.parse(input.trim());
     } catch (_) {
+      _customFeeController.clear();
+      return;
+    }
+
+    if (_minimumSatsPerVb != null && customSatsPerVb < _minimumSatsPerVb!) {
+      CoconutToast.showToast(
+        isVisibleIcon: true,
+        context: context,
+        text: t.toast.min_fee(minimum: _minimumSatsPerVb!),
+      );
       _customFeeController.clear();
       return;
     }
@@ -348,19 +350,19 @@ class _SendFeeSelectionScreenState extends State<SendFeeSelectionScreen> {
   }
 
   Future<void> _setRecommendedFees() async {
-    var result = await _viewModel.nodeprovider.getRecommendedFees();
-    if (result.isFailure) {
+    final recommendedFeesResult = await _viewModel.nodeprovider.getRecommendedFees();
+    if (recommendedFeesResult.isFailure) {
       setState(() {
         _isRecommendedFeeFetchSuccess = false;
       });
       return;
     }
 
-    final recommendedFees = result.value;
+    final RecommendedFee recommendedFees = recommendedFeesResult.value;
 
-    feeInfos[0].satsPerVb = recommendedFees.fastestFee;
-    feeInfos[1].satsPerVb = recommendedFees.halfHourFee;
-    feeInfos[2].satsPerVb = recommendedFees.hourFee;
+    feeInfos[0].satsPerVb = recommendedFees.fastestFee.toDouble();
+    feeInfos[1].satsPerVb = recommendedFees.halfHourFee.toDouble();
+    feeInfos[2].satsPerVb = recommendedFees.hourFee.toDouble();
 
     setState(() => _minimumSatsPerVb = recommendedFees.minimumFee);
 

--- a/lib/screens/send/send_utxo_selection_screen.dart
+++ b/lib/screens/send/send_utxo_selection_screen.dart
@@ -633,7 +633,7 @@ class _SendUtxoSelectionScreenState extends State<SendUtxoSelectionScreen> {
                 customFeeSelected: viewModel.customFeeSelected,
                 sendAmount: viewModel.sendAmount,
                 estimatedFee: viewModel.estimatedFee,
-                satsPerVb: viewModel.satsPerVb,
+                satsPerVb: viewModel.satsPerVb?.toInt(),
                 change: viewModel.change,
               )),
           _buildTotalUtxoAmount(

--- a/lib/screens/wallet_detail/transaction_fee_bumping_screen.dart
+++ b/lib/screens/wallet_detail/transaction_fee_bumping_screen.dart
@@ -149,9 +149,9 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
                                       _buildRecommendFeeWidget(),
                                       CoconutLayout.spacing_300h,
                                       _buildCurrentMempoolFeesWidget(
-                                        viewModel.feeInfos[0].satsPerVb ?? 0,
-                                        viewModel.feeInfos[1].satsPerVb ?? 0,
-                                        viewModel.feeInfos[2].satsPerVb ?? 0,
+                                        viewModel.feeInfos[0].satsPerVb?.toInt() ?? 0,
+                                        viewModel.feeInfos[1].satsPerVb?.toInt() ?? 0,
+                                        viewModel.feeInfos[2].satsPerVb?.toInt() ?? 0,
                                       ),
                                     ] else if (viewModel.didFetchRecommendedFeesSuccessfully ==
                                         false)

--- a/lib/services/model/response/recommended_fee.dart
+++ b/lib/services/model/response/recommended_fee.dart
@@ -8,23 +8,40 @@ class RecommendedFee {
   RecommendedFee(
       this._fastestFee, this._halfHourFee, this._hourFee, this._economyFee, this._minimumFee);
 
-  get fastestFee => _fastestFee;
+  int get fastestFee => _fastestFee;
 
-  get halfHourFee => _halfHourFee;
+  int get halfHourFee => _halfHourFee;
 
-  get hourFee => _hourFee;
+  int get hourFee => _hourFee;
 
-  get economyFee => _economyFee;
+  int get economyFee => _economyFee;
 
-  get minimumFee => _minimumFee;
+  int get minimumFee => _minimumFee;
 
   factory RecommendedFee.fromJson(Map<String, dynamic> json) {
-    return RecommendedFee(
-      json['fastestFee'] as int,
-      json['halfHourFee'] as int,
-      json['hourFee'] as int,
-      json['economyFee'] as int,
-      json['minimumFee'] as int,
-    );
+    int _parseIntSafely(dynamic value, String fieldName) {
+      if (value == null) {
+        throw FormatException('$fieldName is null');
+      }
+      if (value is int) {
+        return value;
+      }
+      if (value is String) {
+        return int.parse(value);
+      }
+      throw FormatException('$fieldName has invalid type: ${value.runtimeType}');
+    }
+
+    try {
+      return RecommendedFee(
+        _parseIntSafely(json['fastestFee'], 'fastestFee'),
+        _parseIntSafely(json['halfHourFee'], 'halfHourFee'),
+        _parseIntSafely(json['hourFee'], 'hourFee'),
+        _parseIntSafely(json['economyFee'], 'economyFee'),
+        _parseIntSafely(json['minimumFee'], 'minimumFee'),
+      );
+    } catch (e) {
+      throw FormatException('Failed to parse RecommendedFee: $e');
+    }
   }
 }

--- a/lib/utils/transaction_util.dart
+++ b/lib/utils/transaction_util.dart
@@ -79,7 +79,7 @@ class TransactionUtil {
 
   /// confirmed uxto만 사용 가능
   static List<UtxoState> selectOptimalUtxos(
-      List<UtxoState> utxoList, int amount, int feeRate, AddressType addressType) {
+      List<UtxoState> utxoList, int amount, double feeRate, AddressType addressType) {
     int baseVbyte = 72; // 0 input, 2 output
     int vBytePerInput = 0;
     int dust = _getDustThreshold(addressType);
@@ -105,7 +105,7 @@ class TransactionUtil {
         totalAmount += utxo.amount;
         selectedUtxos.add(utxo);
         totalVbyte += vBytePerInput;
-        finalFee = totalVbyte * feeRate;
+        finalFee = (totalVbyte * feeRate).ceil();
         if (totalAmount >= amount + finalFee + dust) {
           return;
         }

--- a/lib/widgets/card/send_fee_selection_item_card.dart
+++ b/lib/widgets/card/send_fee_selection_item_card.dart
@@ -60,7 +60,7 @@ class FeeSelectionItemCard extends StatelessWidget {
                           if (feeInfo.satsPerVb != null)
                             TextSpan(
                               text:
-                                  " (${feeInfo.satsPerVb} ${feeInfo.satsPerVb == 1 ? 'sat' : 'sats'}/vb)",
+                                  " (${feeInfo.satsPerVb?.toInt()} ${feeInfo.satsPerVb == 1 ? 'sat' : 'sats'}/vb)",
                             ),
                         ],
                       ),

--- a/lib/widgets/textfield/custom_limit_text_field.dart
+++ b/lib/widgets/textfield/custom_limit_text_field.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
+/// TODO: CoconutTextField를 사용하는 방식으로 변경 검토
 /// [CustomLimitTextField] : 최대입력 글자를 입력하고 TextFiled 아래에 표기하는 위젯
 /// (controller.text.length/maxLength) = (1/30)
 class CustomLimitTextField extends StatelessWidget {
@@ -17,6 +18,7 @@ class CustomLimitTextField extends StatelessWidget {
   final TextInputType keyboardType;
   final String placeholder;
   final bool visibleTextLimit;
+  final String Function(String)? formatInput;
 
   const CustomLimitTextField(
       {super.key,
@@ -29,7 +31,8 @@ class CustomLimitTextField extends StatelessWidget {
       this.prefix,
       this.keyboardType = TextInputType.text,
       this.placeholder = '',
-      this.visibleTextLimit = true});
+      this.visibleTextLimit = true,
+      this.formatInput});
 
   @override
   Widget build(BuildContext context) {
@@ -62,7 +65,7 @@ class CustomLimitTextField extends StatelessWidget {
                 onClear();
               },
               child: Container(
-                margin: const EdgeInsets.only(right: 13),
+                padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 13),
                 child: SvgPicture.asset(
                   'assets/svg/text-field-clear.svg',
                   colorFilter: const ColorFilter.mode(
@@ -75,15 +78,15 @@ class CustomLimitTextField extends StatelessWidget {
               ),
             ),
             onChanged: (text) {
-              if (text.runes.length > maxLength) {
-                text = String.fromCharCodes(text.runes.take(maxLength));
-                controller.text = text;
+              String formattedText = formatInput?.call(text) ?? text;
+              if (formattedText.runes.length > maxLength) {
+                formattedText = String.fromCharCodes(formattedText.runes.take(maxLength));
+                controller.text = formattedText;
               }
-              onChanged(text);
+              onChanged(formattedText);
             },
           ),
         ),
-
         // 글자 수 표시
         Visibility(
           visible: visibleTextLimit,


### PR DESCRIPTION
## 1. 변경 사항
<img width="389" alt="스크린샷 2025-06-11 오후 3 12 19" src="https://github.com/user-attachments/assets/f485f420-e42d-4581-8a2a-e3fe4844c757" />

### 1-1. 변경 화면

1) 보내기 과정에서 수수료 설정 화면 - 직접 입력
2) 보내기 과정에서 UTXO 선택 전송 화면 - 수수료 변경 - 직접 입력

### 1-2. 변경 내용

1) 소수점 2자리까지만 입력되도록 입력값 제어
2) 최대 10자리까지만 입력되도록 입력값 제어
3) 소숫점으로 입력된 수수료율로 예상 수수료 계산
4) 직접 입력 TextField placeholder 변경

## 2. 테스트 방법
1) 1-1에 명시한 화면에서 입력값 제어가 제대로 되고, 입력 값으로 예상 수수료 계산/설정이 잘 되는지 확인

## 3. 이슈 번호
#294 