### PR TITLE
[374] 영문 UI 수정 사항

### DIFF
--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -339,6 +339,11 @@ utxo_list_screen:
 
 transaction_detail_screen:
   confirmation: "$height ($count confirmations)"
+  time_ago:
+    just_now: just now
+    minutes: ${count} minutes ago
+    hours: ${count} hours ago
+    days: ${count} days ago
 
 utxo_detail_screen:
   pending: "Pending Confirmation"

--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -208,7 +208,7 @@ wallet_add_input_screen:
 # lib/screens/review
 negative_feedback_screen:
   text1: "Sorry😭"
-  text2: "Please let us know if you have any inconvenience or suggestions!"
+  text2: "Please let us know\nif you have any inconvenience or suggestions!"
   text3: "Send 1:1 message"
   text4: "Next time"
 positive_feedback_screen:

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -381,6 +381,11 @@ utxo_list_screen:
 
 transaction_detail_screen:
   confirmation: "$height ($count승인)"
+  time_ago:
+    just_now: 방금 전
+    minutes: ${count}분 째
+    hours: ${count}시간 째
+    days: ${count}일 째
 
 utxo_detail_screen:
   pending: "승인 대기중"

--- a/lib/screens/home/wallet_list_user_experience_survey_bottom_sheet.dart
+++ b/lib/screens/home/wallet_list_user_experience_survey_bottom_sheet.dart
@@ -39,63 +39,69 @@ class UserExperienceSurveyBottomSheet extends StatelessWidget {
                 )),
         backgroundColor: CoconutColors.black,
         body: SafeArea(
-          child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Image.asset(
-                  'assets/images/splash_logo_${NetworkType.currentNetworkType.isTestnet ? "regtest" : "mainnet"}.png',
-                ),
-                const SizedBox(height: 30),
-                if (isFirst)
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Image.asset(
+                    'assets/images/splash_logo_${NetworkType.currentNetworkType.isTestnet ? "regtest" : "mainnet"}.png',
+                  ),
+                  const SizedBox(height: 30),
+                  if (isFirst)
+                    FittedBox(
+                      child: Text(
+                        t.user_experience_survey_bottom_sheet.text1,
+                        style: CoconutTypography.heading3_21_Bold.setColor(CoconutColors.white),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
                   Text(
-                    t.user_experience_survey_bottom_sheet.text1,
+                    t.user_experience_survey_bottom_sheet.text2,
                     style: CoconutTypography.heading3_21_Bold.setColor(CoconutColors.white),
                   ),
-                Text(
-                  t.user_experience_survey_bottom_sheet.text2,
-                  style: CoconutTypography.heading3_21_Bold.setColor(CoconutColors.white),
-                ),
-                const SizedBox(
-                  height: 80,
-                ),
-                GestureDetector(
-                  onTap: () => Navigator.pushNamed(context, '/positive-feedback'),
-                  child: Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(14), color: CoconutColors.primary),
-                      child: Text(
-                        t.user_experience_survey_bottom_sheet.text3,
-                        style: CoconutTypography.body2_14_Bold.setColor(CoconutColors.gray700),
-                        textAlign: TextAlign.center,
-                      )),
-                ),
-                const SizedBox(
-                  height: 20,
-                ),
-                GestureDetector(
-                  onTap: () {
-                    Navigator.pushNamed(context, '/negative-feedback');
-                  },
-                  child: Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(14),
-                          color: CoconutColors.white.withOpacity(0.5)),
-                      child: Text(
-                        t.user_experience_survey_bottom_sheet.text4,
-                        style: CoconutTypography.body2_14_Bold.setColor(CoconutColors.white),
-                        textAlign: TextAlign.center,
-                      )),
-                ),
-                const SizedBox(
-                  height: 40,
-                ),
-              ],
+                  const SizedBox(
+                    height: 80,
+                  ),
+                  GestureDetector(
+                    onTap: () => Navigator.pushNamed(context, '/positive-feedback'),
+                    child: Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                        decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(14), color: CoconutColors.primary),
+                        child: Text(
+                          t.user_experience_survey_bottom_sheet.text3,
+                          style: CoconutTypography.body2_14_Bold.setColor(CoconutColors.gray700),
+                          textAlign: TextAlign.center,
+                        )),
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  GestureDetector(
+                    onTap: () {
+                      Navigator.pushNamed(context, '/negative-feedback');
+                    },
+                    child: Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                        decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(14),
+                            color: CoconutColors.white.withOpacity(0.5)),
+                        child: Text(
+                          t.user_experience_survey_bottom_sheet.text4,
+                          style: CoconutTypography.body2_14_Bold.setColor(CoconutColors.white),
+                          textAlign: TextAlign.center,
+                        )),
+                  ),
+                  const SizedBox(
+                    height: 40,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/screens/review/negative_feedback_screen.dart
+++ b/lib/screens/review/negative_feedback_screen.dart
@@ -34,60 +34,66 @@ class NegativeFeedbackScreen extends StatelessWidget {
         ),
         backgroundColor: CoconutColors.black,
         body: SafeArea(
-          child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Text(
-                  t.negative_feedback_screen.text1,
-                  style: CoconutTypography.heading2_28_NumberBold.setColor(CoconutColors.white),
-                ),
-                const SizedBox(
-                  height: 20,
-                ),
-                Text(
-                  t.negative_feedback_screen.text2,
-                  style: CoconutTypography.body1_16,
-                ),
-                const SizedBox(
-                  height: 80,
-                ),
-                GestureDetector(
-                  onTap: () => _runKakaoOpenChat(context),
-                  child: Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(14), color: CoconutColors.primary),
-                      child: Text(
-                        t.negative_feedback_screen.text3,
-                        style: CoconutTypography.body2_14_Bold.setColor(CoconutColors.gray800),
-                        textAlign: TextAlign.center,
-                      )),
-                ),
-                const SizedBox(
-                  height: 20,
-                ),
-                GestureDetector(
-                  onTap: () => _stopGettingFeedback(context),
-                  child: Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(14),
-                        color: CoconutColors.white.withOpacity(0.15),
-                      ),
-                      child: Text(
-                        t.negative_feedback_screen.text4,
-                        style: CoconutTypography.body2_14_Bold.setColor(CoconutColors.white),
-                        textAlign: TextAlign.center,
-                      )),
-                ),
-                const SizedBox(
-                  height: 40,
-                ),
-              ],
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    t.negative_feedback_screen.text1,
+                    style: CoconutTypography.heading2_28_NumberBold.setColor(CoconutColors.white),
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  FittedBox(
+                    child: Text(
+                      t.negative_feedback_screen.text2,
+                      style: CoconutTypography.body1_16,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 80,
+                  ),
+                  GestureDetector(
+                    onTap: () => _runKakaoOpenChat(context),
+                    child: Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                        decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(14), color: CoconutColors.primary),
+                        child: Text(
+                          t.negative_feedback_screen.text3,
+                          style: CoconutTypography.body2_14_Bold.setColor(CoconutColors.gray800),
+                          textAlign: TextAlign.center,
+                        )),
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  GestureDetector(
+                    onTap: () => _stopGettingFeedback(context),
+                    child: Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(14),
+                          color: CoconutColors.white.withOpacity(0.15),
+                        ),
+                        child: Text(
+                          t.negative_feedback_screen.text4,
+                          style: CoconutTypography.body2_14_Bold.setColor(CoconutColors.white),
+                          textAlign: TextAlign.center,
+                        )),
+                  ),
+                  const SizedBox(
+                    height: 40,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/screens/review/positive_feedback_screen.dart
+++ b/lib/screens/review/positive_feedback_screen.dart
@@ -33,61 +33,67 @@ class PositiveFeedbackScreen extends StatelessWidget {
         ),
         backgroundColor: CoconutColors.black,
         body: SafeArea(
-          child: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Text(
-                  t.positive_feedback_screen.text1,
-                  style: Styles.h2.merge(const TextStyle(color: CoconutColors.white)),
-                ),
-                const SizedBox(
-                  height: 20,
-                ),
-                Text(
-                  t.positive_feedback_screen.text2,
-                  style: Styles.body1,
-                ),
-                const SizedBox(
-                  height: 80,
-                ),
-                GestureDetector(
-                  onTap: () => _startInAppReview(context),
-                  child: Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(14), color: CoconutColors.primary),
-                      child: Text(
-                        t.positive_feedback_screen.text3,
-                        style: Styles.label.merge(
-                            const TextStyle(color: MyColors.darkgrey, fontWeight: FontWeight.bold)),
-                        textAlign: TextAlign.center,
-                      )),
-                ),
-                const SizedBox(
-                  height: 20,
-                ),
-                GestureDetector(
-                  onTap: () => _stopGettingFeedback(context),
-                  child: Container(
-                      width: MediaQuery.of(context).size.width * 0.5,
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                      decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(14),
-                          color: MyColors.transparentWhite_15),
-                      child: Text(
-                        t.positive_feedback_screen.text4,
-                        style: Styles.label.merge(const TextStyle(
-                            color: CoconutColors.white, fontWeight: FontWeight.bold)),
-                        textAlign: TextAlign.center,
-                      )),
-                ),
-                const SizedBox(
-                  height: 40,
-                ),
-              ],
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    t.positive_feedback_screen.text1,
+                    style: Styles.h2.merge(const TextStyle(color: CoconutColors.white)),
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  FittedBox(
+                    child: Text(
+                      t.positive_feedback_screen.text2,
+                      style: Styles.body1,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 80,
+                  ),
+                  GestureDetector(
+                    onTap: () => _startInAppReview(context),
+                    child: Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                        decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(14), color: CoconutColors.primary),
+                        child: Text(
+                          t.positive_feedback_screen.text3,
+                          style: Styles.label.merge(const TextStyle(
+                              color: MyColors.darkgrey, fontWeight: FontWeight.bold)),
+                          textAlign: TextAlign.center,
+                        )),
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  GestureDetector(
+                    onTap: () => _stopGettingFeedback(context),
+                    child: Container(
+                        width: MediaQuery.of(context).size.width * 0.5,
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                        decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(14),
+                            color: MyColors.transparentWhite_15),
+                        child: Text(
+                          t.positive_feedback_screen.text4,
+                          style: Styles.label.merge(const TextStyle(
+                              color: CoconutColors.white, fontWeight: FontWeight.bold)),
+                          textAlign: TextAlign.center,
+                        )),
+                  ),
+                  const SizedBox(
+                    height: 40,
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -645,13 +645,13 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen>
     Duration difference = now.difference(timeStamp);
 
     if (difference.inMinutes < 1) {
-      return "방금 전"; // 1분 미만일 경우
+      return t.transaction_detail_screen.time_ago.just_now; // 1분 미만일 경우
     } else if (difference.inMinutes < 60) {
-      return "${difference.inMinutes}분 째"; // 1~59분
+      return t.transaction_detail_screen.time_ago.minutes(count: difference.inMinutes); // 1~59분
     } else if (difference.inHours < 24) {
-      return "${difference.inHours}시간 째"; // 1~23시간
+      return t.transaction_detail_screen.time_ago.hours(count: difference.inHours); // 1~23시간
     } else {
-      return "${difference.inDays}일 째"; // 1일 이상
+      return t.transaction_detail_screen.time_ago.days(count: difference.inDays); // 1일 이상
     }
   }
 


