### PR TITLE
[408] 보내기 화면 진입 시 카드 흔들리는 애니메이션

### DIFF
--- a/lib/constants/shared_pref_keys.dart
+++ b/lib/constants/shared_pref_keys.dart
@@ -33,6 +33,9 @@ class SharedPrefKeys {
   /// Fiat
   static const String kSelectedFiat = 'SELECTED_FIAT';
 
+  /// 보내기 화면 수신자 추가 카드 확인 여부
+  static const String kHasSeenAddRecipientCard = "HAS_SEEN_ADD_RECIPIENT_CARD";
+
   // Electrum
   /// [DefaultElectrumServer.serverName] 또는 'CUSTOM'
   static const String kElectrumServerName = 'ELECTRUM_SERVER_NAME';

--- a/lib/providers/preference_provider.dart
+++ b/lib/providers/preference_provider.dart
@@ -43,6 +43,10 @@ class PreferenceProvider extends ChangeNotifier {
   late bool _isChangeTooltipDisabled;
   bool get isChangeTooltipDisabled => language == 'kr' ? _isChangeTooltipDisabled : true;
 
+  /// 보내기 화면 [수신자 추가하기 카드] 확인 여부
+  late bool _hasSeenAddRecipientCard;
+  bool get hasSeenAddRecipientCard => _hasSeenAddRecipientCard;
+
   /// 언어 설정
   late String _language;
   String get language => _language;
@@ -80,6 +84,7 @@ class PreferenceProvider extends ChangeNotifier {
         _walletPreferencesRepository.getExcludedWalletIds().toList();
     _isReceivingTooltipDisabled = _sharedPrefs.getBool(SharedPrefKeys.kIsReceivingTooltipDisabled);
     _isChangeTooltipDisabled = _sharedPrefs.getBool(SharedPrefKeys.kIsChangeTooltipDisabled);
+    _hasSeenAddRecipientCard = _sharedPrefs.getBool(SharedPrefKeys.kHasSeenAddRecipientCard);
 
     // 통화 설정 초기화
     _initializeFiat();
@@ -313,6 +318,13 @@ class PreferenceProvider extends ChangeNotifier {
   Future<void> removeExcludedFromTotalBalanceWalletId(int walletId) async {
     _excludedFromTotalBalanceWalletIds.remove(walletId);
     await _walletPreferencesRepository.setExcludedWalletIds(_excludedFromTotalBalanceWalletIds);
+    notifyListeners();
+  }
+
+  /// 보내기 화면 [수신자 추가 카드] 확인 여부 활성화 - 보내기 화면 진입시 Bounce 애니메이션을 처리하지 않음
+  Future<void> setHasSeenAddRecipientCard() async {
+    _hasSeenAddRecipientCard = true;
+    await _sharedPrefs.setBool(SharedPrefKeys.kHasSeenAddRecipientCard, _hasSeenAddRecipientCard);
     notifyListeners();
   }
 

--- a/lib/providers/view_model/send/refactor/send_view_model.dart
+++ b/lib/providers/view_model/send/refactor/send_view_model.dart
@@ -110,6 +110,7 @@ class SendViewModel extends ChangeNotifier {
   int _currentIndex = 0;
   int get currentIndex => _currentIndex;
   int get lastIndex => _recipientList.length - 1;
+  int get addRecipientCardIndex => _recipientList.length;
 
   bool _showAddressBoard = false;
   bool get showAddressBoard => _showAddressBoard;
@@ -526,7 +527,7 @@ class SendViewModel extends ChangeNotifier {
 
   void _updateFinalErrorMessage() {
     String message = "";
-    // [전체] 충분하지 않은 Balance > [마지막 수신자] 전송 금액 - 예상 수수료가 dustLimit보다 크지 않음 > [수신자] dust 보다 적은 금액을 보내는 경우 > [수신자] 주소가 틀림 > [수신자] 중복된 주소가 있는 경우 > [수신자] empty 값 또는 0이 존재 > 예상 수수료 오류
+    // [전체] 충분하지 않은 Balance 입력 > [수신자] dust 보다 적은 금액을 입력 > [마지막 수신자] 전송 금액 - 예상 수수료가 dustLimit보다 크지 않음 > [수신자] 주소에 에러가 있는 경우 > 최소값보다 낮은 수수료 입력
     if (_isAmountSumExceedsBalance.isError) {
       message = _isAmountSumExceedsBalance.getMessage(currentUnit);
     } else if (_recipientList.any((r) => r.minimumAmountError.isError)) {

--- a/lib/screens/send/refactor/send_screen.dart
+++ b/lib/screens/send/refactor/send_screen.dart
@@ -40,7 +40,7 @@ class SendScreen extends StatefulWidget {
   State<SendScreen> createState() => _SendScreenState();
 }
 
-class _SendScreenState extends State<SendScreen> {
+class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateMixin {
   final Color keyboardToolbarGray = const Color(0xFF2E2E2E);
   final Color feeRateFieldGray = const Color(0xFF2B2B2B);
   // 스크롤 범위 연산에 사용하는 값들
@@ -69,6 +69,10 @@ class _SendScreenState extends State<SendScreen> {
 
   final TextEditingController _amountController = TextEditingController();
   final FocusNode _amountFocusNode = FocusNode();
+
+  // Bounce animation
+  late AnimationController _animationController;
+  late Animation<double> _offsetAnimation;
 
   QRViewController? _qrViewController;
   bool _isQrDataHandling = false;
@@ -103,10 +107,21 @@ class _SendScreenState extends State<SendScreen> {
     _feeRateFocusNode.addListener(() => setState(() {}));
     _amountController.addListener(_amountTextListener);
     _recipientPageController.addListener(_recipientPageListener);
+    _animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 700),
+    );
+
+    if (!context.read<PreferenceProvider>().hasSeenAddRecipientCard) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _startBounce();
+      });
+    }
   }
 
   @override
   void dispose() {
+    _animationController.dispose();
     _recipientPageController.dispose();
     _feeRateController.dispose();
     _feeRateFocusNode.dispose();
@@ -659,12 +674,21 @@ class _SendScreenState extends State<SendScreen> {
               final isMaxMode = data.item2;
               return PageView.builder(
                 controller: _recipientPageController,
-                onPageChanged: (index) => _viewModel.setCurrentPage(index),
+                onPageChanged: (index) {
+                  // 수신자 추가 카드 확인 여부 업데이트
+                  var preferenceProvider = context.read<PreferenceProvider>();
+                  if (index == _viewModel.addRecipientCardIndex &&
+                      !preferenceProvider.hasSeenAddRecipientCard) {
+                    preferenceProvider.setHasSeenAddRecipientCard();
+                  }
+
+                  _viewModel.setCurrentPage(index);
+                },
                 // isMaxMode: 수신자 추가 버튼 안보임
                 itemCount: recipientListLength + (!isMaxMode ? 1 : 0),
                 itemBuilder: (context, index) {
                   if (index == recipientListLength) {
-                    return _buildAddRecipientAddCard();
+                    return _buildAddRecipientCard();
                   }
                   return _buildRecipientPage(context, index);
                 },
@@ -672,7 +696,7 @@ class _SendScreenState extends State<SendScreen> {
             }));
   }
 
-  Widget _buildAddRecipientAddCard() {
+  Widget _buildAddRecipientCard() {
     return Padding(
       padding: const EdgeInsets.only(top: 40, left: 16, right: 16, bottom: 25),
       child: ShrinkAnimationButton(
@@ -1279,4 +1303,45 @@ class _SendScreenState extends State<SendScreen> {
   }
 
   void _clearFocus() => FocusManager.instance.primaryFocus?.unfocus();
+
+  Future<void> _startBounce() async {
+    final pageWidth = _recipientPageController.position.viewportDimension;
+    _offsetAnimation = TweenSequence<double>([
+      // 오른쪽으로 50% 이동
+      TweenSequenceItem(
+        tween: Tween<double>(
+          begin: 0.0,
+          end: pageWidth * 0.5,
+        ).chain(CurveTween(curve: Curves.easeOut)),
+        weight: 5,
+      ),
+      // 왼쪽으로 약간 튕김 (-25px)
+      TweenSequenceItem(
+        tween: Tween<double>(
+          begin: pageWidth * 0.5,
+          end: -25.0, // 더 깊게 당김
+        ).chain(CurveTween(curve: Curves.easeInOut)), // 강한 튕김 곡선
+        weight: 1,
+      ),
+      // 다시 원위치 (0)
+      TweenSequenceItem(
+        tween: Tween<double>(
+          begin: -100.0,
+          end: 0.0,
+        ).chain(CurveTween(curve: Curves.easeOutBack)),
+        weight: 2,
+      ),
+    ]).animate(_animationController);
+
+    _animationController.addListener(() {
+      if (_recipientPageController.hasClients) {
+        final offset = _offsetAnimation.value.clamp(
+          _recipientPageController.position.minScrollExtent,
+          _recipientPageController.position.maxScrollExtent,
+        );
+        _recipientPageController.jumpTo(offset);
+      }
+    });
+    _animationController.forward();
+  }
 }


### PR DESCRIPTION
### 변경사항
 - 보내기 화면 '수신자 추가하기 카드' 확인 여부에 따른 Bounce 애니메이션 처리
 - PreferenceProvider '수신자 추가하기 카드' 확인 여부 변수 추가

### 테스트 방법
어플 실행하여 테스트

### 테스트 시나리오
1. (초기) 보내기 화면 진입시 Bounce 애니메이션 확인 
2. (수신자 추가하기 카드를 스크롤 하기 전) 보내기 화면 진입시 Bounce 애니메이션이 1회 처리됨.
3. (수신자 추가하기 카드를 스크롤 한 이후) 보내기 화면 진입시 Bounce 애니메이션이 처리되지 않음. 

#408 