### PR TITLE
[359] 동기화 상태관리에 '구독' 상태 추가

### DIFF
--- a/lib/enums/network_enums.dart
+++ b/lib/enums/network_enums.dart
@@ -21,7 +21,7 @@ extension TransactionTypeExtension on TransactionType {
 enum SocketConnectionStatus { reconnecting, connecting, connected, terminated }
 
 /// 갱신된 데이터 종류
-enum UpdateElement { balance, utxo, transaction }
+enum UpdateElement { subscription, balance, utxo, transaction }
 
 /// 갱신된 데이터의 상태
 enum WalletSyncState { waiting, syncing, completed }

--- a/lib/model/node/node_provider_state.dart
+++ b/lib/model/node/node_provider_state.dart
@@ -72,12 +72,12 @@ class NodeProviderState {
     // 테이블 헤더 출력 (connectionState 포함)
     final headerBuffer = StringBuffer();
     headerBuffer.writeln('\n');
-    headerBuffer.writeln('┌───────────────────────────────────────┐');
+    headerBuffer.writeln('┌─────────────────────────────────────────────────┐');
     headerBuffer
-        .writeln('│ 연결 상태: $connectionStateSymbol${' ' * (23 - connectionStateSymbol.length)}│');
-    headerBuffer.writeln('├─────────┬─────────┬─────────┬─────────┤');
-    headerBuffer.writeln('│ 지갑 ID │  잔액   │  거래   │  UTXO   │');
-    headerBuffer.writeln('├─────────┼─────────┼─────────┼─────────┤');
+        .writeln('│ 연결 상태: $connectionStateSymbol${' ' * (33 - connectionStateSymbol.length)}│');
+    headerBuffer.writeln('├─────────┬─────────┬─────────┬─────────┬─────────┤');
+    headerBuffer.writeln('│ 지갑 ID │  구독   │  잔액   │  거래   │  UTXO   │');
+    headerBuffer.writeln('├─────────┼─────────┼─────────┼─────────┼─────────┤');
     Logger.log(headerBuffer.toString());
 
     // 각 지갑 상태를 개별적으로 출력 (긴 로그 방지)
@@ -85,23 +85,24 @@ class NodeProviderState {
       final key = walletKeys[i];
       final value = registeredWallets[key]!;
 
+      final subscriptionSymbol = statusToSymbol(value.subscription);
       final balanceSymbol = statusToSymbol(value.balance);
       final transactionSymbol = statusToSymbol(value.transaction);
       final utxoSymbol = statusToSymbol(value.utxo);
 
       final rowBuffer = StringBuffer();
       rowBuffer.writeln(
-          '│ ${key.toString().padRight(7)} │   $balanceSymbol    │   $transactionSymbol    │   $utxoSymbol    │');
+          '│ ${key.toString().padRight(7)} │   $subscriptionSymbol    │   $balanceSymbol    │   $transactionSymbol    │   $utxoSymbol    │');
 
       // 마지막 행이 아니면 행 구분선 추가
       if (i < walletKeys.length - 1) {
-        rowBuffer.writeln('├─────────┼─────────┼─────────┼─────────┤');
+        rowBuffer.writeln('├─────────┼─────────┼─────────┼─────────┼─────────┤');
       }
 
       Logger.log(rowBuffer.toString());
     }
 
     // 테이블 하단 테두리 출력
-    Logger.log('└─────────┴─────────┴─────────┴─────────┘');
+    Logger.log('└─────────┴─────────┴─────────┴─────────┴─────────┘');
   }
 }

--- a/lib/model/node/node_provider_state.dart
+++ b/lib/model/node/node_provider_state.dart
@@ -57,9 +57,9 @@ class NodeProviderState {
     }
 
     final connectionStateSymbol = connectionStateToSymbol(nodeSyncState);
