### PR TITLE
[299] 트랜잭션 메모, Realm 기타

### DIFF
--- a/integration_test/integration_test_utils.dart
+++ b/integration_test/integration_test_utils.dart
@@ -98,7 +98,7 @@ Future<void> skipTutorial(bool skip) async {
 Future<void> savePinCode(String pinCode) async {
   final SecureStorageRepository storageService = SecureStorageRepository();
   final SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
-  await storageService.write(key: kSecureStoragePinKey, value: hashString(pinCode));
+  await storageService.write(key: kSecureStoragePinKey, value: generateHashString(pinCode));
   await sharedPreferences.setBool(SharedPrefKeys.kIsSetPin, true);
 }
 

--- a/lib/constants/realm_constants.dart
+++ b/lib/constants/realm_constants.dart
@@ -1,1 +1,1 @@
-const int kRealmVersion = 4;
+const int kRealmVersion = 5;

--- a/lib/model/node/cpfp_history.dart
+++ b/lib/model/node/cpfp_history.dart
@@ -1,3 +1,5 @@
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
+
 class CpfpHistory {
   final int _id;
   final int walletId;
@@ -16,9 +18,5 @@ class CpfpHistory {
     required this.originalFee,
     required this.newFee,
     required this.timestamp,
-  }) : _id = Object.hash(
-          walletId,
-          parentTransactionHash,
-          childTransactionHash,
-        );
+  }) : _id = getCpfpHistoryId(walletId, parentTransactionHash, childTransactionHash);
 }

