### PR TITLE
[300] 트랜잭션 메모 기능

### DIFF
--- a/lib/screens/send/broadcasting_complete_screen.dart
+++ b/lib/screens/send/broadcasting_complete_screen.dart
@@ -47,19 +47,17 @@ class _BroadcastingCompleteScreenState extends State<BroadcastingCompleteScreen>
                         t.broadcasting_complete_screen.complete,
                         style: CoconutTypography.heading4_18_Bold.setColor(CoconutColors.white),
                       ),
-                      // #300
-                      // CoconutLayout.spacing_400h,
-                      // _buildMemoInputField(),
-                      // if (!_memoFocusNode.hasFocus && _memoController.text.isNotEmpty)
-                      //   _buildMemoReadOnlyText(),
+                      CoconutLayout.spacing_400h,
+                      _buildMemoInputField(),
+                      if (!_memoFocusNode.hasFocus && _memoController.text.isNotEmpty)
+                        _buildMemoReadOnlyText(),
                     ],
                   ),
                 ),
-                // #300
-                // if (_memoFocusNode.hasFocus)
-                //   Positioned(
-                //       bottom: MediaQuery.of(context).viewInsets.bottom + Sizes.size16,
-                //       child: _buildMemoTags()),
+                if (_memoFocusNode.hasFocus)
+                  Positioned(
+                      bottom: MediaQuery.of(context).viewInsets.bottom + Sizes.size16,
+                      child: _buildMemoTags()),
                 Positioned(
                   bottom: Sizes.size24,
                   left: Sizes.size16,
@@ -103,10 +101,11 @@ class _BroadcastingCompleteScreenState extends State<BroadcastingCompleteScreen>
 
   void onTapConfirmButton(BuildContext context) {
     // 메모가 있는 경우 업데이트 시도
-    if (_memoController.text.isNotEmpty &&
+    final memo = _memoController.text.trim();
+    if (memo.isNotEmpty &&
         !context
             .read<TransactionProvider>()
-            .updateTransactionMemo(widget.id, widget.txHash, _memoController.text)) {
+            .updateTransactionMemo(widget.id, widget.txHash, memo)) {
       CoconutToast.showWarningToast(
         context: context,
         text: t.toast.memo_update_failed,


### PR DESCRIPTION
### 변경사항
feat(broadcasting_complete_screen): 트랜잭션 전송 후 '메모 추가' 기능 추가
fix(transaction_repository): 메모 추가/업데이트 되도록 수정(오류 수정)
fix(transaction_repository): 지갑 디테일 - 거래 내역 트랜잭션 메모 확인할 수 있도록 수정(메모 쿼리 추가)

### 테스트 방법
어플 실행하여 테스트

### 테스트 시나리오
1. 지갑 디테일 화면 - 거래 디테일 화면 - 메모 수정 - 지갑 디테일 화면에서 '메모' 확인
2. 지갑 디테일 화면에서 보내기 버튼을 눌러서 전송 완료 화면까지 이동 - 메모 입력 X, 확인 클릭 - 지갑 디테일 화면에서 '메모' 안 나오는지 확인
3. 지갑 디테일 화면에서 보내기 버튼을 눌러서 전송 완료 화면까지 이동 - 메모 입력 O, 확인 클릭 - 지갑 디테일 화면에서 '메모' 확인
4. 기존에 추가된 메모는 다시 '지갑 디테일 화면'으로 진입시 제대로 보여지는지 확인

#300 