### PR TITLE
[358] Unsigned Transaction의 QR 여백 사이즈 조정

### DIFF
--- a/lib/screens/send/unsigned_transaction_qr_screen.dart
+++ b/lib/screens/send/unsigned_transaction_qr_screen.dart
@@ -29,9 +29,6 @@ class _UnsignedTransactionQrScreenState extends State<UnsignedTransactionQrScree
   late final WalletImportSource _walletImportSource;
   late QrScanDensity _qrScanDensity;
   late double _sliderValue;
-  late double _qrPaddingVertical;
-  late double _qrSize;
-  bool _isQrDensityInitialized = false;
   late bool? _isDonation;
 
   @override
@@ -47,39 +44,34 @@ class _UnsignedTransactionQrScreenState extends State<UnsignedTransactionQrScree
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
     //  (QR스캔성능)    일반 화면        갤폴드 접은 화면
     //     볼트           상                상
     //    키스톤           상                상
     //   시드사이너         상                하
     //    제이드          중상                하
-    if (!_isQrDensityInitialized) {
-      final screenWidth = MediaQuery.of(context).size.width;
-      final isNarrowScreen = screenWidth < 360;
-      _qrSize = MediaQuery.sizeOf(context).width * 0.9;
+    final screenWidth = MediaQuery.of(context).size.width;
+    final isNarrowScreen = screenWidth < 360;
 
-      switch (_walletImportSource) {
-        case WalletImportSource.coconutVault:
-          _qrScanDensity = QrScanDensity.fast;
-          _qrSize = MediaQuery.sizeOf(context).width * 0.8;
-          _qrPaddingVertical = 0;
-          break;
-        case WalletImportSource.seedSigner:
-          _qrScanDensity = isNarrowScreen ? QrScanDensity.slow : QrScanDensity.fast;
-          _qrPaddingVertical = 60;
-          break;
-        case WalletImportSource.extendedPublicKey:
-          _qrScanDensity = QrScanDensity.fast;
-          _qrPaddingVertical = 60;
-          break;
-        default:
-          _qrScanDensity = isNarrowScreen ? QrScanDensity.normal : QrScanDensity.fast;
-          _qrPaddingVertical = 30;
-          break;
-      }
-      _sliderValue = _qrScanDensity.index * 5;
-      _isQrDensityInitialized = true;
+    switch (_walletImportSource) {
+      case WalletImportSource.coconutVault:
+      case WalletImportSource.keystone:
+        // 볼트와 키스톤은 스캔 성능이 우수하기 때문에 일반/좁은 화면 모두 _qrScanDensity: fast, padding: 16으로 설정
+        _qrScanDensity = QrScanDensity.fast;
+        break;
+      case WalletImportSource.seedSigner:
+      case WalletImportSource.extendedPublicKey:
+        // 시드사이너는 좁은 화면에서 _qrScanDensity slow가 안정적임
+        _qrScanDensity = isNarrowScreen ? QrScanDensity.slow : QrScanDensity.fast;
+        break;
+      case WalletImportSource.jade:
+        // 제이드는 카메라 성능 최악
+        _qrScanDensity = isNarrowScreen ? QrScanDensity.slow : QrScanDensity.normal;
+        break;
+      default:
+        _qrScanDensity = QrScanDensity.normal;
+        break;
     }
+    _sliderValue = _qrScanDensity.index * 5;
   }
 
   @override
@@ -89,7 +81,7 @@ class _UnsignedTransactionQrScreenState extends State<UnsignedTransactionQrScree
     const targetMmSize = 62.8 * 0.9; // 폴드1에서의 QR mm 크기
 
     // 테스트용(갤폴드에서 보이는 QR사이즈)