--- a/lib/model/node/rbf_history.dart
+++ b/lib/model/node/rbf_history.dart
@@ -1,3 +1,5 @@
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
+
 class RbfHistory {
   final int _id;
   final int walletId;
@@ -14,9 +16,5 @@ class RbfHistory {
     required this.transactionHash,
     required this.feeRate,
     required this.timestamp,
-  }) : _id = Object.hash(
-          walletId,
-          originalTransactionHash,
-          transactionHash,
-        );
+  }) : _id = getRbfHistoryId(walletId, originalTransactionHash, transactionHash);
 }

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -111,7 +111,7 @@ class AuthProvider extends ChangeNotifier {
 
   /// 비밀번호 검증
   Future<bool> verifyPin(String inputPin) async {
-    String hashedInput = hashString(inputPin);
+    String hashedInput = generateHashString(inputPin);
     final savedPin = await _secureStorageService.read(key: kSecureStoragePinKey);
     return savedPin == hashedInput;
   }

--- a/lib/providers/node_provider/network_service.dart
+++ b/lib/providers/node_provider/network_service.dart
@@ -129,13 +129,6 @@ class NetworkService {
     try {
       final txHash = await _electrumService.broadcast(signedTx.serialize());
 
-      // 브로드캐스트 시간 기록
-      _transactionRepository
-          .recordTemporaryBroadcastTime(signedTx.transactionHash, DateTime.now())
-          .catchError((e) {
-        Logger.error(e);
-      });
-
       return Result.success(txHash);
     } catch (e) {
       return Result.failure(ErrorCodes.broadcastErrorWithMessage(e.toString()));

--- a/lib/providers/node_provider/transaction/cpfp_service.dart
+++ b/lib/providers/node_provider/transaction/cpfp_service.dart
@@ -2,11 +2,11 @@ import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/model/node/cpfp_history.dart';
 import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
 import 'package:coconut_wallet/utils/logger.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
 
 typedef CpfpInfo = ({
   String parentTransactionHash,
@@ -50,7 +50,7 @@ class CpfpService {
 
       if (parentTxRecord != null && parentTxRecord.blockHeight == 0) {
         final utxo =
-            _utxoRepository.getUtxoState(walletId, makeUtxoId(input.transactionHash, input.index));
+            _utxoRepository.getUtxoState(walletId, getUtxoId(input.transactionHash, input.index));
         if (utxo != null) {
           isCpfp = true;
           parentTxHash = parentTxRecord.transactionHash;

--- a/lib/providers/node_provider/transaction/rbf_service.dart
+++ b/lib/providers/node_provider/transaction/rbf_service.dart
@@ -2,11 +2,11 @@ import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/model/node/rbf_history.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/transaction_record.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
 import 'package:coconut_wallet/utils/logger.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
 
 typedef RbfInfo = ({
   String originalTransactionHash, // RBF 체인의 최초 트랜잭션
@@ -54,7 +54,7 @@ class RbfService {
   /// 트랜잭션의 입력들을 검사하여 RBF 조건에 해당하는 입력이 있는지 확인
   Future<UtxoState?> findRbfCandidate(int walletId, Transaction tx) async {
     for (final input in tx.inputs) {
-      final utxoId = makeUtxoId(input.transactionHash, input.index);
+      final utxoId = getUtxoId(input.transactionHash, input.index);
       final utxo = _utxoRepository.getUtxoState(walletId, utxoId);
       if (utxo == null) continue;
 

--- a/lib/providers/node_provider/utxo_sync_service.dart
+++ b/lib/providers/node_provider/utxo_sync_service.dart
@@ -3,11 +3,10 @@ import 'package:coconut_wallet/enums/network_enums.dart';
 import 'package:coconut_wallet/model/node/script_status.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
-import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
 import 'package:coconut_wallet/utils/logger.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
 import 'package:coconut_wallet/providers/node_provider/state/state_manager_interface.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
@@ -140,7 +139,7 @@ class UtxoSyncService {
         // 5. 트랜잭션 입력 분석하여 내 지갑의 UTXO인지 확인
         for (int i = 0; i < transaction.inputs.length; i++) {
           final input = transaction.inputs[i];
-          final utxoId = makeUtxoId(input.transactionHash, input.index);
+          final utxoId = getUtxoId(input.transactionHash, input.index);
 
           if (existingUtxoIds.contains(utxoId)) {
             continue;

--- a/lib/providers/utxo_tag_provider.dart
+++ b/lib/providers/utxo_tag_provider.dart
@@ -1,7 +1,7 @@
 import 'package:coconut_wallet/model/utxo/utxo_tag.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/utils/logger.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:uuid/uuid.dart';
 
@@ -36,9 +36,8 @@ class UtxoTagProvider extends ChangeNotifier {
   // [utxo tag 승계 유무에 따라 Utxo 태그 적용]
   // broadcasting_view_model.dart / updateTagsOfUsedUtxos에서 호출
   Future applyTagsToNewUtxos(int walletId, String signedTx, List<int> outputIndexes) async {
-    List<String> newUtxoIds = _isTagsMoveAllowed
-        ? outputIndexes.map((index) => makeUtxoId(signedTx, index)).toList()
-        : [];
+    List<String> newUtxoIds =
+        _isTagsMoveAllowed ? outputIndexes.map((index) => getUtxoId(signedTx, index)).toList() : [];
 
     final result =
         await _utxoRepository.updateTagsOfSpentUtxos(walletId, _spentUtxoIds, newUtxoIds);

--- a/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
@@ -13,10 +13,10 @@ import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/transaction_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/screens/wallet_detail/transaction_fee_bumping_screen.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -685,7 +685,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
     List<Utxo> utxoList = [];
     for (var input in inputList) {
       var utxo =
-          _utxoRepository.getUtxoState(_walletId, makeUtxoId(input.transactionHash, input.index));
+          _utxoRepository.getUtxoState(_walletId, getUtxoId(input.transactionHash, input.index));
       if (utxo != null) {
         utxoList.add(Utxo(utxo.transactionHash, utxo.index, utxo.amount, utxo.derivationPath));
       }

--- a/lib/providers/view_model/wallet_detail/utxo_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_detail_view_model.dart
@@ -8,7 +8,6 @@ import 'package:coconut_wallet/model/node/wallet_update_info.dart';
 import 'package:coconut_wallet/utils/datetime_util.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/transaction_util.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
 import 'package:flutter/material.dart';
 
 class UtxoDetailViewModel extends ChangeNotifier {

--- a/lib/providers/view_model/wallet_detail/utxo_list_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_list_view_model.dart
@@ -13,7 +13,6 @@ import 'package:coconut_wallet/providers/utxo_tag_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/utils/datetime_util.dart';
 import 'package:coconut_wallet/utils/logger.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
 import 'package:flutter/material.dart';
 
 class UtxoListViewModel extends ChangeNotifier {

--- a/lib/repository/realm/address_repository.dart
+++ b/lib/repository/realm/address_repository.dart
@@ -10,6 +10,7 @@ import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/repository/realm/base_repository.dart';
 import 'package:coconut_wallet/repository/realm/converter/address.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 
 class AddressRepository extends BaseRepository {
@@ -199,7 +200,10 @@ class AddressRepository extends BaseRepository {
 
     for (final address in addresses) {
       final addressId = getWalletAddressId(
-          walletId: realmWalletBase.id, index: address.index, address: address.address);
+        realmWalletBase.id,
+        address.index,
+        address.address,
+      );
 
       // 이미 존재하는 주소는 건너뛰기
       if (existingIds.contains(addressId)) {

--- a/lib/repository/realm/converter/address.dart
+++ b/lib/repository/realm/converter/address.dart
@@ -1,9 +1,6 @@
 import 'package:coconut_wallet/model/wallet/wallet_address.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
-
-int getWalletAddressId({required int walletId, required int index, required String address}) {
-  return Object.hash(walletId, index, address);
-}
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 
 WalletAddress mapRealmToWalletAddress(RealmWalletAddress realmAddress) {
   return WalletAddress(
@@ -19,8 +16,7 @@ WalletAddress mapRealmToWalletAddress(RealmWalletAddress realmAddress) {
 
 RealmWalletAddress mapWalletAddressToRealm(int walletId, WalletAddress walletAddress) {
   return RealmWalletAddress(
-    getWalletAddressId(
-        walletId: walletId, index: walletAddress.index, address: walletAddress.address),
+    getWalletAddressId(walletId, walletAddress.index, walletAddress.address),
     walletId,
     walletAddress.address,
     walletAddress.index,

--- a/lib/repository/realm/converter/transaction.dart
+++ b/lib/repository/realm/converter/transaction.dart
@@ -6,6 +6,7 @@ import 'package:coconut_wallet/model/node/rbf_history.dart';
 import 'package:coconut_wallet/model/wallet/transaction_address.dart';
 import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/utils/transaction_util.dart';
 
 // TransactionRecord -> _RealmTransaction 변환 함수
 RealmTransaction mapTransactionToRealmTransaction(
@@ -21,7 +22,6 @@ RealmTransaction mapTransactionToRealmTransaction(
     transaction.fee,
     transaction.vSize,
     transaction.createdAt,
-    memo: transaction.memo,
     inputAddressList:
         transaction.inputAddressList.map((address) => jsonEncode(addressToJson(address))).toList(),
     outputAddressList:
@@ -31,13 +31,15 @@ RealmTransaction mapTransactionToRealmTransaction(
 
 // note(트랜잭션 메모) 정보가 추가로 필요하여 TransactionDto를 반환
 TransactionRecord mapRealmTransactionToTransaction(RealmTransaction realmTransaction,
-    {List<RealmRbfHistory>? realmRbfHistoryList, RealmCpfpHistory? realmCpfpHistory}) {
+    {List<RealmRbfHistory>? realmRbfHistoryList,
+    RealmCpfpHistory? realmCpfpHistory,
+    String? memo}) {
   return TransactionRecord(
       realmTransaction.transactionHash,
       realmTransaction.timestamp,
       realmTransaction.blockHeight,
       TransactionTypeExtension.fromString(realmTransaction.transactionType),
-      realmTransaction.memo,
+      memo,
       realmTransaction.amount,
       realmTransaction.fee,
       realmTransaction.inputAddressList
@@ -97,5 +99,16 @@ RealmRbfHistory mapRbfHistoryToRealmRbfHistory(RbfHistory rbfHistory) {
     rbfHistory.transactionHash,
     rbfHistory.feeRate,
     rbfHistory.timestamp,
+  );
+}
+
+RealmTransactionMemo generateRealmTransactionMemo(
+    String transactionHash, int walletId, String memo) {
+  return RealmTransactionMemo(
+    getTransactionMemoId(transactionHash, walletId),
+    transactionHash,
+    walletId,
+    memo,
+    DateTime.now(),
   );
 }

--- a/lib/repository/realm/converter/transaction.dart
+++ b/lib/repository/realm/converter/transaction.dart
@@ -6,7 +6,7 @@ import 'package:coconut_wallet/model/node/rbf_history.dart';
 import 'package:coconut_wallet/model/wallet/transaction_address.dart';
 import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
-import 'package:coconut_wallet/utils/transaction_util.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 
 // TransactionRecord -> _RealmTransaction 변환 함수
 RealmTransaction mapTransactionToRealmTransaction(

--- a/lib/repository/realm/converter/utxo.dart
+++ b/lib/repository/realm/converter/utxo.dart
@@ -1,7 +1,7 @@
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
 import 'package:coconut_wallet/model/utxo/utxo_tag.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 
 UtxoTag mapRealmUtxoTagToUtxoTag(RealmUtxoTag utxoTag) {
   return UtxoTag(
@@ -15,7 +15,7 @@ UtxoTag mapRealmUtxoTagToUtxoTag(RealmUtxoTag utxoTag) {
 
 RealmUtxo mapUtxoToRealmUtxo(int walletId, UtxoState utxo) {
   return RealmUtxo(
-    makeUtxoId(utxo.transactionHash, utxo.index),
+    getUtxoId(utxo.transactionHash, utxo.index),
     walletId,
     utxo.to,
     utxo.amount,

--- a/lib/repository/realm/migration/migration.dart
+++ b/lib/repository/realm/migration/migration.dart
@@ -28,6 +28,9 @@ import 'package:realm/realm.dart';
 /// [addRealmTransactionMemo] (4 -> 5)
 /// 1. RealmTransactionMemo 추가
 /// 2. RealmTransaction 에서 memo 필드 삭제
+/// 3. RealmTransaction 의 id 를 재생성
+/// 4. RealmWalletAddress 의 id 를 재생성
+/// 5. TempBroadcastTimeRecord 삭제
 ///
 void defaultMigration(Migration migration, int oldVersion) {
   if (oldVersion == kRealmVersion) {

--- a/lib/repository/realm/migration/migration.dart
+++ b/lib/repository/realm/migration/migration.dart
@@ -1,7 +1,7 @@
 import 'package:coconut_wallet/constants/realm_constants.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/utils/hash_util.dart';
 import 'package:coconut_wallet/utils/logger.dart';
-import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:realm/realm.dart';
 
 /// Realm 마이그레이션 주의사항
@@ -61,7 +61,7 @@ void addRealmTransactionMemo(Migration migration) {
       Logger.log('memo: $memoString - $transactionHash - $walletId');
 
       memos.add(RealmTransactionMemo(
-        getTransactionMemoId(transactionHash, walletId),
+        hashToInt([transactionHash, walletId]),
         transactionHash,
         walletId,
         memoString,

--- a/lib/repository/realm/migration/migration.dart
+++ b/lib/repository/realm/migration/migration.dart
@@ -1,6 +1,7 @@
 import 'package:coconut_wallet/constants/realm_constants.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
 import 'package:coconut_wallet/utils/logger.dart';
+import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:realm/realm.dart';
 
 /// Realm 마이그레이션 주의사항
@@ -60,7 +61,7 @@ void addRealmTransactionMemo(Migration migration) {
       Logger.log('memo: $memoString - $transactionHash - $walletId');
 
       memos.add(RealmTransactionMemo(
-        Object.hash(transactionHash, walletId),
+        getTransactionMemoId(transactionHash, walletId),
         transactionHash,
         walletId,
         memoString,
@@ -112,4 +113,5 @@ void resetExceptForWallet(Realm realm) {
   realm.deleteAll<TempBroadcastTimeRecord>();
   realm.deleteAll<RealmRbfHistory>();
   realm.deleteAll<RealmCpfpHistory>();
+  realm.deleteAll<RealmTransactionMemo>();
 }

--- a/lib/repository/realm/migration/migration.dart
+++ b/lib/repository/realm/migration/migration.dart
@@ -140,7 +140,7 @@ void addRealmTransactionMemo(Migration migration) {
       Logger.log('memo: $memoString - $transactionHash - $walletId');
 
       memos.add(RealmTransactionMemo(
-        hashToInt([transactionHash, walletId]),
+        generateHashInt([transactionHash, walletId]),
         transactionHash,
         walletId,
         memoString,

--- a/lib/repository/realm/model/coconut_wallet_model.dart
+++ b/lib/repository/realm/model/coconut_wallet_model.dart
@@ -17,6 +17,7 @@ final realmAllSchemas = [
   RealmUtxo.schema,
   RealmRbfHistory.schema,
   RealmCpfpHistory.schema,
+  RealmTransactionMemo.schema,
 ];
 
 @RealmModel()

--- a/lib/repository/realm/model/coconut_wallet_model.dart
+++ b/lib/repository/realm/model/coconut_wallet_model.dart
@@ -64,7 +64,6 @@ class _RealmTransaction {
   late DateTime timestamp;
   late int blockHeight;
   late String transactionType;
-  String? memo;
   late int amount;
   late int fee;
   late double vSize;
@@ -72,6 +71,18 @@ class _RealmTransaction {
   late List<String> outputAddressList;
   late DateTime createdAt;
   String? replaceByTransactionHash;
+}
+
+@RealmModel()
+class _RealmTransactionMemo {
+  @PrimaryKey()
+  late int id;
+  @Indexed()
+  late String transactionHash;
+  @Indexed()
+  late int walletId;
+  late String memo;
+  late DateTime createdAt;
 }
 
 @RealmModel()

--- a/lib/repository/realm/model/coconut_wallet_model.dart
+++ b/lib/repository/realm/model/coconut_wallet_model.dart
@@ -8,7 +8,6 @@ final realmAllSchemas = [
   RealmExternalWallet.schema,
   RealmTransaction.schema,
   RealmIntegerId.schema,
-  TempBroadcastTimeRecord.schema,
   RealmUtxoTag.schema,
   RealmWalletAddress.schema,
   RealmWalletBalance.schema,
@@ -91,13 +90,6 @@ class _RealmIntegerId {
   @PrimaryKey()
   late String key; // "RealmTransaction"처럼 테이블 이름
   late int value; // 마지막으로 사용한 id
-}
-
-@RealmModel()
-class _TempBroadcastTimeRecord {
-  @PrimaryKey()
-  late String transactionHash;
-  late DateTime createdAt;
 }
 
 @RealmModel()

--- a/lib/repository/realm/realm_manager.dart
+++ b/lib/repository/realm/realm_manager.dart
@@ -78,7 +78,6 @@ class RealmManager {
       realm.deleteAll<RealmScriptStatus>();
       realm.deleteAll<RealmBlockTimestamp>();
       realm.deleteAll<RealmIntegerId>();
-      realm.deleteAll<TempBroadcastTimeRecord>();
       realm.deleteAll<RealmRbfHistory>();
       realm.deleteAll<RealmCpfpHistory>();
       realm.deleteAll<RealmTransactionMemo>();

--- a/lib/repository/realm/realm_manager.dart
+++ b/lib/repository/realm/realm_manager.dart
@@ -81,6 +81,7 @@ class RealmManager {
       realm.deleteAll<TempBroadcastTimeRecord>();
       realm.deleteAll<RealmRbfHistory>();
       realm.deleteAll<RealmCpfpHistory>();
+      realm.deleteAll<RealmTransactionMemo>();
     });
 
     _isInitialized = false;

--- a/lib/repository/realm/service/realm_id_service.dart
+++ b/lib/repository/realm/service/realm_id_service.dart
@@ -30,3 +30,19 @@ int getTransactionMemoId(String transactionHash, int walletId) {
 String getUtxoId(String transactionHash, int index) {
   return '$transactionHash$index';
 }
+
+int getCpfpHistoryId(int walletId, String parentTransactionHash, String childTransactionHash) {
+  return hashToInt([walletId, parentTransactionHash, childTransactionHash]);
+}
+
+int getRbfHistoryId(int walletId, String originalTransactionHash, String transactionHash) {
+  return hashToInt([walletId, originalTransactionHash, transactionHash]);
+}
+
+int getRealmTransactionId(int walletId, String transactionHash) {
+  return hashToInt([walletId, transactionHash]);
+}
+
+int getWalletAddressId(int walletId, int index, String address) {
+  return hashToInt([walletId, index, address]);
+}

--- a/lib/repository/realm/service/realm_id_service.dart
+++ b/lib/repository/realm/service/realm_id_service.dart
@@ -24,7 +24,7 @@ void saveLastId(Realm realm, String key, int lastId) {
 }
 
 int getTransactionMemoId(String transactionHash, int walletId) {
-  return hashToInt([transactionHash, walletId]);
+  return generateHashInt([transactionHash, walletId]);
 }
 
 String getUtxoId(String transactionHash, int index) {
@@ -32,17 +32,17 @@ String getUtxoId(String transactionHash, int index) {
 }
 
 int getCpfpHistoryId(int walletId, String parentTransactionHash, String childTransactionHash) {
-  return hashToInt([walletId, parentTransactionHash, childTransactionHash]);
+  return generateHashInt([walletId, parentTransactionHash, childTransactionHash]);
 }
 
 int getRbfHistoryId(int walletId, String originalTransactionHash, String transactionHash) {
-  return hashToInt([walletId, originalTransactionHash, transactionHash]);
+  return generateHashInt([walletId, originalTransactionHash, transactionHash]);
 }
 
 int getRealmTransactionId(int walletId, String transactionHash) {
-  return hashToInt([walletId, transactionHash]);
+  return generateHashInt([walletId, transactionHash]);
 }
 
 int getWalletAddressId(int walletId, int index, String address) {
-  return hashToInt([walletId, index, address]);
+  return generateHashInt([walletId, index, address]);
 }

--- a/lib/repository/realm/service/realm_id_service.dart
+++ b/lib/repository/realm/service/realm_id_service.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/utils/hash_util.dart';
 import 'package:realm/realm.dart';
 
 int getLastId(Realm realm, String key) {
@@ -20,4 +21,12 @@ void saveLastId(Realm realm, String key, int lastId) {
   realm.write(() {
     counter.value = lastId;
   });
+}
+
+int getTransactionMemoId(String transactionHash, int walletId) {
+  return hashToInt([transactionHash, walletId]);
+}
+
+String getUtxoId(String transactionHash, int index) {
+  return '$transactionHash$index';
 }

--- a/lib/repository/realm/transaction_repository.dart
+++ b/lib/repository/realm/transaction_repository.dart
@@ -9,8 +9,8 @@ import 'package:coconut_wallet/repository/realm/converter/transaction.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/fetch_transaction_response.dart';
+import 'package:coconut_wallet/utils/hash_util.dart';
 import 'package:coconut_wallet/utils/result.dart';
-import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:realm/realm.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 
@@ -209,7 +209,7 @@ class TransactionRepository extends BaseRepository {
     }
 
     final realmTransactionMemo = realm.find<RealmTransactionMemo>(
-      getTransactionMemoId(transactionHash, walletId),
+      hashToInt([transactionHash, walletId]),
     );
 
     if (realmTransaction.blockHeight == 0) {

--- a/lib/repository/realm/transaction_repository.dart
+++ b/lib/repository/realm/transaction_repository.dart
@@ -203,7 +203,7 @@ class TransactionRepository extends BaseRepository {
     }
 
     final realmTransactionMemo = realm.find<RealmTransactionMemo>(
-      hashToInt([transactionHash, walletId]),
+      generateHashInt([transactionHash, walletId]),
     );
 
     if (realmTransaction.blockHeight == 0) {

--- a/lib/repository/realm/transaction_repository.dart
+++ b/lib/repository/realm/transaction_repository.dart
@@ -10,13 +10,14 @@ import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart'
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/fetch_transaction_response.dart';
 import 'package:coconut_wallet/utils/result.dart';
+import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:realm/realm.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 
 class TransactionRepository extends BaseRepository {
   TransactionRepository(super._realmManager);
 
-  /// walletId 로 트랜잭션 목록 조회, rbf/cpfp 내역 미포함
+  /// walletId 로 트랜잭션 목록 조회, rbf/cpfp 내역 미포함, memo 미포함
   List<TransactionRecord> getTransactionRecordList(int walletId) {
     final transactions = realm.query<RealmTransaction>(
         'walletId == $walletId AND replaceByTransactionHash == null SORT(timestamp DESC)');
@@ -61,18 +62,27 @@ class TransactionRepository extends BaseRepository {
 
   /// walletId, transactionHash 로 조회된 transaction 의 메모 변경
   Result<TransactionRecord> updateTransactionMemo(int walletId, String txHash, String memo) {
-    final transactions =
-        realm.query<RealmTransaction>("walletId == '$walletId' AND transactionHash == '$txHash'");
+    final realmMemo = realm
+        .find<RealmTransactionMemo>("walletId == '$walletId' AND transactionHash == '$txHash'");
 
-    return handleRealm<TransactionRecord>(
-      () {
-        final transaction = transactions.first;
+    return handleRealm<TransactionRecord>(() {
+      // 메모 업데이트 또는 생성
+      if (realmMemo == null) {
+        realm.add(generateRealmTransactionMemo(txHash, walletId, memo));
+      } else {
         realm.write(() {
-          transaction.memo = memo;
+          realmMemo.memo = memo;
         });
-        return mapRealmTransactionToTransaction(transaction);
-      },
-    );
+      }
+
+      // 트랜잭션 레코드 조회 및 반환
+      final txRecord = getTransactionRecord(walletId, txHash);
+      if (txRecord == null) {
+        throw ErrorCodes.realmNotFound;
+      }
+
+      return txRecord;
+    });
   }
 
   /// 일시적인 브로드캐스트 시간 기록
@@ -198,15 +208,21 @@ class TransactionRepository extends BaseRepository {
       return null;
     }
 
+    final realmTransactionMemo = realm.find<RealmTransactionMemo>(
+      getTransactionMemoId(transactionHash, walletId),
+    );
+
     if (realmTransaction.blockHeight == 0) {
       final realmRbfHistoryList = getRbfHistoryList(walletId, transactionHash);
       final realmCpfpHistory = getCpfpHistory(walletId, transactionHash);
 
       return mapRealmTransactionToTransaction(realmTransaction,
-          realmRbfHistoryList: realmRbfHistoryList, realmCpfpHistory: realmCpfpHistory);
+          realmRbfHistoryList: realmRbfHistoryList,
+          realmCpfpHistory: realmCpfpHistory,
+          memo: realmTransactionMemo?.memo);
     }
 
-    return mapRealmTransactionToTransaction(realmTransaction);
+    return mapRealmTransactionToTransaction(realmTransaction, memo: realmTransactionMemo?.memo);
   }
 
   bool hasTransactionConfirmed(int walletId, String transactionHash) {

--- a/lib/repository/realm/transaction_repository.dart
+++ b/lib/repository/realm/transaction_repository.dart
@@ -7,6 +7,7 @@ import 'package:coconut_wallet/providers/node_provider/transaction/rbf_service.d
 import 'package:coconut_wallet/repository/realm/base_repository.dart';
 import 'package:coconut_wallet/repository/realm/converter/transaction.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/fetch_transaction_response.dart';
 import 'package:coconut_wallet/utils/hash_util.dart';
@@ -85,13 +86,6 @@ class TransactionRepository extends BaseRepository {
     });
   }
 
-  /// 일시적인 브로드캐스트 시간 기록
-  Future<void> recordTemporaryBroadcastTime(String txHash, DateTime createdAt) async {
-    await realm.writeAsync(() {
-      realm.add(TempBroadcastTimeRecord(txHash, createdAt));
-    });
-  }
-
   /// 트랜잭션 상태 업데이트
   Future<void> updateTransactionStates(
     int walletId,
@@ -163,7 +157,7 @@ class TransactionRepository extends BaseRepository {
         newTxsToAdd.add(mapTransactionToRealmTransaction(
           tx,
           walletId,
-          Object.hash(walletId, tx.transactionHash),
+          getRealmTransactionId(walletId, tx.transactionHash),
         ));
       } else if (existingTx.blockHeight == 0 && tx.blockHeight > 0) {
         // 미확인 -> 확인 상태로 변경된 트랜잭션 - 업데이트

--- a/lib/repository/realm/utxo_repository.dart
+++ b/lib/repository/realm/utxo_repository.dart
@@ -5,9 +5,8 @@ import 'package:coconut_wallet/model/utxo/utxo_tag.dart';
 import 'package:coconut_wallet/repository/realm/base_repository.dart';
 import 'package:coconut_wallet/repository/realm/converter/utxo.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/utils/result.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
-import 'package:realm/realm.dart';
 
 class UtxoRepository extends BaseRepository {
   UtxoRepository(super._realmManager);
@@ -295,7 +294,7 @@ class UtxoRepository extends BaseRepository {
     /// 트랜잭션에 사용된 UTXO의 상태를 업데이트합니다.
     for (var input in transaction.inputs) {
       // UTXO 소유 지갑 ID 찾기
-      final utxoId = makeUtxoId(input.transactionHash, input.index);
+      final utxoId = getUtxoId(input.transactionHash, input.index);
       final utxo = getUtxoState(walletId, utxoId);
 
       // UTXO가 자기 자신을 참조하지 않는지 확인
@@ -321,7 +320,7 @@ class UtxoRepository extends BaseRepository {
     lib.Transaction transaction,
   ) async {
     final utxoIds =
-        transaction.inputs.map((input) => makeUtxoId(input.transactionHash, input.index)).toList();
+        transaction.inputs.map((input) => getUtxoId(input.transactionHash, input.index)).toList();
 
     await deleteUtxoList(walletId, utxoIds);
   }

--- a/lib/screens/settings/pin_setting_screen.dart
+++ b/lib/screens/settings/pin_setting_screen.dart
@@ -150,7 +150,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
           await _authProvider.checkDeviceBiometrics();
         }
 
-        var hashedPin = hashString(pin);
+        var hashedPin = generateHashString(pin);
         if (!mounted) return;
         await Provider.of<WalletProvider>(context, listen: false)
             .encryptWalletSecureData(hashedPin)

--- a/lib/screens/settings/realm_debug_screen.dart
+++ b/lib/screens/settings/realm_debug_screen.dart
@@ -123,8 +123,6 @@ class _RealmDebugScreenState extends State<RealmDebugScreen> {
         return _convertToMapList(realm.query<RealmBlockTimestamp>(query));
       case 'RealmIntegerId':
         return _convertToMapList(realm.query<RealmIntegerId>(query));
-      case 'TempBroadcastTimeRecord':
-        return _convertToMapList(realm.query<TempBroadcastTimeRecord>(query));
       case 'RealmRbfHistory':
         return _convertToMapList(realm.query<RealmRbfHistory>(query));
       case 'RealmCpfpHistory':
@@ -230,9 +228,6 @@ class _RealmDebugScreenState extends State<RealmDebugScreen> {
       } else if (obj is RealmIntegerId) {
         map['key'] = obj.key;
         map['value'] = obj.value;
-      } else if (obj is TempBroadcastTimeRecord) {
-        map['transactionHash'] = obj.transactionHash;
-        map['createdAt'] = obj.createdAt.toIso8601String();
       } else if (obj is RealmRbfHistory) {
         map['id'] = obj.id;
         map['walletId'] = obj.walletId;
@@ -344,7 +339,6 @@ class _RealmDebugScreenState extends State<RealmDebugScreen> {
       'RealmScriptStatus': realm.all<RealmScriptStatus>().length,
       'RealmBlockTimestamp': realm.all<RealmBlockTimestamp>().length,
       'RealmIntegerId': realm.all<RealmIntegerId>().length,
-      'TempBroadcastTimeRecord': realm.all<TempBroadcastTimeRecord>().length,
       'RealmRbfHistory': realm.all<RealmRbfHistory>().length,
       'RealmCpfpHistory': realm.all<RealmCpfpHistory>().length,
       'RealmTransactionMemo': realm.all<RealmTransactionMemo>().length,

--- a/lib/screens/settings/realm_debug_screen.dart
+++ b/lib/screens/settings/realm_debug_screen.dart
@@ -43,7 +43,6 @@ class _RealmDebugScreenState extends State<RealmDebugScreen> {
     'RealmScriptStatus',
     'RealmBlockTimestamp',
     'RealmIntegerId',
-    'TempBroadcastTimeRecord',
     'RealmRbfHistory',
     'RealmCpfpHistory',
     'RealmTransactionMemo',

--- a/lib/screens/settings/realm_debug_screen.dart
+++ b/lib/screens/settings/realm_debug_screen.dart
@@ -46,6 +46,7 @@ class _RealmDebugScreenState extends State<RealmDebugScreen> {
     'TempBroadcastTimeRecord',
     'RealmRbfHistory',
     'RealmCpfpHistory',
+    'RealmTransactionMemo',
   ];
 
   @override
@@ -128,6 +129,8 @@ class _RealmDebugScreenState extends State<RealmDebugScreen> {
         return _convertToMapList(realm.query<RealmRbfHistory>(query));
       case 'RealmCpfpHistory':
         return _convertToMapList(realm.query<RealmCpfpHistory>(query));
+      case 'RealmTransactionMemo':
+        return _convertToMapList(realm.query<RealmTransactionMemo>(query));
       default:
         throw ArgumentError('지원되지 않는 테이블: $tableName');
     }
@@ -163,7 +166,6 @@ class _RealmDebugScreenState extends State<RealmDebugScreen> {
         map['timestamp'] = obj.timestamp.toIso8601String();
         map['blockHeight'] = obj.blockHeight;
         map['transactionType'] = obj.transactionType;
-        map['memo'] = obj.memo;
         map['amount'] = obj.amount;
         map['fee'] = obj.fee;
         map['vSize'] = obj.vSize;
@@ -246,6 +248,12 @@ class _RealmDebugScreenState extends State<RealmDebugScreen> {
         map['originalFee'] = obj.originalFee;
         map['newFee'] = obj.newFee;
         map['timestamp'] = obj.timestamp.toIso8601String();
+      } else if (obj is RealmTransactionMemo) {
+        map['id'] = obj.id;
+        map['transactionHash'] = obj.transactionHash;
+        map['walletId'] = obj.walletId;
+        map['memo'] = obj.memo;
+        map['createdAt'] = obj.createdAt.toIso8601String();
       } else {
         // 알 수 없는 타입인 경우 기본 처리
         map['type'] = obj.runtimeType.toString();
@@ -339,6 +347,7 @@ class _RealmDebugScreenState extends State<RealmDebugScreen> {
       'TempBroadcastTimeRecord': realm.all<TempBroadcastTimeRecord>().length,
       'RealmRbfHistory': realm.all<RealmRbfHistory>().length,
       'RealmCpfpHistory': realm.all<RealmCpfpHistory>().length,
+      'RealmTransactionMemo': realm.all<RealmTransactionMemo>().length,
     };
   }
 

--- a/lib/utils/electrum_utils.dart
+++ b/lib/utils/electrum_utils.dart
@@ -1,7 +1,7 @@
 import 'package:coconut_lib/coconut_lib.dart';
-import 'package:coconut_wallet/utils/hash_util.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
 
 /// 스크립트 및 주소 관련 유틸리티 클래스
 class ElectrumUtil {
@@ -36,13 +36,10 @@ class ElectrumUtil {
     throw 'Unsupported address type: $addressType';
   }
 
-  static String scriptToReversedHash(String script) {
-    String scriptHash = hexHashString(script);
-    return hex.encode(hex.decode(scriptHash).reversed.toList());
-  }
-
   static String addressToReversedScriptHash(AddressType addressType, String address) {
     String script = getScriptForAddress(addressType, address);
-    return scriptToReversedHash(script);
+    final bytes = hex.decode(script);
+    final digest = sha256.convert(bytes);
+    return hex.encode(digest.bytes.reversed.toList());
   }
 }

--- a/lib/utils/hash_util.dart
+++ b/lib/utils/hash_util.dart
@@ -13,3 +13,25 @@ String hexHashString(String input) {
   final digest = sha256.convert(bytes);
   return hex.encode(digest.bytes);
 }
+
+/// 여러 개의 파라미터(int, String)를 조합하여 안정적인 integer ID를 생성합니다.
+int hashToInt(List<dynamic> params) {
+  final buffer = StringBuffer();
+  bool hasValidParam = false;
+
+  for (int i = 0; i < params.length; i++) {
+    final param = params[i];
+    if (param is String || param is int) {
+      if (hasValidParam) buffer.write('_');
+      buffer.write(param);
+      hasValidParam = true;
+    }
+  }
+
+  if (!hasValidParam) return 0;
+
+  final digest = sha256.convert(utf8.encode(buffer.toString()));
+  final bytes = digest.bytes;
+
+  return ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]).abs();
+}

--- a/lib/utils/hash_util.dart
+++ b/lib/utils/hash_util.dart
@@ -1,21 +1,14 @@
 import 'dart:convert';
-import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
 
-String hashString(String input) {
+String generateHashString(String input) {
   final bytes = utf8.encode(input);
   final digest = sha256.convert(bytes);
   return digest.toString();
 }
 
-String hexHashString(String input) {
-  final bytes = hex.decode(input);
-  final digest = sha256.convert(bytes);
-  return hex.encode(digest.bytes);
-}
-
 /// 여러 개의 파라미터(int, String)를 조합하여 안정적인 integer ID를 생성합니다.
-int hashToInt(List<dynamic> params) {
+int generateHashInt(List<dynamic> params) {
   final buffer = StringBuffer();
   bool hasValidParam = false;
 

--- a/lib/utils/transaction_util.dart
+++ b/lib/utils/transaction_util.dart
@@ -179,7 +179,3 @@ class TransactionUtil {
     );
   }
 }
-
-int getTransactionMemoId(String transactionHash, int walletId) {
-  return Object.hash(transactionHash, walletId);
-}

--- a/lib/utils/transaction_util.dart
+++ b/lib/utils/transaction_util.dart
@@ -179,3 +179,7 @@ class TransactionUtil {
     );
   }
 }
+
+int getTransactionMemoId(String transactionHash, int walletId) {
+  return Object.hash(transactionHash, walletId);
+}

--- a/lib/utils/utxo_util.dart
+++ b/lib/utils/utxo_util.dart
@@ -1,9 +1,0 @@
-import 'package:coconut_lib/coconut_lib.dart';
-
-extension UtxoExtension on Utxo {
-  String get utxoId => '$transactionHash$index';
-}
-
-String makeUtxoId(String transactionHash, int index) {
-  return '$transactionHash$index';
-}

--- a/test/mock/utxo_mock.dart
+++ b/test/mock/utxo_mock.dart
@@ -1,6 +1,6 @@
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/converter/utxo.dart';
 
 /// UTXO 모킹을 위한 유틸리티 클래스
@@ -26,7 +26,7 @@ class UtxoMock {
     UtxoStatus status = UtxoStatus.unspent,
     String? spentByTransactionHash,
   }) {
-    final utxoId = id ?? makeUtxoId(transactionHash, index);
+    final utxoId = id ?? getUtxoId(transactionHash, index);
     final derivationPath = _buildDerivationPath(addressIndex);
 
     return RealmUtxo(

--- a/test/providers/node_provider/transaction/rbf_service_test.dart
+++ b/test/providers/node_provider/transaction/rbf_service_test.dart
@@ -4,12 +4,12 @@ import 'package:coconut_wallet/model/node/rbf_history.dart';
 import 'package:coconut_wallet/model/wallet/watch_only_wallet.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/rbf_service.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/repository/realm/wallet_repository.dart';
 import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -324,7 +324,7 @@ void main() {
         final incomingUtxoList = [
           UtxoMock.createIncomingUtxo(
             transactionHash: originalTx.transactionHash,
-            id: makeUtxoId(originalTx.transactionHash, 0),
+            id: getUtxoId(originalTx.transactionHash, 0),
           ),
         ];
         final originalTxRecord = TransactionMock.createUnconfirmedTransactionRecord(
@@ -353,7 +353,7 @@ void main() {
         final incomingUtxoList = [
           UtxoMock.createIncomingUtxo(
             transactionHash: originalTx.transactionHash,
-            id: makeUtxoId(originalTx.transactionHash, 0),
+            id: getUtxoId(originalTx.transactionHash, 0),
           ),
         ];
 

--- a/test/repository/realm/address_repository_test.dart
+++ b/test/repository/realm/address_repository_test.dart
@@ -2,8 +2,8 @@ import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/model/wallet/singlesig_wallet_list_item.dart';
 import 'package:coconut_wallet/model/wallet/wallet_address.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
-import 'package:coconut_wallet/repository/realm/converter/address.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../mock/wallet_mock.dart';
@@ -69,8 +69,7 @@ void main() {
     realmManager.realm.write(() {
       realmManager.realm.addAll<RealmWalletAddress>([
         ...initialAddresses.map((address) => RealmWalletAddress(
-              getWalletAddressId(
-                  walletId: testWalletId, index: address.index, address: address.address),
+              getWalletAddressId(testWalletId, address.index, address.address),
               testWalletId,
               address.address,
               address.index,

--- a/test/repository/realm/test_realm_manager.dart
+++ b/test/repository/realm/test_realm_manager.dart
@@ -59,7 +59,6 @@ class TestRealmManager implements RealmManager {
       realm.deleteAll<RealmScriptStatus>();
       realm.deleteAll<RealmBlockTimestamp>();
       realm.deleteAll<RealmIntegerId>();
-      realm.deleteAll<TempBroadcastTimeRecord>();
       realm.deleteAll<RealmRbfHistory>();
       realm.deleteAll<RealmCpfpHistory>();
     });

--- a/test/repository/realm/transaction_repository_test.dart
+++ b/test/repository/realm/transaction_repository_test.dart
@@ -398,29 +398,6 @@ void main() {
     });
   });
 
-  group('임시 브로드캐스트 시간 기록 테스트', () {
-    test('임시 브로드캐스트 시간을 기록하고 조회할 수 있어야 함', () async {
-      // 테스트용 트랜잭션 해시와 시간
-      const txHash = 'broadcast_tx_hash';
-      final broadcastTime = DateTime.now();
-
-      // 임시 브로드캐스트 시간 기록
-      await transactionRepository.recordTemporaryBroadcastTime(txHash, broadcastTime);
-
-      // 기록된 데이터 조회
-      final tempRecords = realmManager.realm.all<TempBroadcastTimeRecord>();
-      final recordedItem = tempRecords.firstWhere((r) => r.transactionHash == txHash);
-
-      // 검증
-      expect(tempRecords, isNotEmpty);
-      expect(recordedItem.transactionHash, txHash);
-
-      // DateTime 비교는 정밀도 차이 때문에 근사값으로 비교
-      final timeDiff = recordedItem.createdAt.difference(broadcastTime).inMilliseconds.abs();
-      expect(timeDiff < 1000, true); // 1초 이내 차이는 허용
-    });
-  });
-
   group('RBF 대체 표시 테스트', () {
     test('markAsRbfReplaced 함수가 트랜잭션에 대체 정보를 올바르게 설정해야 함', () async {
       // 테스트용 트랜잭션 생성 및 추가

--- a/test/repository/realm/utxo_repository_test.dart
+++ b/test/repository/realm/utxo_repository_test.dart
@@ -1,7 +1,7 @@
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/singlesig_wallet_list_item.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
-import 'package:coconut_wallet/utils/utxo_util.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../mock/transaction_mock.dart';
@@ -54,7 +54,7 @@ void main() {
         );
 
         // Then
-        final utxoId = makeUtxoId(
+        final utxoId = getUtxoId(
           mockTx.inputs[0].transactionHash,
           mockTx.inputs[0].index,
         );
@@ -92,7 +92,7 @@ void main() {
         );
 
         // Then
-        final utxoId = makeUtxoId(
+        final utxoId = getUtxoId(
           mockTx.inputs[0].transactionHash,
           mockTx.inputs[0].index,
         );
@@ -132,7 +132,7 @@ void main() {
         );
 
         // Then
-        final utxoId = makeUtxoId(
+        final utxoId = getUtxoId(
           mockTx.inputs[0].transactionHash,
           mockTx.inputs[0].index,
         );


### PR DESCRIPTION
## 1. 변경 사항
- RealmTransaction에서 메모 프로퍼티 삭제
- RealmTransactionMemo 추가
- Realm 관련 id 함수들을 RealmIdService 로 옮김
-  TempBroadcastTimeRecord 스키마 삭제
- Object.hash값이 Realm에 저장되지 않도록 수정 

## 2. 테스트 방법
1. 이 브랜치 이외의 다른 브랜치에서 트랜잭션 메모 작성
2. `299-tx-memo` 브랜치 체크아웃
3. realm 빌드 ([README 개발환경 설정 4번 참조](https://github.com/noncelab/coconut_wallet/?tab=readme-ov-file#%EA%B0%9C%EB%B0%9C%ED%99%98%EA%B2%BD-%EC%84%A4%EC%A0%95))
4. pubspec.yaml 버전을 이전 브랜치의 값과 동일하게 수정
5. 앱 실행
6. 트랜잭션 메모들이 잘 마이그레이션 되는지 확인
(`RealmTransactionMemo migration start` 이런 텍스트 로그를 기록하니 이 텍스트로 실행되는지 확인 가능합니다)

## 이슈
- #299