### PR TITLE
[318] 특정 주소 클립보드 복사 - 주소 스캔/붙여넣기 화면 에러

### DIFF
--- a/lib/utils/address_util.dart
+++ b/lib/utils/address_util.dart
@@ -1,0 +1,4 @@
+String shortenAddress(String address, {int head = 8, int tail = 8}) {
+  if (address.length <= head + tail) return address;
+  return '${address.substring(0, head)}...${address.substring(address.length - tail)}';
+}

--- a/lib/widgets/body/send_address/send_address_body.dart
+++ b/lib/widgets/body/send_address/send_address_body.dart
@@ -83,7 +83,7 @@ class SendAddressBody extends StatelessWidget {
                             children: [
                                 TextSpan(
                                     text:
-                                        '${address?.substring(0, 10)}...${address?.substring(35)}',
+                                        '${address!.substring(0, 10)}...${address!.substring(address!.length - 10)}',
                                     style: TextStyle(
                                         fontFamily: CustomFonts.number.getFontFamily,
                                         fontWeight: FontWeight.bold)),

--- a/lib/widgets/body/send_address/send_address_body.dart
+++ b/lib/widgets/body/send_address/send_address_body.dart
@@ -42,7 +42,8 @@ class SendAddressBody extends StatelessWidget {
       Positioned(
           left: 0,
           right: 0,
-          top: -110, // Adjust this value to move the QRView up or down
+          top: -110,
+          // Adjust this value to move the QRView up or down
           height: MediaQuery.of(context).size.height +
               MediaQuery.of(context).padding.top +
               MediaQuery.of(context).padding.bottom,
@@ -82,8 +83,9 @@ class SendAddressBody extends StatelessWidget {
                             style: Styles.label.merge(const TextStyle(color: MyColors.darkgrey)),
                             children: [
                                 TextSpan(
-                                    text:
-                                        '${address!.substring(0, 10)}...${address!.substring(address!.length - 10)}',
+                                    text: address!.length > 20
+                                        ? '${address!.substring(0, 10)}...${address!.substring(address!.length - 10)}'
+                                        : address!,
                                     style: TextStyle(
                                         fontFamily: CustomFonts.number.getFontFamily,
                                         fontWeight: FontWeight.bold)),

--- a/lib/widgets/body/send_address/send_address_body.dart
+++ b/lib/widgets/body/send_address/send_address_body.dart
@@ -1,6 +1,7 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/styles.dart';
+import 'package:coconut_wallet/utils/address_util.dart';
 import 'package:flutter/material.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 
@@ -83,9 +84,7 @@ class SendAddressBody extends StatelessWidget {
                             style: Styles.label.merge(const TextStyle(color: MyColors.darkgrey)),
                             children: [
                                 TextSpan(
-                                    text: address!.length > 16
-                                        ? '${address!.substring(0, 8)}...${address!.substring(address!.length - 8)}'
-                                        : address!,
+                                    text: shortenAddress(address!),
                                     style: TextStyle(
                                         fontFamily: CustomFonts.number.getFontFamily,
                                         fontWeight: FontWeight.bold)),

--- a/lib/widgets/body/send_address/send_address_body.dart
+++ b/lib/widgets/body/send_address/send_address_body.dart
@@ -83,8 +83,8 @@ class SendAddressBody extends StatelessWidget {
                             style: Styles.label.merge(const TextStyle(color: MyColors.darkgrey)),
                             children: [
                                 TextSpan(
-                                    text: address!.length > 20
-                                        ? '${address!.substring(0, 10)}...${address!.substring(address!.length - 10)}'
+                                    text: address!.length > 16
+                                        ? '${address!.substring(0, 8)}...${address!.substring(address!.length - 8)}'
                                         : address!,
                                     style: TextStyle(
                                         fontFamily: CustomFonts.number.getFontFamily,


### PR DESCRIPTION
### 변경사항
 - 비트코인 주소 표현 형식 수정(앞 10글자 + ... + 뒤 10글자) 

### 테스트 방법
1. 어플 실행하여 테스트

### 테스트 시나리오
1. 지갑 리스트 - 지갑 디테일 - 보내기 화면에서 '주소 ~ 붙여넣기' 버튼 확인

TC: 1BviRJRgcoqkN4Z115o7R1XgKo6QvzaJQp

#318 