-    final buffer = StringBuffer();
 
     if (registeredWallets.isEmpty) {
+      final buffer = StringBuffer();
       buffer.writeln('--> 등록된 지갑이 없습니다.');
       buffer.writeln('--> nodeSyncState: $nodeSyncState');
       Logger.log(buffer.toString());
@@ -70,14 +70,17 @@ class NodeProviderState {
     final walletKeys = registeredWallets.keys.toList();
 
     // 테이블 헤더 출력 (connectionState 포함)
-    buffer.writeln('\n');
-    buffer.writeln('┌───────────────────────────────────────┐');
-    buffer.writeln('│ 연결 상태: $connectionStateSymbol${' ' * (23 - connectionStateSymbol.length)}│');
-    buffer.writeln('├─────────┬─────────┬─────────┬─────────┤');
-    buffer.writeln('│ 지갑 ID │  잔액   │  거래   │  UTXO   │');
-    buffer.writeln('├─────────┼─────────┼─────────┼─────────┤');
+    final headerBuffer = StringBuffer();
+    headerBuffer.writeln('\n');
+    headerBuffer.writeln('┌───────────────────────────────────────┐');
+    headerBuffer
+        .writeln('│ 연결 상태: $connectionStateSymbol${' ' * (23 - connectionStateSymbol.length)}│');
+    headerBuffer.writeln('├─────────┬─────────┬─────────┬─────────┤');
+    headerBuffer.writeln('│ 지갑 ID │  잔액   │  거래   │  UTXO   │');
+    headerBuffer.writeln('├─────────┼─────────┼─────────┼─────────┤');
+    Logger.log(headerBuffer.toString());
 
-    // 각 지갑 상태 출력
+    // 각 지갑 상태를 개별적으로 출력 (긴 로그 방지)
     for (int i = 0; i < walletKeys.length; i++) {
       final key = walletKeys[i];
       final value = registeredWallets[key]!;
@@ -86,16 +89,19 @@ class NodeProviderState {
       final transactionSymbol = statusToSymbol(value.transaction);
       final utxoSymbol = statusToSymbol(value.utxo);
 
-      buffer.writeln(
+      final rowBuffer = StringBuffer();
+      rowBuffer.writeln(
           '│ ${key.toString().padRight(7)} │   $balanceSymbol    │   $transactionSymbol    │   $utxoSymbol    │');
 
       // 마지막 행이 아니면 행 구분선 추가
       if (i < walletKeys.length - 1) {
-        buffer.writeln('├─────────┼─────────┼─────────┼─────────┤');
+        rowBuffer.writeln('├─────────┼─────────┼─────────┼─────────┤');
       }
+
+      Logger.log(rowBuffer.toString());
     }
 
-    buffer.writeln('└─────────┴─────────┴─────────┴─────────┘');
-    Logger.log(buffer.toString());
+    // 테이블 하단 테두리 출력
+    Logger.log('└─────────┴─────────┴─────────┴─────────┘');
   }
 }

--- a/lib/model/node/wallet_update_counter.dart
+++ b/lib/model/node/wallet_update_counter.dart
@@ -4,12 +4,15 @@ class WalletUpdateCounter {
   int _balanceCounter;
   int _transactionCounter;
   int _utxoCounter;
+  int _subscriptionCounter;
 
   WalletUpdateCounter({
     int balanceCounter = 0,
     int transactionCounter = 0,
     int utxoCounter = 0,
-  })  : _utxoCounter = utxoCounter,
+    int subscriptionCounter = 0,
+  })  : _subscriptionCounter = subscriptionCounter,
+        _utxoCounter = utxoCounter,
         _transactionCounter = transactionCounter,
         _balanceCounter = balanceCounter;
 
@@ -21,6 +24,9 @@ class WalletUpdateCounter {
   /// 특정 업데이트 요소의 카운터 증가
   void incrementCounter(UpdateElement updateType) {
     switch (updateType) {
+      case UpdateElement.subscription:
+        _subscriptionCounter++;
+        break;
       case UpdateElement.balance:
         _balanceCounter++;
         break;
@@ -38,6 +44,12 @@ class WalletUpdateCounter {
   /// @return 카운터 값이 0이면 true, 아니면 false
   bool decrementCounter(UpdateElement updateType) {
     switch (updateType) {
+      case UpdateElement.subscription:
+        _subscriptionCounter--;
+        if (_subscriptionCounter <= 0) {
+          return true;
+        }
+        break;
       case UpdateElement.balance:
         _balanceCounter--;
         if (_balanceCounter <= 0) {

--- a/lib/model/node/wallet_update_info.dart
+++ b/lib/model/node/wallet_update_info.dart
@@ -3,12 +3,14 @@ import 'package:coconut_wallet/enums/network_enums.dart';
 /// 갱신된 데이터 정보를 담는 클래스
 class WalletUpdateInfo {
   final int walletId;
+  WalletSyncState subscription;
   WalletSyncState balance;
   WalletSyncState utxo;
   WalletSyncState transaction;
 
   WalletUpdateInfo(
     this.walletId, {
+    this.subscription = WalletSyncState.waiting,
     this.balance = WalletSyncState.waiting,
     this.transaction = WalletSyncState.waiting,
     this.utxo = WalletSyncState.waiting,
@@ -19,16 +21,21 @@ class WalletUpdateInfo {
       identical(this, other) ||
       other is WalletUpdateInfo &&
           walletId == other.walletId &&
+          subscription == other.subscription &&
           balance == other.balance &&
           utxo == other.utxo &&
           transaction == other.transaction;
 
   @override
-  int get hashCode => Object.hash(walletId, balance, utxo, transaction);
+  int get hashCode => Object.hash(walletId, subscription, balance, utxo, transaction);
 
   factory WalletUpdateInfo.fromExisting(WalletUpdateInfo existingInfo,
-      {WalletSyncState? balance, WalletSyncState? transaction, WalletSyncState? utxo}) {
+      {WalletSyncState? subscription,
+      WalletSyncState? balance,
+      WalletSyncState? transaction,
+      WalletSyncState? utxo}) {
     return WalletUpdateInfo(existingInfo.walletId,
+        subscription: subscription ?? existingInfo.subscription,
         balance: balance ?? existingInfo.balance,
         transaction: transaction ?? existingInfo.transaction,
         utxo: utxo ?? existingInfo.utxo);

--- a/lib/providers/node_provider/isolate/isolate_controller.dart
+++ b/lib/providers/node_provider/isolate/isolate_controller.dart
@@ -43,7 +43,9 @@ class IsolateController {
           isolateToMainSendPort.send(Result.success(true));
           break;
         case IsolateControllerCommand.subscribeWallet:
-          isolateToMainSendPort.send(await _subscriptionService.subscribeWallet(params[0]));
+          final walletItem = params[0];
+          _isolateStateManager.initWalletUpdateStatus(walletItem.id);
+          isolateToMainSendPort.send(await _subscriptionService.subscribeWallet(walletItem));
           break;
         case IsolateControllerCommand.unsubscribeWallet:
           isolateToMainSendPort.send(await _subscriptionService.unsubscribeWallet(params[0]));

--- a/lib/providers/node_provider/state/isolate_state_manager.dart
+++ b/lib/providers/node_provider/state/isolate_state_manager.dart
@@ -67,6 +67,10 @@ class IsolateStateManager implements StateManagerInterface {
     WalletSyncState prevStatus;
 
     switch (updateType) {
+      case UpdateElement.subscription:
+        prevStatus = walletUpdateInfo.subscription;
+        walletUpdateInfo.subscription = newStatus;
+        return prevStatus != newStatus;
       case UpdateElement.balance:
         prevStatus = walletUpdateInfo.balance;
         walletUpdateInfo.balance = newStatus;
@@ -157,7 +161,8 @@ class IsolateStateManager implements StateManagerInterface {
       return false;
     }
 
-    return walletInfo.balance == WalletSyncState.syncing ||
+    return walletInfo.subscription == WalletSyncState.syncing ||
+        walletInfo.balance == WalletSyncState.syncing ||
         walletInfo.transaction == WalletSyncState.syncing ||
         walletInfo.utxo == WalletSyncState.syncing;
   }

--- a/lib/providers/node_provider/state/node_state_manager.dart
+++ b/lib/providers/node_provider/state/node_state_manager.dart
@@ -85,8 +85,9 @@ class NodeStateManager implements StateManagerInterface {
       final prevWalletInfo = prevState.registeredWallets[walletId]!;
       final newWalletInfo = newState.registeredWallets[walletId]!;
 
-      // 지갑 상세 상태 비교 (balance, transaction, utxo)
-      if (prevWalletInfo.balance != newWalletInfo.balance ||
+      // 지갑 상세 상태 비교 (subscription, balance, transaction, utxo)
+      if (prevWalletInfo.subscription != newWalletInfo.subscription ||
+          prevWalletInfo.balance != newWalletInfo.balance ||
           prevWalletInfo.transaction != newWalletInfo.transaction ||
           prevWalletInfo.utxo != newWalletInfo.utxo) {
         return true;
@@ -122,6 +123,9 @@ class NodeStateManager implements StateManagerInterface {
     }
 
     switch (updateType) {
+      case UpdateElement.subscription:
+        walletUpdateInfo.subscription = WalletSyncState.syncing;
+        break;
       case UpdateElement.balance:
         walletUpdateInfo.balance = WalletSyncState.syncing;
         break;
@@ -157,6 +161,9 @@ class NodeStateManager implements StateManagerInterface {
     NodeSyncState? newConnectionState;
 
     switch (updateType) {
+      case UpdateElement.subscription:
+        walletUpdateInfo.subscription = WalletSyncState.completed;
+        break;
       case UpdateElement.balance:
         walletUpdateInfo.balance = WalletSyncState.completed;
         break;
@@ -193,6 +200,7 @@ class NodeStateManager implements StateManagerInterface {
     if (existingInfo == null) {
       updateInfo = WalletUpdateInfo(
         walletId,
+        subscription: WalletSyncState.completed,
         balance: WalletSyncState.completed,
         transaction: WalletSyncState.completed,
         utxo: WalletSyncState.completed,
@@ -201,6 +209,7 @@ class NodeStateManager implements StateManagerInterface {
       // 기존 정보가 있는 경우 모든 카운터를 0으로 설정하고 상태를 완료로 변경
       updateInfo = WalletUpdateInfo.fromExisting(
         existingInfo,
+        subscription: WalletSyncState.completed,
         balance: WalletSyncState.completed,
         transaction: WalletSyncState.completed,
         utxo: WalletSyncState.completed,
@@ -289,7 +298,8 @@ class NodeStateManager implements StateManagerInterface {
     final registeredWallets = updatedWallets ?? _state.registeredWallets;
 
     for (final walletInfo in registeredWallets.values) {
-      if (walletInfo.balance != WalletSyncState.completed ||
+      if (walletInfo.subscription != WalletSyncState.completed ||
+          walletInfo.balance != WalletSyncState.completed ||
           walletInfo.transaction != WalletSyncState.completed ||
           walletInfo.utxo != WalletSyncState.completed) {
         return false;

--- a/lib/providers/node_provider/subscription/script_sync_service.dart
+++ b/lib/providers/node_provider/subscription/script_sync_service.dart
@@ -79,6 +79,8 @@ class ScriptSyncService {
         await _addressRepository.setWalletAddressUsed(
             dto.walletItem, dto.scriptStatus.index, dto.scriptStatus.isChange);
       }
+      // 구독 완료
+      _stateManager.addWalletCompletedState(dto.walletItem.id, UpdateElement.subscription);
 
       // Balance 동기화
       await _balanceSyncService.fetchScriptBalance(dto.walletItem, dto.scriptStatus);
@@ -137,9 +139,6 @@ class ScriptSyncService {
   }) async {
     try {
       final now = DateTime.now();
-
-      // 지갑 업데이트 상태 초기화
-      _stateManager.initWalletUpdateStatus(walletItem.id);
 
       // Balance 병렬 처리
       await _balanceSyncService.fetchScriptBalanceBatch(walletItem, scriptStatuses);

--- a/lib/providers/node_provider/subscription/subscription_service.dart
+++ b/lib/providers/node_provider/subscription/subscription_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:coconut_wallet/enums/network_enums.dart';
 import 'package:coconut_wallet/model/node/script_status.dart';
 import 'package:coconut_wallet/model/node/subscribe_stream_dto.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
@@ -36,6 +37,7 @@ class SubscriptionService {
   Future<Result<bool>> subscribeWallet(
     WalletListItemBase walletItem,
   ) async {
+    _stateManager.addWalletSyncState(walletItem.id, UpdateElement.subscription);
     final [receiveResult, changeResult] = await Future.wait([
       _subscribeWallet(walletItem, false, _scriptStatusController),
       _subscribeWallet(walletItem, true, _scriptStatusController),
@@ -72,6 +74,8 @@ class SubscriptionService {
       _stateManager.addWalletCompletedAllStates(walletItem.id);
       return Result.success(true);
     }
+
+    _stateManager.addWalletCompletedState(walletItem.id, UpdateElement.subscription);
 
     // 변경 이력이 있는 지갑에 대해서만 balance, transaction, utxo 업데이트
     await _scriptSyncService.syncBatchScriptStatusList(


### PR DESCRIPTION
### 1. 변경사항
- 구독 상태 관리 추가
- 동기화 상태 로그 출력할 때 지갑 갯수 4개부터 잘리는 오류 수정

### 2. 테스트 방법
- 저사양 기기에서 지갑 여러개 연달아 추가, 잔액 갱신에 오류가 없어야 함

### 이슈
- #359