-    // final qrSize = screenWidth * (targetMmSize / deviceMmWidth);
+    final qrSize = screenWidth * (targetMmSize / deviceMmWidth);
     return Scaffold(
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       backgroundColor: CoconutColors.black,
@@ -118,8 +110,10 @@ class _UnsignedTransactionQrScreenState extends State<UnsignedTransactionQrScree
                 ),
                 Container(
                   margin: const EdgeInsets.only(top: 40),
-                  padding: EdgeInsets.symmetric(
-                    vertical: _qrPaddingVertical,
+                  // width: qrSize, // 테스트용(갤폴드에서 보이는 QR사이즈)
+                  // height: qrSize, // 테스트용(갤폴드에서 보이는 QR사이즈)
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 16,
                     horizontal: 16,
                   ),
                   decoration: BoxDecoration(
@@ -127,8 +121,6 @@ class _UnsignedTransactionQrScreenState extends State<UnsignedTransactionQrScree
                   child: Center(
                     child: AnimatedQrView(
                       key: ValueKey(_qrScanDensity),
-                      qrSize: _qrSize,
-                      // qrSize: qrSize, // 테스트용(갤폴드에서 보이는 QR사이즈)
                       qrScanDensity: _qrScanDensity,
                       qrViewDataHandler:
                           BcUrQrViewHandler(_psbtBase64, _qrScanDensity, {'urType': 'crypto-psbt'}),

--- a/lib/widgets/animated_qr/animated_qr_view.dart
+++ b/lib/widgets/animated_qr/animated_qr_view.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/screens/send/unsigned_transaction_qr_screen.dart';
 import 'package:coconut_wallet/widgets/animated_qr/view_data_handler/i_qr_view_data_handler.dart';
 import 'package:coconut_wallet/widgets/overlays/coconut_loading_overlay.dart';
@@ -7,14 +8,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 class AnimatedQrView extends StatefulWidget {
-  final double qrSize;
   final int milliSeconds;
   final QrScanDensity qrScanDensity;
   final IQrViewDataHandler qrViewDataHandler;
 
   const AnimatedQrView(
       {super.key,
-      required this.qrSize,
       required this.qrViewDataHandler,
       required this.qrScanDensity,
       this.milliSeconds = 600});
@@ -67,17 +66,23 @@ class _AnimatedQrViewState extends State<AnimatedQrView> {
       // QR 전환이 바로 안될 때를 대비한 위젯 - 실제로는 렌더링 되지 않을 가능성 높음
       return Stack(
         children: [
-          QrImageView(data: _qrData, size: widget.qrSize, version: _qrVersion),
+          QrImageView(data: _qrData, version: _qrVersion),
           Positioned(
-            left: 0,
-            right: 0,
-            top: 0,
-            bottom: 0,
-            child: SizedBox(
-              width: widget.qrSize,
-              height: widget.qrSize,
-              child: const CoconutLoadingOverlay(
-                applyFullScreen: true,
+            left: 70,
+            right: 70,
+            top: 70,
+            bottom: 70,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: Container(
+                width: 100,
+                height: 100,
+                decoration: const BoxDecoration(
+                  color: CoconutColors.gray300,
+                ),
+                child: const CoconutLoadingOverlay(
+                  applyFullScreen: true,
+                ),
               ),
             ),
           ),
@@ -89,7 +94,7 @@ class _AnimatedQrViewState extends State<AnimatedQrView> {
     // 시드사이너가 QR version 10 인 경우 빠르게 인식이 안되어 9로 설정합니다.
     // 아래 QrImageView의 maxInputLength는 2192bits(274bytes)
 
-    return QrImageView(data: _qrData, size: widget.qrSize, version: _qrVersion);
+    return QrImageView(data: _qrData, version: _qrVersion);
   }
 
   @override


### PR DESCRIPTION
## 1. 변경 사항
Unsigned Transaction 화면의 QR 여백이 일치하지 않았던 현상을 해결했습니다.
모든 기기(볼트, 키스톤, 시드사이너, 제이드)로 테스트 한 결과,
QR에 담긴 정보량(density)과 QR 패딩이 스캔 성공 여부에 영향이 있음을 확인했습니다.
-> 해당 기기의 스캔 성공률이 높아지도록 패딩을 조정하는 것 보다는 density의 초기 설정값을 다르게 하는 것이 통일성이 있다고 생각했습니다.

QR의 패딩은 모든 기기에서 16으로 통일했습니다.

```dart
final screenWidth = MediaQuery.of(context).size.width;
    final isNarrowScreen = screenWidth < 360;

    switch (_walletImportSource) {
      case WalletImportSource.coconutVault:
      case WalletImportSource.keystone:
        // 볼트와 키스톤은 스캔 성능이 우수하기 때문에 일반/좁은 화면 모두 _qrScanDensity: fast, padding: 16으로 설정
        _qrScanDensity = QrScanDensity.fast;
        break;
      case WalletImportSource.seedSigner:
      case WalletImportSource.extendedPublicKey:
        // 시드사이너는 좁은 화면에서 _qrScanDensity slow가 안정적임
        _qrScanDensity = isNarrowScreen ? QrScanDensity.slow : QrScanDensity.fast;
        break;
      case WalletImportSource.jade:
        // 제이드는 카메라 성능 최악
        _qrScanDensity = isNarrowScreen ? QrScanDensity.slow : QrScanDensity.normal;
        break;
      default:
        _qrScanDensity = QrScanDensity.normal;
        break;
    }
```
## [볼트, 키스톤]
볼트와 키스톤은 스캔 성능이 우수했습니다.
-> 화면 진입 초기에 설정되는 _qrScanDensity는 일반 화면, 좁은 화면 모두 fast로 설정

## [시드사이너]
시드사이너는 좁은 화면(360px 이하)에서 스캔 성공률이 저조했습니다.
-> _qrScanDensity는 좁은 화면 slow, 일반 화면 fast로 설정

## [JADE]
제이드는 카메라 성능이 다른 기기보다 낮았으나, 일반 화면에서 QrScanDensity.normal인 경우 스캔이 어렵진 않았습니다.
-> _qrScanDensity는 좁은 화면 slow, 일반 화면 normal로 설정

## 2. 테스트 방법
1) UnsignedTransactionQrScreen에서 하드월렛별 초기 설정되는 _qrScanDensity가 올바르게 설정되는지 확인합니다.
2) 갤럭시 폴드 접은 화면에서도 확인해보면 좋을 것 같습니다. (JADE, 시드사이너 등록 후)

## 3. 이슈 번호
#358 