### PR TITLE
[321] 주소 검색 화면 결과 문구 상단 고정

### DIFF
--- a/lib/screens/wallet_detail/address_search_screen.dart
+++ b/lib/screens/wallet_detail/address_search_screen.dart
@@ -173,10 +173,13 @@ class _AddressSearchScreenState extends State<AddressSearchScreen> {
                           maxLines: 1,
                           padding: const EdgeInsets.only(),
                           height: Sizes.size40,
-                          prefix: IconButton(
-                            onPressed: () {},
-                            icon: const Icon(Icons.search_rounded, color: CoconutColors.gray600),
-                            iconSize: Sizes.size22,
+                          prefix: const IgnorePointer(
+                            ignoring: true,
+                            child: IconButton(
+                              onPressed: null,
+                              icon: Icon(Icons.search_rounded, color: CoconutColors.gray600),
+                              iconSize: Sizes.size22,
+                            ),
                           ),
                           suffix: IconButton(
                             iconSize: 14,
@@ -210,38 +213,46 @@ class _AddressSearchScreenState extends State<AddressSearchScreen> {
                     body: canShowResult
                         ? Padding(
                             padding: const EdgeInsets.symmetric(horizontal: Sizes.size16),
-                            child: SingleChildScrollView(
-                              child: Consumer<AddressSearchViewModel>(
-                                  builder: (context, viewModel, child) {
-                                return Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    CoconutLayout.spacing_100h,
-                                    Text(
-                                      "'${_addressController.text}' ${t.address_search_screen.search_result} ${viewModel.searchedAddressLength > 0 ? t.address_search_screen.address_n_found(n: viewModel.searchedAddressLength) : ""}",
-                                      style:
-                                          CoconutTypography.body3_12.setColor(CoconutColors.white),
-                                    ),
-                                    CoconutLayout.spacing_1000h,
-                                    if (viewModel.receivingAddressList.isNotEmpty) ...[
-                                      Text(t.address_search_screen.receiving_address,
-                                          style: CoconutTypography.body2_14_Bold
-                                              .setColor(CoconutColors.white)),
-                                      CoconutLayout.spacing_300h,
-                                      _buildWalletAddressList(viewModel.receivingAddressList),
-                                      CoconutLayout.spacing_1000h,
-                                    ],
-                                    if (viewModel.changeAddressList.isNotEmpty) ...[
-                                      Text(t.address_search_screen.change_address,
-                                          style: CoconutTypography.body2_14_Bold
-                                              .setColor(CoconutColors.white)),
-                                      CoconutLayout.spacing_300h,
-                                      _buildWalletAddressList(viewModel.changeAddressList),
-                                    ],
-                                    if (viewModel.searchedAddressLength == 0) _buildNotFoundView(),
-                                  ],
-                                );
-                              }),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                CoconutLayout.spacing_200h,
+                                Text(
+                                  "'${_addressController.text}' ${t.address_search_screen.search_result} ${viewModel.searchedAddressLength > 0 ? t.address_search_screen.address_n_found(n: viewModel.searchedAddressLength) : ""}",
+                                  style: CoconutTypography.body3_12.setColor(CoconutColors.white),
+                                ),
+                                CoconutLayout.spacing_400h,
+                                Expanded(
+                                  child: SingleChildScrollView(
+                                    child: Consumer<AddressSearchViewModel>(
+                                        builder: (context, viewModel, child) {
+                                      return Column(
+                                        crossAxisAlignment: CrossAxisAlignment.start,
+                                        children: [
+                                          CoconutLayout.spacing_500h,
+                                          if (viewModel.receivingAddressList.isNotEmpty) ...[
+                                            Text(t.address_search_screen.receiving_address,
+                                                style: CoconutTypography.body2_14_Bold
+                                                    .setColor(CoconutColors.white)),
+                                            CoconutLayout.spacing_300h,
+                                            _buildWalletAddressList(viewModel.receivingAddressList),
+                                            CoconutLayout.spacing_1000h,
+                                          ],
+                                          if (viewModel.changeAddressList.isNotEmpty) ...[
+                                            Text(t.address_search_screen.change_address,
+                                                style: CoconutTypography.body2_14_Bold
+                                                    .setColor(CoconutColors.white)),
+                                            CoconutLayout.spacing_300h,
+                                            _buildWalletAddressList(viewModel.changeAddressList),
+                                          ],
+                                          if (viewModel.searchedAddressLength == 0)
+                                            _buildNotFoundView(),
+                                        ],
+                                      );
+                                    }),
+                                  ),
+                                ),
+                              ],
                             ),
                           )
                         : Container()),

--- a/lib/screens/wallet_detail/address_search_screen.dart
+++ b/lib/screens/wallet_detail/address_search_screen.dart
@@ -221,7 +221,7 @@ class _AddressSearchScreenState extends State<AddressSearchScreen> {
                                   "'${_addressController.text}' ${t.address_search_screen.search_result} ${viewModel.searchedAddressLength > 0 ? t.address_search_screen.address_n_found(n: viewModel.searchedAddressLength) : ""}",
                                   style: CoconutTypography.body3_12.setColor(CoconutColors.white),
                                 ),
-                                CoconutLayout.spacing_400h,
+                                CoconutLayout.spacing_200h,
                                 Expanded(
                                   child: SingleChildScrollView(
                                     child: Consumer<AddressSearchViewModel>(
@@ -229,7 +229,7 @@ class _AddressSearchScreenState extends State<AddressSearchScreen> {
                                       return Column(
                                         crossAxisAlignment: CrossAxisAlignment.start,
                                         children: [
-                                          CoconutLayout.spacing_500h,
+                                          CoconutLayout.spacing_700h,
                                           if (viewModel.receivingAddressList.isNotEmpty) ...[
                                             Text(t.address_search_screen.receiving_address,
                                                 style: CoconutTypography.body2_14_Bold


### PR DESCRIPTION
### 변경사항
style(address_search_screen): 검색 결과 문구를 상단에 고정하도록 변경, 돋보기 아이콘 클릭 이벤트 제거

### 테스트 방법
1. 어플 실행하여 테스트

### 테스트 시나리오
1. 지갑 디테일 화면 - 상단에 지갑 이름 클릭 - 지갑 정보 화면에서 전체 주소 보기 클릭 - 주소 리스트 화면 우측 상단 돋보기 버튼 클릭 - 주소 검색 화면에서 테스트 진행
2. 초기 상태에서 상단 문구가 보이지 않아야 합니다. 
3. 결과가 있는 경우: 'xx' 검색 결과 주소 n개를 찾았어요 / 결과가 없는 경우: 'xx' 검색 결과 문구가 상단에 고정되어야 합니다. 
4. (추가 수정사항) 검색창 돋보기 아이콘 클릭시 ripple 효과 제거되었습니다.

<image src="https://github.com/user-attachments/assets/4ecfc0d0-a9a5-4005-b696-e4f7251ce542" width="250px" />
<image src="https://github.com/user-attachments/assets/bdc8da0b-7737-444d-b700-0b0177573ae8" width="250px" />

#321 