### PR TITLE
[333] 지갑 주소 인덱스가 1부터 나오는 현상

### DIFF
--- a/lib/providers/view_model/wallet_detail/address_list_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/address_list_view_model.dart
@@ -39,14 +39,14 @@ class AddressListViewModel extends ChangeNotifier {
         "[address_list_view_model.initializeAddressList] firstCount = $firstCount, showOnlyUnusedAddresses = $showOnlyUnusedAddresses");
     _receivingAddressList = await getWalletAddressList(
       _walletBaseItem!,
-      0,
+      -1,
       firstCount,
       false,
       showOnlyUnusedAddresses,
     );
     _changeAddressList = await getWalletAddressList(
       _walletBaseItem!,
-      0,
+      -1,
       firstCount,
       true,
       showOnlyUnusedAddresses,


### PR DESCRIPTION
### 변경사항
fix(address_list_view_model): 월렛 주소 인덱스가 0부터 나오도록 수정

### 테스트 방법
어플 실행하여 테스트

### 테스트 시나리오
1. 지갑 리스트 화면 지갑 클릭 - 지갑 디테일 화면 상단에 지갑 정보 클릭 - 전체 주소 보기 클릭 - 주소 인덱스가 정상적으로 나오는지 확인

#333 