### PR TITLE
[386] 전체주소보기 툴팁 UI 변경/개선

### DIFF
--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -525,6 +525,7 @@ tooltip:
   mfp: "This is the unique value of the wallet.\nAlso called Master Fingerprint (MFP)."
   rbf: "A feature to replace an existing transaction with a new one by increasing the fee. (RBF, Replace-By-Fee)"
   cpfp: "A feature to increase priority by setting a high fee on a new transaction (Child) to make the existing transaction (Parent) process faster. (CPFP, Child-Pays-For-Parent)"
+  dont_show_again: "Don't show again"
 
 toast:
   back_exit: "Press the back button once more to exit."

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -567,6 +567,7 @@ tooltip:
   mfp: "지갑의 고유 값이에요.\n마스터 핑거프린트(MFP)라고도 해요."
   rbf: "수수료를 올려, 기존 거래를 새로운 거래로 대체하는 기능이에요. (RBF, Replace-By-Fee)"
   cpfp: "새로운 거래(Child)에 높은 수수료를 지정해 기존 거래(Parent)가 빨리 처리되도록 우선순위를 높이는 기능이에요. (CPFP, Child-Pays-For-Parent)"
+  dont_show_again: "다시 보지 않기"
 
 toast:
   back_exit: "뒤로 가기 버튼을 한 번 더 누르면 종료됩니다."

