### PR TITLE
[415] 써드파티로 지갑 추가시 발생하는 버그 수정

### DIFF
--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -79,10 +79,22 @@ class WalletAddInputViewModel extends ChangeNotifier {
   Future<ResultOfSyncFromVault> addWallet() async {
     assert(validExtendedPublicKey != null || validDescriptor != null);
     if (validExtendedPublicKey != null) {
-      return await addWalletFromExtendedPublicKey(validExtendedPublicKey!);
+      return await addWalletFromExtendedPublicKey(validExtendedPublicKey!).then((result) {
+        if (result.result == WalletSyncResult.newWalletAdded) {
+          _walletProvider.addToWalletOrder(result.walletId!);
+          _walletProvider.addToFavoriteWallets(result.walletId!);
+        }
+        return result;
+      });
     }
 
-    return await addWalletFromDescriptor(validDescriptor!);
+    return await addWalletFromDescriptor(validDescriptor!).then((result) {
+      if (result.result == WalletSyncResult.newWalletAdded) {
+        _walletProvider.addToWalletOrder(result.walletId!);
+        _walletProvider.addToFavoriteWallets(result.walletId!);
+      }
+      return result;
+    });
   }
 
   Future<ResultOfSyncFromVault> addWalletFromExtendedPublicKey(String extendedPublicKey) async {

--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -79,22 +79,10 @@ class WalletAddInputViewModel extends ChangeNotifier {
   Future<ResultOfSyncFromVault> addWallet() async {
     assert(validExtendedPublicKey != null || validDescriptor != null);
     if (validExtendedPublicKey != null) {
-      return await addWalletFromExtendedPublicKey(validExtendedPublicKey!).then((result) {
-        if (result.result == WalletSyncResult.newWalletAdded) {
-          _walletProvider.addToWalletOrder(result.walletId!);
-          _walletProvider.addToFavoriteWallets(result.walletId!);
-        }
-        return result;
-      });
+      return await addWalletFromExtendedPublicKey(validExtendedPublicKey!);
     }
 
-    return await addWalletFromDescriptor(validDescriptor!).then((result) {
-      if (result.result == WalletSyncResult.newWalletAdded) {
-        _walletProvider.addToWalletOrder(result.walletId!);
-        _walletProvider.addToFavoriteWallets(result.walletId!);
-      }
-      return result;
-    });
+    return await addWalletFromDescriptor(validDescriptor!);
   }
 
   Future<ResultOfSyncFromVault> addWalletFromExtendedPublicKey(String extendedPublicKey) async {

--- a/lib/providers/view_model/home/wallet_add_scanner_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_scanner_view_model.dart
@@ -64,58 +64,32 @@ class WalletAddScannerViewModel extends ChangeNotifier {
   }
 
   Future<ResultOfSyncFromVault> addCoconutVaultWallet(WatchOnlyWallet watchOnlyWallet) async {
-    return await _walletProvider.syncFromCoconutVault(watchOnlyWallet).then((result) {
-      if (result.result == WalletSyncResult.newWalletAdded) {
-        _handleNewWalletAdded(result.walletId!);
-      }
-      return result;
-    });
+    return await _walletProvider.syncFromCoconutVault(watchOnlyWallet);
   }
 
   Future<ResultOfSyncFromVault> addKeystoneWallet(UR ur) async {
     final name = getNextThirdPartyWalletName(
         WalletImportSource.keystone, _walletProvider.walletItemList.map((e) => e.name).toList());
     final wallet = _walletAddService.createKeystoneWallet(ur, name);
-    return await _walletProvider.syncFromThirdParty(wallet).then((result) {
-      if (result.result == WalletSyncResult.newWalletAdded) {
-        _handleNewWalletAdded(result.walletId!);
-      }
-      return result;
-    });
+    return await _walletProvider.syncFromThirdParty(wallet);
   }
 
   Future<ResultOfSyncFromVault> addJadeWallet(UR ur) async {
     final name = getNextThirdPartyWalletName(
         WalletImportSource.jade, _walletProvider.walletItemList.map((e) => e.name).toList());
     final wallet = _walletAddService.createJadeWallet(ur, name);
-    return await _walletProvider.syncFromThirdParty(wallet).then((result) {
-      if (result.result == WalletSyncResult.newWalletAdded) {
-        _handleNewWalletAdded(result.walletId!);
-      }
-      return result;
-    });
+    return await _walletProvider.syncFromThirdParty(wallet);
   }
 
   Future<ResultOfSyncFromVault> addSeedSignerWallet(String descriptor) async {
     final name = getNextThirdPartyWalletName(
         WalletImportSource.seedSigner, _walletProvider.walletItemList.map((e) => e.name).toList());
     final wallet = _walletAddService.createSeedSignerWallet(descriptor, name);
-    return await _walletProvider.syncFromThirdParty(wallet).then((result) {
-      if (result.result == WalletSyncResult.newWalletAdded) {
-        _handleNewWalletAdded(result.walletId!);
-      }
-      return result;
-    });
+    return await _walletProvider.syncFromThirdParty(wallet);
   }
 
   String getWalletName(int walletId) {
     return _walletProvider.getWalletById(walletId).name;
-  }
-
-  /// 새 지갑이 추가되었을 때 처리하는 함수(즐겨찾기, 지갑 순서 추가)
-  void _handleNewWalletAdded(int walletId) {
-    _walletProvider.addToWalletOrder(walletId);
-    _walletProvider.addToFavoriteWallets(walletId);
   }
 
   Future<void> setFakeBalanceIfEnabled(int? walletId) async {

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -138,7 +138,7 @@ class WalletProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> addToFavoriteWallets(int walletId) async {
+  Future<void> addToFavoriteWalletsUntilFive(int walletId) async {
     final favoriteWallets = _preferenceProvider.favoriteWalletIds.toList();
 
     // 즐겨찾기된 지갑이 5개이상이면 등록안함
@@ -427,7 +427,7 @@ class WalletProvider extends ChangeNotifier {
   /// 새 지갑이 추가되었을 때 처리하는 함수(즐겨찾기, 지갑 순서 추가)
   void _handleNewWalletAdded(int walletId) {
     addToWalletOrder(walletId);
-    addToFavoriteWallets(walletId);
+    addToFavoriteWalletsUntilFive(walletId);
   }
 
   @override

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -193,6 +193,10 @@ class WalletProvider extends ChangeNotifier {
 
     Logger.log('--> syncFromCoconutVault:::::: ${_walletItemList.map((e) => e.id).toList()}');
 
+    if (result == WalletSyncResult.newWalletAdded) {
+      _handleNewWalletAdded(newWallet.id);
+    }
+
     return ResultOfSyncFromVault(result: result, walletId: newWallet.id);
   }
 
@@ -214,6 +218,10 @@ class WalletProvider extends ChangeNotifier {
     // case 1: 새 지갑 생성
     bool isMultisig = watchOnlyWallet.signers != null;
     var newWallet = await _addNewWallet(watchOnlyWallet, isMultisig);
+
+    if (result == WalletSyncResult.newWalletAdded) {
+      _handleNewWalletAdded(newWallet.id);
+    }
 
     return ResultOfSyncFromVault(result: result, walletId: newWallet.id);
   }
@@ -414,6 +422,12 @@ class WalletProvider extends ChangeNotifier {
       favoriteWalletIds = List.from(walletItemList.take(5).map((w) => w.id));
       await _preferenceProvider.setFavoriteWalletIds(favoriteWalletIds);
     }
+  }
+
+  /// 새 지갑이 추가되었을 때 처리하는 함수(즐겨찾기, 지갑 순서 추가)
+  void _handleNewWalletAdded(int walletId) {
+    addToWalletOrder(walletId);
+    addToFavoriteWallets(walletId);
   }
 
   @override

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -12,6 +12,7 @@ import 'package:coconut_wallet/model/wallet/wallet_address.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/model/wallet/watch_only_wallet.dart';
 import 'package:coconut_wallet/providers/preference_provider.dart';
+import 'package:coconut_wallet/providers/view_model/home/wallet_add_scanner_view_model.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
@@ -128,6 +129,25 @@ class WalletProvider extends ChangeNotifier {
     return -1;
   }
 
+  Future<void> addToWalletOrder(int walletId) async {
+    final walletOrder = _preferenceProvider.walletOrder.toList();
+    if (!walletOrder.contains(walletId)) {
+      walletOrder.add(walletId);
+
+      await _preferenceProvider.setWalletOrder(walletOrder);
+    }
+  }
+
+  Future<void> addToFavoriteWallets(int walletId) async {
+    final favoriteWallets = _preferenceProvider.favoriteWalletIds.toList();
+
+    // 즐겨찾기된 지갑이 5개이상이면 등록안함
+    if (favoriteWallets.length < kMaxStarLenght && !favoriteWallets.contains(walletId)) {
+      favoriteWallets.add(walletId);
+      await _preferenceProvider.setFavoriteWalletIds(favoriteWallets);
+    }
+  }
+
   /// case1. 새로운 pubkey인지 확인 후 지갑으로 추가하기 ("지갑을 추가했습니다.")
   /// case2. 이미 존재하는 fingerprint이지만 이름/계정/칼라 중 하나라도 변경되었을 경우 ("동기화를 완료했습니다.")
   /// case3. 이미 존재하고 변화가 없는 경우 ("이미 추가된 지갑입니다.")
@@ -170,6 +190,8 @@ class WalletProvider extends ChangeNotifier {
 
     // case 1: 새 지갑 생성
     var newWallet = await _addNewWallet(watchOnlyWallet, isMultisig);
+
+    Logger.log('--> syncFromCoconutVault:::::: ${_walletItemList.map((e) => e.id).toList()}');
 
     return ResultOfSyncFromVault(result: result, walletId: newWallet.id);
   }

--- a/lib/widgets/icon/wallet_item_icon.dart
+++ b/lib/widgets/icon/wallet_item_icon.dart
@@ -22,11 +22,8 @@ class WalletItemIcon extends StatelessWidget {
     var isExternalWallet = walletImportSource != WalletImportSource.coconutVault;
     return Container(
       padding: const EdgeInsets.all(6),
-      constraints: const BoxConstraints(
-        // zpub일 경우에 아이콘 사이즈가 작게 나오기 때문에 minimum 설정
-        minHeight: 22,
-        minWidth: 22,
-      ),
+      width: 30,
+      height: 30,
       decoration: BoxDecoration(
         color: isExternalWallet
             ? CoconutColors.gray700


### PR DESCRIPTION
## 1. 변경 사항

### **써드파티 지갑 추가**
- 확장공개키, 디스크립터를 통해 외부지갑 추가 시 즐겨찾기 목록, 지갑 순서 목록에도 추가

### **아이콘 크기 조정**
- WalletItemCard의 Icon Size 조정

<table>
<tr>
<td>
<img width="200" src="https://github.com/user-attachments/assets/01e1d757-43b7-422c-b62e-47ac11796bf6" />
</td>
<td>
<img width="200" src="https://github.com/user-attachments/assets/1017cd85-0a0f-4131-ba97-5b45283f664b" />
</td>
</tr>
</table>

## 2. 테스트 방법
1. RegTest에서 [지갑 추가] - [직접 입력] - 확장공개키 입력```vpub5ZdVSzwrt5MtucJVAJb3oKASCZLjYQeNkGmns66BpHhNhNYSP8yubjjhYAYSEZQQP7uiiGtQstg99NvKdqM7YBMBkRzEGTbS1sC4zWbdAgp```

2. 홈화면의 즐겨찾기 목록, 지갑 전체보기 화면에 잘 추가됐는지 확인
3. 이후 다른 지갑 추가해도 확장공개키로 추가한 지갑이 사라지지 않는지 확인(기존에는 사라졌었음)
4. 아이콘 사이즈 동일 여부 확인
5. 확장공개키로 추가한 지갑 삭제시 에러 발생 여부 확인(기존에는 에러 발생)


## 3. 이슈 번호
#415