### PR TITLE
[394] bc-ur qr scan 시 진행률 표기

### DIFF
--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -315,6 +315,9 @@ unsigned_tx_qr_screen:
   guide_hardware_wallet:
     step1: "Please scan the QR code below with your hardware wallet to start the signing process."
 
+coconut_qr_scanner:
+  reading_extra_data: "Reading additional data to collect.\nPlease keep scanning."
+
 # lib/screens/settings
 app_info_screen:
   made_by_team_pow: "Made by Team POW."

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -315,6 +315,9 @@ unsigned_tx_qr_screen:
   guide_hardware_wallet:
     step1: "하드웨어 월렛으로 아래 QR 코드를 스캔하여 서명 과정을 시작해 주세요."
 
+coconut_qr_scanner:
+  reading_extra_data: "추가로 수집할 데이터를 읽고 있습니다.\n계속 스캔해 주세요."
+
 # lib/screens/settings
 app_info_screen:
   made_by_team_pow: "포우팀이 만듭니다."

--- a/lib/widgets/animated_qr/coconut_qr_scanner.dart
+++ b/lib/widgets/animated_qr/coconut_qr_scanner.dart
@@ -197,7 +197,7 @@ class _CoconutQrScannerState extends State<CoconutQrScanner> with SingleTickerPr
                   child: ValueListenableBuilder<double>(
                     valueListenable: _progressNotifier,
                     builder: (context, value, _) {
-                      bool isScanningExtraData = value >= 0.99;
+                      bool isScanningExtraData = value > 0.99;
                       return Padding(
                         padding: EdgeInsets.only(top: isScanningExtraData ? 24 : 0),
                         child: Text(


### PR DESCRIPTION
### 변경사항
 - 진행도 애니메이션 삭제
 - 진행률 퍼센트 표시 하다가 99% 이후 텍스트 표시
<image src="https://github.com/user-attachments/assets/c35019a6-2e33-4f99-8b87-0a1828b1bb78" width="250px" />
<image src="https://github.com/user-attachments/assets/45cb1466-6eca-45bb-ae9e-cb85b53b35d1" width="250px" />
<image src="https://github.com/user-attachments/assets/80304b6b-2916-41c7-8607-bb2c638c6f0d" width="250px" />

### 테스트 방법
어플 실행하여 테스트

### 테스트 시나리오
1. [월렛] 지갑 보내기 - >[월렛] 보내기 QR -> [볼트] QR 읽고 서명 -> [월렛] 서명 트랜잭션 읽기에서 진행률 확인 

#394 