--- a/lib/constants/shared_pref_keys.dart
+++ b/lib/constants/shared_pref_keys.dart
@@ -14,8 +14,8 @@ class SharedPrefKeys {
   static const String kCanCheckBiometrics = "CAN_CHECK_BIOMETRICS";
   static const String kIsBtcUnit = "IS_BTC_UNIT";
   static const String kShowOnlyUnusedAddresses = "SHOW_ONLY_UNUSED_ADDRESSES";
-  static const String kIsReceivingTooltipDisabled = "IS_RECEIVING_TOOLTIP_VISIBLE";
-  static const String kIsChangeTooltipDisabled = "IS_CHANGE_TOOLTIP_VISIBLE";
+  static const String kIsReceivingTooltipDisabled = "IS_RECEIVING_TOOLTIP_DISABLED";
+  static const String kIsChangeTooltipDisabled = "IS_CHANGE_TOOLTIP_DISABLED";
   static const String kIsBalanceHidden = "IS_BALANCE_HIDDEN";
   static const String kHideTermsShortcut = "IS_OPEN_TERMS_SCREEN";
   static const String kNextIdField = 'nextId';

--- a/lib/constants/shared_pref_keys.dart
+++ b/lib/constants/shared_pref_keys.dart
@@ -14,6 +14,8 @@ class SharedPrefKeys {
   static const String kCanCheckBiometrics = "CAN_CHECK_BIOMETRICS";
   static const String kIsBtcUnit = "IS_BTC_UNIT";
   static const String kShowOnlyUnusedAddresses = "SHOW_ONLY_UNUSED_ADDRESSES";
+  static const String kIsReceivingTooltipDisabled = "IS_RECEIVING_TOOLTIP_VISIBLE";
+  static const String kIsChangeTooltipDisabled = "IS_CHANGE_TOOLTIP_VISIBLE";
   static const String kIsBalanceHidden = "IS_BALANCE_HIDDEN";
   static const String kHideTermsShortcut = "IS_OPEN_TERMS_SCREEN";
   static const String kNextIdField = 'nextId';

--- a/lib/providers/preference_provider.dart
+++ b/lib/providers/preference_provider.dart
@@ -5,6 +5,7 @@ import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/utils/locale_util.dart';
+import 'package:coconut_wallet/utils/logger.dart';
 import 'package:flutter/material.dart';
 
 class PreferenceProvider extends ChangeNotifier {
@@ -101,20 +102,20 @@ class PreferenceProvider extends ChangeNotifier {
   /// 언어 설정 적용 (동기 버전)
   void _applyLanguageSettingSync() {
     try {
-      print('Applying language setting: $_language');
+      Logger.log('Applying language setting: $_language');
       if (_language == 'kr') {
         LocaleSettings.setLocaleSync(AppLocale.kr);
-        print('Korean locale applied successfully');
+        Logger.log('Korean locale applied successfully');
       } else if (_language == 'en') {
         LocaleSettings.setLocaleSync(AppLocale.en);
-        print('English locale applied successfully');
+        Logger.log('English locale applied successfully');
       }
 
       // 언어 설정 후 상태 업데이트를 위해 notifyListeners 호출
       notifyListeners();
     } catch (e) {
       // 언어 초기화 실패 시 로그 출력 (선택사항)
-      print('Language initialization failed: $e');
+      Logger.log('Language initialization failed: $e');
     }
   }
 
@@ -131,7 +132,7 @@ class PreferenceProvider extends ChangeNotifier {
       }
     } catch (e) {
       // 언어 초기화 실패 시 로그 출력 (선택사항)
-      print('Language initialization failed: $e');
+      Logger.log('Language initialization failed: $e');
     }
   }
 

--- a/lib/providers/preference_provider.dart
+++ b/lib/providers/preference_provider.dart
@@ -29,6 +29,14 @@ class PreferenceProvider extends ChangeNotifier {
   late bool _showOnlyUnusedAddresses;
   bool get showOnlyUnusedAddresses => _showOnlyUnusedAddresses;
 
+  /// 전체 주소 보기 화면 [입금] 툴팁 표시 여부
+  late bool _isReceivingTooltipDisabled;
+  bool get isReceivingTooltipDisabled => _isReceivingTooltipDisabled;
+
+  /// 전체 주소 보기 화면 [잔돈] 툴팁 표시 여부
+  late bool _isChangeTooltipDisabled;
+  bool get isChangeTooltipDisabled => _isChangeTooltipDisabled;
+
   /// 언어 설정
   late String _language;
   String get language => _language;
@@ -45,6 +53,8 @@ class PreferenceProvider extends ChangeNotifier {
         ? _sharedPrefs.getBool(SharedPrefKeys.kIsBtcUnit)
         : true;
     _showOnlyUnusedAddresses = _sharedPrefs.getBool(SharedPrefKeys.kShowOnlyUnusedAddresses);
+    _isReceivingTooltipDisabled = _sharedPrefs.getBool(SharedPrefKeys.kIsReceivingTooltipDisabled);
+    _isChangeTooltipDisabled = _sharedPrefs.getBool(SharedPrefKeys.kIsChangeTooltipDisabled);
 
     // 통화 설정 초기화
     _initializeFiat();
@@ -158,6 +168,20 @@ class PreferenceProvider extends ChangeNotifier {
   Future<void> changeShowOnlyUnusedAddresses(bool show) async {
     _showOnlyUnusedAddresses = show;
     await _sharedPrefs.setBool(SharedPrefKeys.kShowOnlyUnusedAddresses, show);
+    notifyListeners();
+  }
+
+  /// 주소 리스트 화면 '입금' 툴팁 다시 보지 않기 설정
+  Future<void> setReceivingTooltipDisabledPermanently() async {
+    _isReceivingTooltipDisabled = true;
+    await _sharedPrefs.setBool(SharedPrefKeys.kIsReceivingTooltipDisabled, true);
+    notifyListeners();
+  }
+
+  /// 주소 리스트 화면 '잔돈' 툴팁 다시 보지 않기 설정
+  Future<void> setChangeTooltipDisabledPermanently() async {
+    _isChangeTooltipDisabled = true;
+    await _sharedPrefs.setBool(SharedPrefKeys.kIsChangeTooltipDisabled, true);
     notifyListeners();
   }
 

--- a/lib/providers/preference_provider.dart
+++ b/lib/providers/preference_provider.dart
@@ -29,13 +29,13 @@ class PreferenceProvider extends ChangeNotifier {
   late bool _showOnlyUnusedAddresses;
   bool get showOnlyUnusedAddresses => _showOnlyUnusedAddresses;
 
-  /// 전체 주소 보기 화면 [입금] 툴팁 표시 여부
+  /// 전체 주소 보기 화면 [입금] 툴팁 표시 여부 - 영문 버전에서는 표시 안함
   late bool _isReceivingTooltipDisabled;
-  bool get isReceivingTooltipDisabled => _isReceivingTooltipDisabled;
+  bool get isReceivingTooltipDisabled => language == 'kr' ? _isReceivingTooltipDisabled : true;
 
-  /// 전체 주소 보기 화면 [잔돈] 툴팁 표시 여부
+  /// 전체 주소 보기 화면 [잔돈] 툴팁 표시 여부 - 영문 버전에서는 표시 안함
   late bool _isChangeTooltipDisabled;
-  bool get isChangeTooltipDisabled => _isChangeTooltipDisabled;
+  bool get isChangeTooltipDisabled => language == 'kr' ? _isChangeTooltipDisabled : true;
 
   /// 언어 설정
   late String _language;

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -220,6 +220,7 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                                                 _isWalletInfoExpanded
                                                     ? 'assets/svg/circle-warning.svg'
                                                     : 'assets/svg/circle-help.svg',
+                                                width: 18,
                                                 colorFilter: const ColorFilter.mode(
                                                     CoconutColors.white, BlendMode.srcIn),
                                               ),

--- a/lib/screens/wallet_detail/address_list_screen.dart
+++ b/lib/screens/wallet_detail/address_list_screen.dart
@@ -264,19 +264,11 @@ class _AddressListScreenState extends State<AddressListScreen> {
               Selector<PreferenceProvider, bool>(
                 selector: (context, provider) => provider.isReceivingTooltipDisabled,
                 builder: (context, isReceivingTooltipDisabled, child) {
-                  if (isReceivingTooltipDisabled) {
-                    return Container();
-                  }
-                  return Column(
-                    children: [
-                      _buildTooltip(
-                        t.tooltip.address_receiving,
-                        () => context
-                            .read<PreferenceProvider>()
-                            .setReceivingTooltipDisabledPermanently(),
-                      ),
-                      CoconutLayout.spacing_700h,
-                    ],
+                  return _buildAnimatedTooltip(
+                    isDisabled: isReceivingTooltipDisabled,
+                    text: t.tooltip.address_receiving,
+                    onDisable: () =>
+                        context.read<PreferenceProvider>().setReceivingTooltipDisabledPermanently(),
                   );
                 },
               ),
@@ -284,22 +276,36 @@ class _AddressListScreenState extends State<AddressListScreen> {
               Selector<PreferenceProvider, bool>(
                 selector: (context, provider) => provider.isChangeTooltipDisabled,
                 builder: (context, isChangeTooltipDisabled, child) {
-                  if (isChangeTooltipDisabled) {
-                    return Container();
-                  }
-                  return Column(
-                    children: [
-                      _buildTooltip(
-                        t.tooltip.address_change,
-                        () => context
-                            .read<PreferenceProvider>()
-                            .setChangeTooltipDisabledPermanently(),
-                      ),
-                      CoconutLayout.spacing_700h,
-                    ],
+                  return _buildAnimatedTooltip(
+                    isDisabled: isChangeTooltipDisabled,
+                    text: t.tooltip.address_change,
+                    onDisable: () =>
+                        context.read<PreferenceProvider>().setChangeTooltipDisabledPermanently(),
                   );
                 },
               ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAnimatedTooltip({
+    required bool isDisabled,
+    required String text,
+    required VoidCallback onDisable,
+  }) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
+      height: isDisabled ? 0 : null,
+      curve: Curves.easeInOut,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 500),
+        opacity: isDisabled ? 0.0 : 1.0,
+        child: Column(
+          children: [
+            _buildTooltip(text, onDisable),
+            CoconutLayout.spacing_700h,
           ],
         ),
       ),

--- a/lib/screens/wallet_detail/address_list_screen.dart
+++ b/lib/screens/wallet_detail/address_list_screen.dart
@@ -339,7 +339,7 @@ class _AddressListScreenState extends State<AddressListScreen> {
                 CoconutLayout.spacing_50h,
                 CoconutUnderlinedButton(
                     padding: const EdgeInsets.only(top: 8, right: 8, bottom: 8),
-                    text: '다시 보지 않기',
+                    text: t.tooltip.dont_show_again,
                     textStyle: CoconutTypography.body3_12,
                     onTap: onTap)
               ],

--- a/lib/screens/wallet_detail/address_list_screen.dart
+++ b/lib/screens/wallet_detail/address_list_screen.dart
@@ -9,14 +9,13 @@ import 'package:coconut_wallet/providers/preference_provider.dart';
 import 'package:coconut_wallet/providers/view_model/wallet_detail/address_list_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/utils/logger.dart';
-import 'package:coconut_wallet/widgets/button/tooltip_button.dart';
 import 'package:coconut_wallet/widgets/card/address_list_address_item_card.dart';
 import 'package:coconut_wallet/widgets/overlays/common_bottom_sheets.dart';
 import 'package:coconut_wallet/screens/common/qrcode_bottom_sheet.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
+import 'package:tuple/tuple.dart';
 
 class AddressListScreen extends StatefulWidget {
   final int id;
@@ -29,51 +28,17 @@ class AddressListScreen extends StatefulWidget {
 }
 
 class _AddressListScreenState extends State<AddressListScreen> {
-  bool _isTapOnTooltipButton(Offset globalPosition) {
-    final keys = [_receivingTooltipKey, _changeTooltipKey];
-
-    for (final key in keys) {
-      final context = key.currentContext;
-      if (context == null) continue;
-
-      final box = context.findRenderObject() as RenderBox;
-      final position = box.localToGlobal(Offset.zero);
-      final size = box.size;
-      final rect = position & size;
-
-      if (rect.contains(globalPosition)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   /// 페이지네이션
   late final AddressListViewModel viewModel;
   bool _isInitializing = false;
   bool _isLoadMoreRunning = false;
   bool _isScrollingToTop = false;
-  bool isReceivingSelected = true;
-
-  /// 툴팁
-  final GlobalKey _receivingTooltipKey = GlobalKey();
-  final GlobalKey _changeTooltipKey = GlobalKey();
-  final GlobalKey _toolbarWidgetKey = GlobalKey();
-
-  Offset _receivingTooltipIconPosition = Offset.zero;
-  Offset _changeTooltipIconPosition = Offset.zero;
-
-  late RenderBox _receivingTooltipIconRenderBox;
-  late RenderBox _changeTooltipIconRenderBox;
+  bool _isReceivingSelected = true;
 
   final GlobalKey _appBarKey = GlobalKey();
+  final GlobalKey _toolTipKey = GlobalKey();
   Size _appBarSize = const Size(0, 0);
-
-  bool _receivingTooltipVisible = false;
-  bool _changeTooltipVisible = false;
-  Timer? _tooltipTimer;
-  int _tooltipRemainingTime = 5;
+  Size _toolTipSize = const Size(0, 0);
 
   /// 스크롤
   final bool _isScrollOverTitleHeight = false;
@@ -82,109 +47,35 @@ class _AddressListScreenState extends State<AddressListScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final Tuple2<bool, bool> isTooltipDisabled =
+        context.select<PreferenceProvider, Tuple2<bool, bool>>(
+      (provider) => Tuple2(provider.isReceivingTooltipDisabled, provider.isChangeTooltipDisabled),
+    );
     return ChangeNotifierProvider.value(
       value: viewModel,
       child: Consumer<AddressListViewModel>(
         builder: (context, viewModel, child) {
           List<WalletAddress> addressList =
-              isReceivingSelected ? viewModel.receivingAddressList : viewModel.changeAddressList;
-          return PopScope(
-            canPop: true,
-            onPopInvokedWithResult: (didPop, _) {
-              _removeTooltip();
-            },
-            child: Stack(
-              children: [
-                GestureDetector(
-                  onTapDown: (details) {
-                    if (!_isTapOnTooltipButton(details.globalPosition)) {
-                      _removeTooltip();
-                    }
-                  },
-                  child: Scaffold(
-                      extendBodyBehindAppBar: true,
-                      backgroundColor: CoconutColors.black,
-                      appBar: _buildAppBar(context),
-                      body: Column(
-                        children: [
-                          _buildSegmentedControl(),
-                          Expanded(
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 10),
-                              child: _isInitializing
-                                  ? const Center(child: CircularProgressIndicator())
-                                  : GestureDetector(
-                                      onTapDown: (_) {
-                                        _removeTooltip();
-                                      },
-                                      behavior: HitTestBehavior.opaque,
-                                      child: Stack(
-                                        children: [
-                                          NotificationListener<UserScrollNotification>(
-                                            onNotification: (notification) {
-                                              if (notification.direction != ScrollDirection.idle) {
-                                                _removeTooltip();
-                                              }
-                                              return false;
-                                            },
-                                            child: ListView.builder(
-                                              padding: EdgeInsets.zero,
-                                              controller: _controller,
-                                              itemCount: addressList.length,
-                                              itemBuilder: (context, index) => AddressItemCard(
-                                                onPressed: () {
-                                                  _removeTooltip();
-                                                  CommonBottomSheets.showBottomSheet_90(
-                                                      context: context,
-                                                      child: QrcodeBottomSheet(
-                                                          qrcodeTopWidget: Text(
-                                                            addressList[index].derivationPath,
-                                                            style: CoconutTypography.body2_14.merge(
-                                                              TextStyle(
-                                                                color: CoconutColors.white
-                                                                    .withOpacity(0.7),
-                                                              ),
-                                                            ),
-                                                          ),
-                                                          qrData: addressList[index].address,
-                                                          title: t.address_list_screen
-                                                              .address_index(
-                                                                  index:
-                                                                      addressList[index].index)));
-                                                },
-                                                address: addressList[index].address,
-                                                derivationPath: addressList[index].derivationPath,
-                                                isUsed: addressList[index].isUsed,
-                                                balanceInSats: addressList[index].total,
-                                                currentUnit: _currentUnit,
-                                              ),
-                                            ),
-                                          ),
-                                          if (_isLoadMoreRunning)
-                                            Positioned(
-                                              left: 0,
-                                              right: 0,
-                                              bottom: 40,
-                                              child: Container(
-                                                padding: const EdgeInsets.all(30),
-                                                child: const Center(
-                                                  child: CircularProgressIndicator(
-                                                      color: CoconutColors.white),
-                                                ),
-                                              ),
-                                            ),
-                                        ],
-                                      ),
-                                    ),
-                            ),
-                          ),
-                        ],
-                      )),
-                ),
-                //
-                tooltipWidget(context),
-              ],
-            ),
+              _isReceivingSelected ? viewModel.receivingAddressList : viewModel.changeAddressList;
+          return GestureDetector(
+            child: Scaffold(
+                extendBodyBehindAppBar: true,
+                backgroundColor: CoconutColors.black,
+                appBar: _buildAppBar(context),
+                body: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                  ),
+                  child: Column(
+                    children: [
+                      _buildSegmentedControl(),
+                      _buildShowOnlyUsedAddressesButton(),
+                      Expanded(
+                        child: _buildAddressList(addressList, isTooltipDisabled),
+                      ),
+                    ],
+                  ),
+                )),
           );
         },
       ),
@@ -193,10 +84,6 @@ class _AddressListScreenState extends State<AddressListScreen> {
 
   @override
   void dispose() {
-    if (_tooltipTimer != null) {
-      _tooltipTimer!.cancel();
-      _tooltipTimer = null;
-    }
     _controller.dispose();
     super.dispose();
   }
@@ -204,26 +91,24 @@ class _AddressListScreenState extends State<AddressListScreen> {
   @override
   void initState() {
     super.initState();
+    final preferenceProvider = context.read<PreferenceProvider>();
+
     viewModel = AddressListViewModel(context.read<WalletProvider>(), widget.id);
-    _currentUnit = context.read<PreferenceProvider>().currentUnit;
+    _currentUnit = preferenceProvider.currentUnit;
     _controller = ScrollController();
     _initializeAddressList();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _controller.addListener(_nextLoad);
-
-      if (_appBarKey.currentContext != null) {
-        final appBarRenderBox = _appBarKey.currentContext?.findRenderObject() as RenderBox;
-        _appBarSize = appBarRenderBox.size;
+      if (_appBarKey.currentContext?.mounted ?? false) {
+        final renderObject = _appBarKey.currentContext!.findRenderObject();
+        if (renderObject is RenderBox && renderObject.hasSize) {
+          setState(() {
+            _appBarSize = renderObject.size;
+          });
+        }
       }
-
-      _receivingTooltipIconRenderBox =
-          _receivingTooltipKey.currentContext!.findRenderObject() as RenderBox;
-      _receivingTooltipIconPosition = _receivingTooltipIconRenderBox.localToGlobal(Offset.zero);
-
-      _changeTooltipIconRenderBox =
-          _changeTooltipKey.currentContext!.findRenderObject() as RenderBox;
-      _changeTooltipIconPosition = _changeTooltipIconRenderBox.localToGlobal(Offset.zero);
+      _controller.addListener(_nextLoad);
+      _updateTooltipSize();
     });
   }
 
@@ -238,7 +123,7 @@ class _AddressListScreenState extends State<AddressListScreen> {
 
     final showOnlyUnusedAddresses = context.read<PreferenceProvider>().showOnlyUnusedAddresses;
 
-    if (isReceivingSelected) {
+    if (_isReceivingSelected) {
       viewModel.receivingAddressList.clear();
     } else {
       viewModel.changeAddressList.clear();
@@ -279,216 +164,297 @@ class _AddressListScreenState extends State<AddressListScreen> {
         ]);
   }
 
+  void _updateTooltipSize() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+
+      final context = _toolTipKey.currentContext;
+      if (context != null && context.mounted) {
+        final renderBox = context.findRenderObject();
+        if (renderBox is RenderBox && renderBox.hasSize) {
+          final newSize = renderBox.size;
+          if (_toolTipSize != newSize) {
+            setState(() {
+              _toolTipSize = newSize;
+            });
+          }
+        }
+      }
+    });
+  }
+
+  Widget _buildShowOnlyUsedAddressesButton() {
+    return Selector<PreferenceProvider, bool>(
+        selector: (_, viewModel) => viewModel.showOnlyUnusedAddresses,
+        builder: (context, showOnlyUnusedAddresses, child) {
+          return Row(
+            children: [
+              const Spacer(),
+              GestureDetector(
+                onTap: () {
+                  context
+                      .read<PreferenceProvider>()
+                      .changeShowOnlyUnusedAddresses(!showOnlyUnusedAddresses);
+                  scrollToTop().then((_) => _initializeAddressList());
+                },
+                child: Container(
+                  color: Colors.transparent,
+                  padding: const EdgeInsets.only(left: 16, right: 16, top: 8, bottom: 8),
+                  child: Row(
+                    children: [
+                      SvgPicture.asset(
+                        'assets/svg/check.svg',
+                        colorFilter: ColorFilter.mode(
+                            showOnlyUnusedAddresses ? CoconutColors.white : CoconutColors.gray700,
+                            BlendMode.srcIn),
+                        width: 10,
+                        height: 10,
+                      ),
+                      CoconutLayout.spacing_100w,
+                      Text(
+                        t.address_list_screen.show_only_unused_address,
+                        style: CoconutTypography.body3_12,
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            ],
+          );
+        });
+  }
+
   Widget _buildSegmentedControl() {
-    return Container(
+    return Padding(
       padding: EdgeInsets.only(top: _appBarSize.height),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [CoconutColors.black, CoconutColors.black.withOpacity(0.8), Colors.transparent],
-          stops: const [0.0, 0.7, 1.0],
+      child: CoconutSegmentedControl(
+          labels: [t.address_list_screen.receiving, t.address_list_screen.change],
+          isSelected: [_isReceivingSelected, !_isReceivingSelected],
+          onPressed: (index) async {
+            if (index == 0) {
+              if (!_isReceivingSelected) {
+                setState(() {
+                  _isReceivingSelected = true;
+                });
+                _updateTooltipSize();
+              }
+            } else {
+              if (_isReceivingSelected) {
+                setState(() {
+                  _isReceivingSelected = false;
+                });
+                _updateTooltipSize();
+              }
+            }
+            await scrollToTop();
+            await _initializeAddressList();
+          }),
+    );
+  }
+
+  Widget _buildTooltipSection() {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: SizedBox(
+        child: Column(
+          children: [
+            CoconutLayout.spacing_100h,
+            if (_isReceivingSelected)
+              Selector<PreferenceProvider, bool>(
+                selector: (context, provider) => provider.isReceivingTooltipDisabled,
+                builder: (context, isReceivingTooltipDisabled, child) {
+                  if (isReceivingTooltipDisabled) {
+                    return Container();
+                  }
+                  return Column(
+                    children: [
+                      _buildTooltip(
+                        t.tooltip.address_receiving,
+                        () => context
+                            .read<PreferenceProvider>()
+                            .setReceivingTooltipDisabledPermanently(),
+                      ),
+                      CoconutLayout.spacing_700h,
+                    ],
+                  );
+                },
+              ),
+            if (!_isReceivingSelected)
+              Selector<PreferenceProvider, bool>(
+                selector: (context, provider) => provider.isChangeTooltipDisabled,
+                builder: (context, isChangeTooltipDisabled, child) {
+                  if (isChangeTooltipDisabled) {
+                    return Container();
+                  }
+                  return Column(
+                    children: [
+                      _buildTooltip(
+                        t.tooltip.address_change,
+                        () => context
+                            .read<PreferenceProvider>()
+                            .setChangeTooltipDisabledPermanently(),
+                      ),
+                      CoconutLayout.spacing_700h,
+                    ],
+                  );
+                },
+              ),
+          ],
         ),
       ),
-      child: Column(
-        key: _toolbarWidgetKey,
+    );
+  }
+
+  Widget _buildTooltip(String text, VoidCallback onTap) {
+    return Container(
+      key: _toolTipKey,
+      width: MediaQuery.sizeOf(context).width,
+      padding: const EdgeInsets.only(top: 14, left: 12, right: 12, bottom: 2),
+      decoration: BoxDecoration(
+        color: CoconutColors.gray800,
+        borderRadius: BorderRadius.circular(
+          CoconutStyles.radius_250,
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(10, 0, 10, 10),
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(20),
-                color: CoconutColors.white.withOpacity(0.15),
-              ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: TooltipButton(
-                      isSelected: isReceivingSelected,
-                      text: t.address_list_screen.receiving,
-                      isLeft: true,
-                      iconKey: _receivingTooltipKey,
-                      iconPadding: const EdgeInsets.all(8.0),
-                      onTap: () async {
-                        if (isReceivingSelected) {
-                          await scrollToTop();
-                          await _initializeAddressList();
-                        } else {
-                          setState(() {
-                            isReceivingSelected = true;
-                          });
-                          await scrollToTop();
-                          await _initializeAddressList();
-                        }
-                        _removeTooltip();
-                      },
-                      onTapDown: (_) {
-                        _showTooltip(
-                          context,
-                          true,
-                        );
-                      },
-                    ),
-                  ),
-                  Expanded(
-                    child: TooltipButton(
-                      isSelected: !isReceivingSelected,
-                      text: t.address_list_screen.change,
-                      isLeft: false,
-                      iconKey: _changeTooltipKey,
-                      iconPadding: const EdgeInsets.all(8.0),
-                      onTap: () async {
-                        if (!isReceivingSelected) {
-                          await scrollToTop();
-                          await _initializeAddressList();
-                        } else {
-                          setState(() {
-                            isReceivingSelected = false;
-                          });
-                          await scrollToTop();
-                          await _initializeAddressList();
-                        }
-                        _removeTooltip();
-                      },
-                      onTapDown: (_) {
-                        _showTooltip(
-                          context,
-                          false,
-                        );
-                      },
-                    ),
-                  ),
-                ],
-              ),
+          SvgPicture.asset(
+            'assets/svg/circle-info.svg',
+            colorFilter: const ColorFilter.mode(
+              CoconutColors.white,
+              BlendMode.srcIn,
             ),
           ),
-          Selector<PreferenceProvider, bool>(
-              selector: (_, viewModel) => viewModel.showOnlyUnusedAddresses,
-              builder: (context, showOnlyUnusedAddresses, child) {
-                return Row(
-                  children: [
-                    const Spacer(),
-                    GestureDetector(
-                      onTap: () {
-                        context
-                            .read<PreferenceProvider>()
-                            .changeShowOnlyUnusedAddresses(!showOnlyUnusedAddresses);
-                        scrollToTop().then((_) => _initializeAddressList());
-                      },
-                      child: Container(
-                        color: Colors.transparent,
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: Sizes.size16,
-                        ),
-                        child: Row(
-                          children: [
-                            SvgPicture.asset(
-                              'assets/svg/check.svg',
-                              colorFilter: ColorFilter.mode(
-                                  showOnlyUnusedAddresses
-                                      ? CoconutColors.white
-                                      : CoconutColors.gray700,
-                                  BlendMode.srcIn),
-                              width: 10,
-                              height: 10,
-                            ),
-                            CoconutLayout.spacing_100w,
-                            Text(
-                              t.address_list_screen.show_only_unused_address,
-                              style: CoconutTypography.body3_12,
-                            ),
-                          ],
-                        ),
-                      ),
-                    )
-                  ],
-                );
-              }),
-          CoconutLayout.spacing_400h
+          CoconutLayout.spacing_200w,
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  text,
+                  style: CoconutTypography.body3_12,
+                ),
+                CoconutLayout.spacing_50h,
+                CoconutUnderlinedButton(
+                    padding: const EdgeInsets.only(top: 8, right: 8, bottom: 8),
+                    text: '다시 보지 않기',
+                    textStyle: CoconutTypography.body3_12,
+                    onTap: onTap)
+              ],
+            ),
+          )
         ],
       ),
     );
   }
 
-  Widget tooltipWidget(BuildContext context) {
-    if (_receivingTooltipVisible) {
-      _receivingTooltipIconRenderBox =
-          _receivingTooltipKey.currentContext!.findRenderObject() as RenderBox;
-      _receivingTooltipIconPosition = _receivingTooltipIconRenderBox.localToGlobal(Offset.zero);
-      final tooltipIconPositionTop =
-          _receivingTooltipIconPosition.dy + _receivingTooltipIconRenderBox.size.height;
-      return Positioned(
-        top: widget.isFullScreen
-            ? tooltipIconPositionTop
-            : tooltipIconPositionTop -
-                MediaQuery.of(context).size.height *
-                    0.1, // 0.1 : bottomSheet가 height * 0.9  만큼 차지하기 때문
-        left: _receivingTooltipIconPosition.dx - 30,
-        right: MediaQuery.of(context).size.width - _receivingTooltipIconPosition.dx - 200,
-        child: CoconutToolTip(
-          onTapRemove: () => _removeTooltip(),
-          width: MediaQuery.sizeOf(context).width,
-          isPlacementTooltipVisible: _receivingTooltipVisible,
-          isBubbleClipperSideLeft: true,
-          backgroundColor: CoconutColors.white,
-          tooltipType: CoconutTooltipType.placement,
-          brightness: Brightness.light,
-          richText: RichText(
-            text: TextSpan(
-              text: t.tooltip.address_receiving,
-              style: CoconutTypography.body3_12.setColor(CoconutColors.black).merge(
-                    const TextStyle(
-                      height: 1.3,
+  Widget _buildAddressList(
+    List<WalletAddress> addressList,
+    Tuple2<bool, bool> isTooltipDisabled,
+  ) {
+    return _isInitializing
+        ? const Center(child: CircularProgressIndicator())
+        : NotificationListener<ScrollNotification>(
+            onNotification: (ScrollNotification notification) {
+              if (_controller.hasClients &&
+                  (notification is ScrollEndNotification) &&
+                  ((_isReceivingSelected && !isTooltipDisabled.item1) ||
+                      (!_isReceivingSelected && !isTooltipDisabled.item2))) {
+                final currentOffset = _controller.offset;
+
+                Future.microtask(() {
+                  if (!_controller.hasClients) return;
+
+                  if (currentOffset < _appBarSize.height / 2 + 32) {
+                    _controller.animateTo(
+                      0,
+                      duration: const Duration(milliseconds: 200),
+                      curve: Curves.easeOut,
+                    );
+                  } else if (currentOffset < _appBarSize.height + 32) {
+                    _controller.animateTo(
+                      _appBarSize.height + 32,
+                      duration: const Duration(milliseconds: 200),
+                      curve: Curves.easeOut,
+                    );
+                  }
+                });
+
+                return true;
+              }
+
+              return false;
+            },
+            child: CustomScrollView(
+              controller: _controller,
+              slivers: [
+                SliverToBoxAdapter(child: _buildTooltipSection()),
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) {
+                      return Container(
+                        color: CoconutColors.black,
+                        child: Column(
+                          children: [
+                            AddressItemCard(
+                              onPressed: () {
+                                CommonBottomSheets.showBottomSheet_90(
+                                  context: context,
+                                  child: QrcodeBottomSheet(
+                                    qrcodeTopWidget: Text(
+                                      addressList[index].derivationPath,
+                                      style: CoconutTypography.body2_14.merge(
+                                        TextStyle(
+                                          color: CoconutColors.white.withOpacity(0.7),
+                                        ),
+                                      ),
+                                    ),
+                                    qrData: addressList[index].address,
+                                    title: t.address_list_screen
+                                        .address_index(index: addressList[index].index),
+                                  ),
+                                );
+                              },
+                              address: addressList[index].address,
+                              derivationPath: addressList[index].derivationPath,
+                              isUsed: addressList[index].isUsed,
+                              balanceInSats: addressList[index].total,
+                              currentUnit: _currentUnit,
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                    childCount: addressList.length,
+                  ),
+                ),
+                if (_isLoadMoreRunning)
+                  const SliverToBoxAdapter(
+                    child: Padding(
+                      padding: EdgeInsets.only(bottom: 40, top: 20),
+                      child: Center(
+                        child: CircularProgressIndicator(color: CoconutColors.white),
+                      ),
                     ),
                   ),
+              ],
             ),
-          ),
-        ),
-      );
-    } else if (_changeTooltipVisible) {
-      _changeTooltipIconRenderBox =
-          _changeTooltipKey.currentContext!.findRenderObject() as RenderBox;
-      _changeTooltipIconPosition = _changeTooltipIconRenderBox.localToGlobal(Offset.zero);
-      return Positioned(
-        top: widget.isFullScreen
-            ? _changeTooltipIconPosition.dy + _changeTooltipIconRenderBox.size.height
-            : _changeTooltipIconPosition.dy - 50,
-        left: _changeTooltipIconPosition.dx - 200,
-        right: MediaQuery.of(context).size.width -
-            _changeTooltipIconPosition.dx +
-            (_changeTooltipIconRenderBox.size.width) -
-            46,
-        child: CoconutToolTip(
-          onTapRemove: () => _removeTooltip(),
-          width: MediaQuery.sizeOf(context).width,
-          isPlacementTooltipVisible: _changeTooltipVisible,
-          isBubbleClipperSideLeft: false,
-          backgroundColor: CoconutColors.white,
-          tooltipType: CoconutTooltipType.placement,
-          brightness: Brightness.light,
-          richText: RichText(
-            text: TextSpan(
-              text: t.tooltip.address_change,
-              style: CoconutTypography.body3_12.setColor(CoconutColors.black).merge(
-                    const TextStyle(
-                      height: 1.3,
-                    ),
-                  ),
-            ),
-          ),
-        ),
-      );
-    }
-    return Container();
+          );
   }
 
   Future<void> _nextLoad() async {
+    // 스크롤이 _appBarSize.height + 32 부근에 도달하면 멈추도록 설정
+    if (_controller.position.pixels.toInt() == (_appBarSize.height).toInt() + 32) {
+      _controller.jumpTo(_appBarSize.height + 32);
+    }
+
     if (_isInitializing || _isLoadMoreRunning || _controller.position.extentAfter > 500) {
       return;
     }
 
     // 현재 탭 상태 저장 (로딩 중 탭 변경 시 데이터 추가 방지)
-    final wasReceivingSelected = isReceivingSelected;
+    final wasReceivingSelected = _isReceivingSelected;
 
     setState(() {
       _isLoadMoreRunning = true;
@@ -497,19 +463,19 @@ class _AddressListScreenState extends State<AddressListScreen> {
     List<WalletAddress> newAddresses = [];
     try {
       final cursor =
-          !isReceivingSelected ? viewModel.changeInitialCursor : viewModel.receivingInitialCursor;
+          !_isReceivingSelected ? viewModel.changeInitialCursor : viewModel.receivingInitialCursor;
       newAddresses = await viewModel.getWalletAddressList(
         viewModel.walletBaseItem!,
         cursor,
         kAddressLoadCount,
-        !isReceivingSelected,
+        !_isReceivingSelected,
         context.read<PreferenceProvider>().showOnlyUnusedAddresses,
       );
 
       // UI 업데이트 - 탭 상태가 변경되지 않았을 때만 데이터 추가
-      if (mounted && wasReceivingSelected == isReceivingSelected && !_isScrollingToTop) {
+      if (mounted && wasReceivingSelected == _isReceivingSelected && !_isScrollingToTop) {
         setState(() {
-          if (isReceivingSelected) {
+          if (_isReceivingSelected) {
             viewModel.receivingAddressList.addAll(newAddresses);
           } else {
             viewModel.changeAddressList.addAll(newAddresses);
@@ -525,8 +491,8 @@ class _AddressListScreenState extends State<AddressListScreen> {
           _isLoadMoreRunning = false;
         });
         // 탭 상태가 변경되지 않았을 때만 백그라운드 저장
-        if (wasReceivingSelected == isReceivingSelected) {
-          _addAddressesWithGapLimit(newAddresses, !isReceivingSelected);
+        if (wasReceivingSelected == _isReceivingSelected) {
+          _addAddressesWithGapLimit(newAddresses, !_isReceivingSelected);
         }
       }
     }
@@ -547,52 +513,6 @@ class _AddressListScreenState extends State<AddressListScreen> {
         );
       } catch (e) {
         Logger.error('[_preloadAddressesInBackground] Failed to preload addresses: $e');
-      }
-    });
-  }
-
-  void _removeTooltip() {
-    if (!_receivingTooltipVisible && !_changeTooltipVisible) return;
-    setState(() {
-      _tooltipRemainingTime = 0;
-      _receivingTooltipVisible = false;
-      _changeTooltipVisible = false;
-    });
-    if (_tooltipTimer != null) {
-      _tooltipTimer!.cancel();
-    }
-  }
-
-  void _showTooltip(BuildContext context, bool isLeft) {
-    if (isLeft && _receivingTooltipVisible || !isLeft && _changeTooltipVisible) {
-      debugPrint('Tooltip already visible');
-      _removeTooltip();
-      return;
-    }
-
-    _removeTooltip();
-    if (isLeft) {
-      setState(() {
-        _receivingTooltipVisible = true;
-        _changeTooltipVisible = false;
-      });
-    } else {
-      setState(() {
-        _receivingTooltipVisible = false;
-        _changeTooltipVisible = true;
-      });
-    }
-
-    _tooltipRemainingTime = 5;
-    _tooltipTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (_tooltipRemainingTime > 0) {
-        _tooltipRemainingTime--;
-      } else {
-        setState(() {
-          _removeTooltip();
-        });
-
-        timer.cancel();
       }
     });
   }

--- a/lib/screens/wallet_detail/wallet_detail_receive_address_bottom_sheet.dart
+++ b/lib/screens/wallet_detail/wallet_detail_receive_address_bottom_sheet.dart
@@ -10,10 +10,12 @@ import 'package:tuple/tuple.dart';
 
 class ReceiveAddressBottomSheet extends StatelessWidget {
   final int id;
+  final double paddingTop;
 
   const ReceiveAddressBottomSheet({
     super.key,
     required this.id,
+    this.paddingTop = 0,
   });
 
   @override
@@ -71,6 +73,7 @@ class ReceiveAddressBottomSheet extends StatelessWidget {
                                   child: AddressListScreen(
                                     id: id,
                                     isFullScreen: false,
+                                    paddingTop: paddingTop,
                                   ),
                                 );
                               },

--- a/lib/screens/wallet_detail/wallet_detail_screen.dart
+++ b/lib/screens/wallet_detail/wallet_detail_screen.dart
@@ -397,6 +397,7 @@ class _WalletDetailScreenState extends State<WalletDetailScreen> {
         value: _viewModel,
         child: ReceiveAddressBottomSheet(
           id: widget.id,
+          paddingTop: MediaQuery.of(context).padding.top,
         ),
       ),
     );


### PR DESCRIPTION
## 1. 변경 사항

<img width="200" src="https://github.com/user-attachments/assets/183e2d9a-f304-4fa4-b631-efa6a1b52a43" />

### **입금 / 잔돈 툴팁 다시 보지 않기 여부 개별 관리**
- 입금 목록에서 툴팁을 '다시 보지 않기' 해도 잔돈 목록의 툴팁을 '다시 보지 않기'를 하지 않으면 잔돈 툴팁은 보임

---

<img width="200" src="https://github.com/user-attachments/assets/1b23c590-c233-4039-88c9-0f74ada80cdc" />

### **툴팁은 SliverListHeader로 교체**
- 화면 공간 차지 최소화
- offset이 0 ~ (ToolTip 높이 / 2) 구간에서 손을 뗴면 상단으로 이동, (ToolTip 높이 / 2) ~ ToolTip 높이 구간에서 손을 떼면 AddresList 0번째 인덱스로 이동

---

<img width="200" src="https://github.com/user-attachments/assets/b726b3af-62f5-4fb4-9991-4a9f02ec50a4" />

### **[다시 보지 않기] 기능**
- '다시 보지 않기' 하면 앱 삭제 후 재설치 시점까지 보이지 않음
- PrefereceProvider ``` _isReceivingTooltipDisabled ```, ``` _isChangeTooltipDisabled ```

## 2. 테스트 방법
1) **한글** 모드에서 테스트 (영문 설정에서는 툴팁 노출하지 않음)
2) 지갑의 '전체 주소 보기' 화면에서 '입금' 툴팁과 '잔돈' 툴팁이 바뀐 형태로 표시되는지 확인합니다.
3) '다시 보지 않기' 클릭 후 화면 이동 후 복귀 또는 앱 재실행 시 더이상 툴팁이 보이지 않아야 합니다.
4) 지갑 상세 화면 -> [받기]버튼 -> '전체 주소 보기' (BottomSheet 형태) 에서도 동일하게 작동하는지 확인합니다.

## 3. 이슈 번호
#386