### PR DESCRIPTION
## 1. 변경 사항

<img width="300" src="https://github.com/user-attachments/assets/d0e25b06-b3f1-436b-a1a2-373faf42a3bb" />

transactionDetailScreen화면의 하드코딩되어 있던 '%d분 째', '%d시간 째', '%d일 째' 문구를 slang에 추가
- 방금 전     |    just now
- %d분 째   |   %d minutes ago
- %d시간 째   |   %d hours ago
- %d일 째   |   %d days ago

---

<img width="300" src="https://github.com/user-attachments/assets/4419bbad-b561-4e56-aba7-76451129ed69" />

트랜잭션 실행 후 뜨는 리뷰요청 bottom sheet에 영문버전에서 개행되는 현상이 발생하여, fittedBox로 수정 후 전체 패딩 16 추가

---

## 2. 테스트 방법
1) 앱 언어를 영문으로 설정 후 트랜 잭션 실행
2) 이후 뜨는 리뷰 요청 화면에서 개행 없이 FittedBox가 적용되는지 확인 (negativeFeedbackScreen에서 'Please let us know if you have any inconvenience or suggestions!' 문구는 FittedBox로 적용 시 문구가 너무 작아지기 때문에 Please let us know**\n**if you ... 로 개행 적용
3) 트랜잭션 상세 화면으로 이동 후 시간 표시가 영문으로 나오는지 확인

## 3. 이슈 번호
#374 