### PR TITLE
[308] 용어설명 화면의 DraggableScrollableSheet 닫힘 중단 현상

### DIFF
--- a/lib/widgets/overlays/common_bottom_sheets.dart
+++ b/lib/widgets/overlays/common_bottom_sheets.dart
@@ -158,9 +158,11 @@ class CommonBottomSheets {
     bool snap = true,
     double initialChildSize = 1,
     double maxChildSize = 1,
-    double minChildSize = 0.9,
+    double minChildSize = 0.9001,
     double maxHeight = 0.9,
   }) async {
+    var adjustedMinChildSize = minChildSize;
+    if (maxHeight >= adjustedMinChildSize) adjustedMinChildSize = maxHeight + 0.0001;
     return showModalBottomSheet<T>(
         context: context,
         builder: (context) {
@@ -169,7 +171,7 @@ class CommonBottomSheets {
             snap: snap,
             initialChildSize: initialChildSize,
             maxChildSize: maxChildSize,
-            minChildSize: minChildSize,
+            minChildSize: adjustedMinChildSize,
             builder: (_, controller) {
               return SingleChildScrollView(
                 // physics: const ClampingScrollPhysics(),


### PR DESCRIPTION
## 1. 변경 사항
DraggableScrollableSheet의 minChildSize 수정

### 1-1. 변경 화면

1) 용어집 - 상세 설명 화면

### 1-2. 변경 내용

DraggableScrollableSheet에서 snap이 true면 드래그하다가 손을 떼면 가까운 snap 위치로 자동 이동합니다.
만약 minChildSize가 maxHeight 이하면, 손을 뗐을 때 최소 크기로 유지될 수 있습니다.

minChildSize
- DraggableScrollableSheet의 높이를 비율(0.0 ~ 1.0) 로 지정합니다.

maxHeight
- showModalBottomSheet의 constraints에서 사용하는 값이며, 실제 최대 높이 제한입니다.

minChildSize 값을 maxHeight(0.9) 보다 크게 설정하여 일정량의 스크롤을 하고 손을 떼어도 maxHeight값으로 고정되지 않고 완전히 닫히도록 개선했습니다.

## 2. 이슈 번호
#308  