### PR TITLE
bech32 주소 대문자 허용

### DIFF
--- a/lib/providers/view_model/send/send_address_view_model.dart
+++ b/lib/providers/view_model/send/send_address_view_model.dart
@@ -31,7 +31,7 @@ class SendAddressViewModel extends ChangeNotifier {
     if (clipboardText.isNotEmpty) {
       try {
         await validateAddress(clipboardText);
-        _address = clipboardText;
+        _address = _isBech32(clipboardText) ? clipboardText.toLowerCase() : clipboardText;
       } catch (_) {
         _address = null;
       }
@@ -41,7 +41,7 @@ class SendAddressViewModel extends ChangeNotifier {
 
   void saveWalletIdAndRecipientAddress(int id, String address) {
     _sendInfoProvider.setWalletId(id);
-    _sendInfoProvider.setRecipientAddress(address);
+    _sendInfoProvider.setRecipientAddress(_isBech32(address) ? address.toLowerCase() : address);
   }
 
   void setIsNetworkOn(bool? isNetworkOn) {
@@ -49,30 +49,40 @@ class SendAddressViewModel extends ChangeNotifier {
   }
 
   Future<void> validateAddress(String recipient) async {
-    if (recipient.isEmpty || recipient.length < 26) {
+    if (recipient.isEmpty) {
+      throw invalidAddressMessage;
+    }
+
+    final normalized = recipient.toLowerCase();
+
+    // Bech32m(T2R) 주소 최대 62자
+    if (normalized.length < 26 || normalized.length > 62) {
       throw invalidAddressMessage;
     }
 
     if (NetworkType.currentNetworkType == NetworkType.testnet) {
-      if (recipient.startsWith('1') || recipient.startsWith('3') || recipient.startsWith('bc1')) {
+      if (normalized.startsWith('1') ||
+          normalized.startsWith('3') ||
+          normalized.startsWith('bc1')) {
         throw noTestnetAddressMessage;
       }
     } else if (NetworkType.currentNetworkType == NetworkType.mainnet) {
-      if (recipient.startsWith('m') ||
-          recipient.startsWith('n') ||
-          recipient.startsWith('2') ||
-          recipient.startsWith('tb1')) {
+      if (normalized.startsWith('m') ||
+          normalized.startsWith('n') ||
+          normalized.startsWith('2') ||
+          normalized.startsWith('tb1')) {
         throw noMainnetAddressMessage;
       }
     } else if (NetworkType.currentNetworkType == NetworkType.regtest) {
-      if (!recipient.startsWith('bcrt1')) {
+      if (!normalized.startsWith('bcrt1')) {
         throw noRegtestnetAddressMessage;
       }
     }
 
     bool result = false;
     try {
-      result = WalletUtility.validateAddress(recipient);
+      final addressForValidation = _isBech32(normalized) ? normalized : recipient;
+      result = WalletUtility.validateAddress(addressForValidation);
     } catch (e) {
       throw invalidAddressMessage;
     }
@@ -82,6 +92,13 @@ class SendAddressViewModel extends ChangeNotifier {
     }
   }
 
+  bool _isBech32(String address) {
+    final normalizedAddress = address.toLowerCase();
+    return normalizedAddress.startsWith('bc1') ||
+        normalizedAddress.startsWith('tb1') ||
+        normalizedAddress.startsWith('bcrt1');
+  }
+
   /// --- batch transaction
   bool isSendAmountValid(int walletId, int totalSendAmount) {
     return _walletProvider.getWalletBalance(walletId).confirmed > totalSendAmount;
@@ -89,6 +106,12 @@ class SendAddressViewModel extends ChangeNotifier {
 
   void saveWalletIdAndBatchRecipients(int id, Map<String, double> recipients) {
     _sendInfoProvider.setWalletId(id);
-    _sendInfoProvider.setRecipientsForBatch(recipients);
+
+    final normalizedRecipients = <String, double>{};
+    for (final entry in recipients.entries) {
+      final address = _isBech32(entry.key) ? entry.key.toLowerCase() : entry.key;
+      normalizedRecipients[address] = entry.value;
+    }
+    _sendInfoProvider.setRecipientsForBatch(normalizedRecipients);
   }
 }

--- a/test/view_model/send_address_view_model_test.dart
+++ b/test/view_model/send_address_view_model_test.dart
@@ -1,0 +1,191 @@
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/providers/send_info_provider.dart';
+import 'package:coconut_wallet/providers/view_model/send/send_address_view_model.dart';
+import 'package:coconut_wallet/providers/wallet_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+
+@GenerateMocks([SendInfoProvider, WalletProvider])
+// flutter pub run build_runner build
+// 또는
+// flutter pub run build_runner build --delete-conflicting-outputs
+// 수행 후 테스트 코드 실행
+import 'send_address_view_model_test.mocks.dart';
+
+void main() {
+  late SendAddressViewModel viewModel;
+  late MockSendInfoProvider mockSendInfoProvider;
+  late MockWalletProvider mockWalletProvider;
+
+  setUp(() {
+    mockSendInfoProvider = MockSendInfoProvider();
+    mockWalletProvider = MockWalletProvider();
+    viewModel = SendAddressViewModel(mockSendInfoProvider, true, mockWalletProvider);
+  });
+
+  group('validateAddress', () {
+    test('빈 주소는 에러를 발생시켜야 함', () async {
+      expect(
+        () => viewModel.validateAddress(''),
+        throwsA(viewModel.invalidAddressMessage),
+      );
+    });
+
+    test('잘못된 길이의 bech32 주소는 에러를 발생시켜야 함', () async {
+      expect(
+        () => viewModel.validateAddress('bc1q'),
+        throwsA(viewModel.invalidAddressMessage),
+      );
+    });
+
+    test('잘못된 길이의 legacy 주소는 에러를 발생시켜야 함 - 26자 미만', () async {
+      expect(
+        () => viewModel.validateAddress('1A1zP1eP5Q'),
+        throwsA(viewModel.invalidAddressMessage),
+      );
+    });
+
+    test('잘못된 길이의 legacy 주소는 에러를 발생시켜야 함 - 62자 초과', () async {
+      expect(
+        () => viewModel.validateAddress(
+            '1ThisAddressIsWayTooLongToBeValidOnBitcoinNetworkIfT2RAddressIsInsertedItWillBeOver62Characters'),
+        throwsA(viewModel.invalidAddressMessage),
+      );
+    });
+
+    group('testnet 네트워크', () {
+      setUp(() {
+        NetworkType.setNetworkType(NetworkType.testnet);
+      });
+
+      test('mainnet 주소는 에러를 발생시켜야 함', () async {
+        expect(
+          () => viewModel.validateAddress('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'),
+          throwsA(viewModel.noTestnetAddressMessage),
+        );
+        expect(
+          () => viewModel.validateAddress('3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX'),
+          throwsA(viewModel.noTestnetAddressMessage),
+        );
+        expect(
+          () => viewModel.validateAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'),
+          throwsA(viewModel.noTestnetAddressMessage),
+        );
+      });
+      test('유효한 testnet 주소는 검증을 통과해야 함 - m 주소', () async {
+        expect(
+          () => viewModel.validateAddress('mr3MGrB8CpqEkJAT8XaenEcQxXvG6FEGKa'),
+          returnsNormally,
+        );
+      });
+
+      test('유효한 testnet 주소는 검증을 통과해야 함 - n 주소', () async {
+        expect(
+          () => viewModel.validateAddress('n4Jp6MDWWyz3naY7ydyFua76fNvH3KYCMu'),
+          returnsNormally,
+        );
+      });
+
+      test('유효한 testnet 주소는 검증을 통과해야 함 - 2 주소', () async {
+        expect(
+          () => viewModel.validateAddress('2N2i65CqwXpacR5HRDCnKyoK7VS1jf2Kj37'),
+          returnsNormally,
+        );
+      });
+
+      test('유효한 testnet 주소는 검증을 통과해야 함 - tb1 ', () async {
+        expect(
+          () => viewModel.validateAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'),
+          returnsNormally,
+        );
+      });
+
+      test('유효한 testnet 주소는 검증을 통과해야 함 - TB1', () async {
+        expect(
+          () => viewModel.validateAddress('TB1Q3SQEUFQWJ853G2TLPFN8QZ3YTUKE3K9T2YT67T'),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('mainnet 네트워크', () {
+      setUp(() {
+        NetworkType.setNetworkType(NetworkType.mainnet);
+      });
+
+      test('testnet 주소는 에러를 발생시켜야 함', () async {
+        expect(
+          () => viewModel.validateAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'),
+          throwsA(viewModel.noMainnetAddressMessage),
+        );
+        expect(
+          () => viewModel.validateAddress('mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn'),
+          throwsA(viewModel.noMainnetAddressMessage),
+        );
+        expect(
+          () => viewModel.validateAddress('2MzQwSSnBHWHqSAqtTVQ6v47Xtais7Ja7Vb'),
+          throwsA(viewModel.noMainnetAddressMessage),
+        );
+      });
+
+      test('유효한 mainnet 주소는 검증을 통과해야 함 - 1 주소', () async {
+        expect(
+          () => viewModel.validateAddress('1MFwsZ6Z7x9qDmDZcJeRY44mkr2kBJydv4'),
+          returnsNormally,
+        );
+      });
+
+      test('유효한 mainnet 주소는 검증을 통과해야 함 - 3 주소', () async {
+        expect(
+          () => viewModel.validateAddress('3GBTzpjL56T3wiCjtF6tdzoyyJ3FkarPjg'),
+          returnsNormally,
+        );
+      });
+
+      test('유효한 mainnet 주소는 검증을 통과해야 함 - bc1', () async {
+        expect(
+          () => viewModel.validateAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'),
+          returnsNormally,
+        );
+      });
+
+      test('유효한 mainnet 주소는 검증을 통과해야 함 - BC1', () async {
+        expect(
+          () => viewModel.validateAddress('BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4'),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('regtest 네트워크', () {
+      setUp(() {
+        NetworkType.setNetworkType(NetworkType.regtest);
+      });
+
+      test('regtest가 아닌 주소는 에러를 발생시켜야 함', () async {
+        expect(
+          () => viewModel.validateAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'),
+          throwsA(viewModel.noRegtestnetAddressMessage),
+        );
+        expect(
+          () => viewModel.validateAddress('tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'),
+          throwsA(viewModel.noRegtestnetAddressMessage),
+        );
+      });
+
+      test('유효한 regtest 주소는 검증을 통과해야 함 - bcrt1 주소', () async {
+        expect(
+          () => viewModel.validateAddress('bcrt1qz9edcv2r9wh5rjfyj2nvvms6uxyqctnu70ecaq'),
+          returnsNormally,
+        );
+      });
+
+      test('유효한 regtest 주소는 검증을 통과해야 함 - BCRT1', () async {
+        expect(
+          () => viewModel.validateAddress('BCRT1QZ9EDCV2R9WH5RJFYJ2NVVMS6UXYQCTNU70ECAQ'),
+          returnsNormally,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
### 변경 사항

`send_address_view_model.dart` 수정
- bech32 대문자 입력되는 경우, 소문자로 변경하여 lib 검증 함수 호출 / 라이브러리 수정없이 동작하도록 소문자로 변경하여 sendInfoProvider에 저장

`send_address_view_model_test.dart` 추가
- regtest인 경우 코코넛 네트워크 안에서만 유효하므로, 기존 코드대로 m,n 주소 검증하지 않음

```
flutter pub run build_runner build --delete-conflicting-outputs
```
```
flutter test ./test/view_model/send_address_view_model_test.dart
```