### PR TITLE
주소 스캔 시 BIP21 지원하도록 수정

### DIFF
--- a/lib/screens/send/send_address_screen.dart
+++ b/lib/screens/send/send_address_screen.dart
@@ -175,8 +175,8 @@ class _SendAddressScreenState extends State<SendAddressScreen> with WidgetsBindi
 
       _isProcessing = true;
 
-      _viewModel.validateAddress(scanData.code!).then((_) {
-        _viewModel.saveWalletIdAndRecipientAddress(widget.id, scanData.code!);
+      _viewModel.validateAddress(scanData.code!).then((normalizedAddress) {
+        _viewModel.saveWalletIdAndRecipientAddress(widget.id, normalizedAddress);
         if (_viewModel.isNetworkOn) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             _goNext(); // Navigator.push 호출은 메인 스레드에서 실행

--- a/lib/utils/address_util.dart
+++ b/lib/utils/address_util.dart
@@ -2,3 +2,32 @@ String shortenAddress(String address, {int head = 8, int tail = 8}) {
   if (address.length <= head + tail) return address;
   return '${address.substring(0, head)}...${address.substring(address.length - tail)}';
 }
+
+/// Bip21 주소를 정규화
+/// Bech32 (P2WPKH, P2WSH) 주소인 경우 소문자 변환
+String normalizeAddress(String input) {
+  final address = extractAddressFromBip21(input);
+  return isBech32(address) ? address.toLowerCase() : address;
+}
+
+String extractAddressFromBip21(String input) {
+  if (!input.toLowerCase().startsWith('bitcoin:')) {
+    return input;
+  }
+
+  final withoutScheme = input.substring(8);
+
+  final queryIndex = withoutScheme.indexOf('?');
+  if (queryIndex == -1) {
+    return withoutScheme;
+  }
+
+  return withoutScheme.substring(0, queryIndex);
+}
+
+bool isBech32(String address) {
+  final normalizedAddress = address.toLowerCase();
+  return normalizedAddress.startsWith('bc1') ||
+      normalizedAddress.startsWith('tb1') ||
+      normalizedAddress.startsWith('bcrt1');
+}

--- a/lib/widgets/card/address_and_amount_card.dart
+++ b/lib/widgets/card/address_and_amount_card.dart
@@ -15,12 +15,12 @@ class AddressAndAmountCard extends StatefulWidget {
   final String amount;
   final String? addressPlaceholder;
   final String? amountPlaceholder;
-  final void Function(String address) onAddressChanged;
+  final Future<String> Function(String address) onAddressChanged;
   final void Function(String amount) onAmountChanged;
   final void Function(bool isContentEmpty) onDeleted;
   final VoidCallback? onFocusRequested;
   final VoidCallback? onFocusAfterScanned;
-  final Future<void> Function(String address) validateAddress;
+  final Future<String> Function(String address) validateAddress;
   final bool isRemovable;
   final bool isAddressInvalid;
   final bool isAmountDust;
@@ -209,12 +209,15 @@ class _AddressAndAmountCardState extends State<AddressAndAmountCard> {
     );
   }
 
-  void _onAddressChanged(String value) {
+  void _onAddressChanged(String value) async {
     if (value.isEmpty) {
       _addressController.clear();
     }
 
-    widget.onAddressChanged(value);
+    var finalAddress = await widget.onAddressChanged(value);
+    if (finalAddress != _addressController.text) {
+      _addressController.text = finalAddress;
+    }
   }
 
   void _onAmountChanged(String value) {
@@ -239,9 +242,9 @@ class _AddressAndAmountCardState extends State<AddressAndAmountCard> {
 
       _isQrDataHandling = true;
 
-      widget.validateAddress(scanData.code!).then((_) {
+      widget.validateAddress(scanData.code!).then((normalizedAddress) {
         if (mounted) {
-          Navigator.pop(context, scanData.code!);
+          Navigator.pop(context, normalizedAddress);
         }
       }).catchError((e) {
         if (mounted) {


### PR DESCRIPTION
### 변경 사항
- send_address_view_model.dart
   - _parseBip21Address 추가
   - validateAddress, loadDataFromClipboard, saveWalletIdAndRecipientAddress에서도 사용하도록 수정
   
### 테스트 방법
- 블루월렛, 넌척에서 보여주는 주소 QR을 스캔
- 입력 정보 확인에서 주소가 일치하는지 확인