### PR TITLE
[313] 주소 스캔 화면 - 포그라운드로 복귀 시 붙여넣기 활성화 되도록 개선

### DIFF
--- a/lib/providers/view_model/send/send_address_view_model.dart
+++ b/lib/providers/view_model/send/send_address_view_model.dart
@@ -32,10 +32,10 @@ class SendAddressViewModel extends ChangeNotifier {
       try {
         await validateAddress(clipboardText);
         _address = clipboardText;
-        notifyListeners();
       } catch (_) {
-        // ignore
+        _address = null;
       }
+      notifyListeners();
     }
   }
 

--- a/lib/providers/view_model/send/send_address_view_model.dart
+++ b/lib/providers/view_model/send/send_address_view_model.dart
@@ -25,7 +25,7 @@ class SendAddressViewModel extends ChangeNotifier {
     _sendInfoProvider.clear();
   }
 
-  void loadDataFromClipboardIfValid() async {
+  void loadDataFromClipboard() async {
     ClipboardData? data = await Clipboard.getData(Clipboard.kTextPlain);
     final clipboardText = data?.text ?? '';
     if (clipboardText.isNotEmpty) {

--- a/lib/screens/send/send_address_screen.dart
+++ b/lib/screens/send/send_address_screen.dart
@@ -121,14 +121,14 @@ class _SendAddressScreenState extends State<SendAddressScreen> with WidgetsBindi
     _viewModel.clearSendInfoProvider();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _viewModel.loadDataFromClipboardIfValid();
+      _viewModel.loadDataFromClipboard();
     });
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
-      _viewModel.loadDataFromClipboardIfValid();
+      _viewModel.loadDataFromClipboard();
     }
   }
 

--- a/lib/screens/send/send_address_screen.dart
+++ b/lib/screens/send/send_address_screen.dart
@@ -24,7 +24,7 @@ class SendAddressScreen extends StatefulWidget {
   State<SendAddressScreen> createState() => _SendAddressScreenState();
 }
 
-class _SendAddressScreenState extends State<SendAddressScreen> {
+class _SendAddressScreenState extends State<SendAddressScreen> with WidgetsBindingObserver {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
   Barcode? result;
   QRViewController? controller;
@@ -105,6 +105,7 @@ class _SendAddressScreenState extends State<SendAddressScreen> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     controller?.dispose();
     super.dispose();
   }
@@ -112,6 +113,7 @@ class _SendAddressScreenState extends State<SendAddressScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _viewModel = SendAddressViewModel(
         Provider.of<SendInfoProvider>(context, listen: false),
         Provider.of<ConnectivityProvider>(context, listen: false).isNetworkOn,
@@ -121,6 +123,13 @@ class _SendAddressScreenState extends State<SendAddressScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _viewModel.loadDataFromClipboardIfValid();
     });
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _viewModel.loadDataFromClipboardIfValid();
+    }
   }
 
   // In order to get hot reload to work we need to pause the camera if the platform


### PR DESCRIPTION
## 1. 변경 사항
<table>
<tr>
<td>
<img width="150" src="https://github.com/user-attachments/assets/5126dce9-922a-48cc-acae-65392b355981" />
</td>
</tr>
</table>

### 1-1. 변경 화면

1) 보내기 - 주소 스캔 화면

### 1-2. 변경 내용

1) 라이프사이클 변경될 때 마다 클립보드에서 복사된 내용 가져오도록 개선
2) 메서드명 변경: loadDataFromClipboardIfValid -> loadDataFromClipboard


## 2. 테스트 방법
1) 클립보드에 주소 복사를 하지 않은 상태에서 보내기 - 주소 스캔 화면에 진입합니다.
2) 백그라운드로 전환해 정상적인 주소를 복사합니다.
3) 다시 앱의 포그라운드로 들어와 '붙여넣기'버튼이 활성화 되는지 확인합니다.

## 3. 이슈 번호
#313 