### PR TITLE
[418] MFP 없는 지갑 보내기 안되도록 처리

### DIFF
--- a/lib/providers/view_model/send/refactor/send_view_model.dart
+++ b/lib/providers/view_model/send/refactor/send_view_model.dart
@@ -250,6 +250,8 @@ class SendViewModel extends ChangeNotifier {
     return true;
   }
 
+  bool get isSelectedWalletNull => _selectedWalletItem == null;
+
   bool isMaxModeIndex(int index) {
     return _isMaxMode && index == lastIndex;
   }

--- a/lib/screens/home/wallet_home_screen.dart
+++ b/lib/screens/home/wallet_home_screen.dart
@@ -17,7 +17,6 @@ import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/visibility_provider.dart';
 import 'package:coconut_wallet/screens/home/wallet_list_user_experience_survey_bottom_sheet.dart';
 import 'package:coconut_wallet/screens/wallet_detail/wallet_info_screen.dart';
-import 'package:coconut_wallet/services/wallet_add_service.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/uri_launcher.dart';
 import 'package:coconut_wallet/widgets/animated_balance.dart';
@@ -712,17 +711,6 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
       (id) => id == firstWallet.id,
       orElse: () => firstWallet.id,
     );
-
-    final wallet = _viewModel.getWalletById(targetId);
-    if (wallet is! MultisigWalletListItem &&
-        (wallet.walletBase as SingleSignatureWallet).keyStore.masterFingerprint ==
-            WalletAddService.masterFingerprintPlaceholder) {
-      CoconutToast.showToast(
-          isVisibleIcon: true,
-          context: context,
-          text: t.wallet_detail_screen.toast.no_mfp_wallet_cant_send);
-      return;
-    }
 
     if (!_checkStateAndShowToast(targetId)) return;
     Navigator.pushNamed(context, '/send',

--- a/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
+++ b/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
@@ -4,6 +4,7 @@ import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/wallet/balance.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
+import 'package:coconut_wallet/utils/wallet_util.dart';
 import 'package:coconut_wallet/widgets/icon/wallet_item_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -14,12 +15,14 @@ class SelectWalletBottomSheet extends StatefulWidget {
   final ScrollController? scrollController;
   final int walletId;
   final BitcoinUnit currentUnit;
+  final bool showOnlyMfpWallets;
 
   const SelectWalletBottomSheet(
       {super.key,
       required this.walletId,
       required this.onWalletChanged,
       required this.currentUnit,
+      required this.showOnlyMfpWallets,
       this.scrollController});
 
   @override
@@ -27,7 +30,7 @@ class SelectWalletBottomSheet extends StatefulWidget {
 }
 
 class _SelectWalletBottomSheetState extends State<SelectWalletBottomSheet> {
-  late final List<WalletListItemBase> _walletList;
+  late List<WalletListItemBase> _walletList;
   late final Map<int, Balance> _walletBalanceMap;
   int _selectedWalletId = -1;
 
@@ -36,6 +39,9 @@ class _SelectWalletBottomSheetState extends State<SelectWalletBottomSheet> {
     super.initState();
     final walletProvider = context.read<WalletProvider>();
     _walletList = walletProvider.walletItemList;
+    if (widget.showOnlyMfpWallets) {
+      _walletList = _walletList.where((wallet) => !isWalletNonMfp(wallet)).toList();
+    }
     _walletBalanceMap = walletProvider.fetchWalletBalanceMap();
     _selectedWalletId = widget.walletId;
   }

--- a/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
+++ b/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
@@ -40,7 +40,7 @@ class _SelectWalletBottomSheetState extends State<SelectWalletBottomSheet> {
     final walletProvider = context.read<WalletProvider>();
     _walletList = walletProvider.walletItemList;
     if (widget.showOnlyMfpWallets) {
-      _walletList = _walletList.where((wallet) => !isWalletNonMfp(wallet)).toList();
+      _walletList = _walletList.where((wallet) => !isWalletWithoutMfp(wallet)).toList();
     }
     _walletBalanceMap = walletProvider.fetchWalletBalanceMap();
     _selectedWalletId = widget.walletId;

--- a/lib/screens/send/refactor/select_wallet_with_options_bottom_sheet.dart
+++ b/lib/screens/send/refactor/select_wallet_with_options_bottom_sheet.dart
@@ -145,7 +145,7 @@ class _SelectWalletWithOptionsBottomSheetState extends State<SelectWalletWithOpt
   }
 
   Widget _buildUtxoOption() {
-    bool isNonMpfWallet = isWalletNonMfp(_selectedWalletItem);
+    bool isNonMpfWallet = isWalletWithoutMfp(_selectedWalletItem);
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onTap: () {
@@ -264,7 +264,7 @@ class _SelectWalletWithOptionsBottomSheetState extends State<SelectWalletWithOpt
           Row(
             children: [
               Text(
-                isWalletNonMfp(_selectedWalletItem)
+                isWalletWithoutMfp(_selectedWalletItem)
                     ? '-'
                     : _selectedWalletItem?.name ?? t.send_screen.select_wallet,
                 style: CoconutTypography.body3_12,

--- a/lib/screens/send/refactor/send_screen.dart
+++ b/lib/screens/send/refactor/send_screen.dart
@@ -129,7 +129,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
     }
 
     // MFP 없는 지갑이 선택된 경우 Toast 메시지 출력 하기
-    if (isWalletNonMfp(_viewModel.selectedWalletItem)) {
+    if (isWalletWithoutMfp(_viewModel.selectedWalletItem)) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         CoconutToast.showToast(
             isVisibleIcon: true,
@@ -231,8 +231,10 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
                   final selectedUtxoListLength = data.item4;
                   final currentUnit = data.item5;
 
+                  // null 이거나, 대표지갑이 mfp가 없고 mfp 있는 지갑이 0개일 때
                   if (_viewModel.isSelectedWalletNull ||
-                      isWalletNonMfp(_viewModel.selectedWalletItem)) {
+                      (isWalletWithoutMfp(_viewModel.selectedWalletItem) &&
+                          !hasMfpWallet(_viewModel.walletItemList))) {
                     return Container(
                       color: Colors.transparent,
                       width: 50,
@@ -255,16 +257,20 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
                       Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Text(selectedWalletItem!.name,
+                          Text(
+                              isWalletWithoutMfp(_viewModel.selectedWalletItem)
+                                  ? '-'
+                                  : selectedWalletItem!.name,
                               style: CoconutTypography.body1_16.setColor(CoconutColors.white)),
                           CoconutLayout.spacing_50w,
                           const Icon(Icons.keyboard_arrow_down_sharp,
                               color: CoconutColors.white, size: 16),
                         ],
                       ),
-                      Text(amountText,
-                          style:
-                              CoconutTypography.body3_12_NumberBold.setColor(CoconutColors.white)),
+                      if (!isWalletWithoutMfp(_viewModel.selectedWalletItem))
+                        Text(amountText,
+                            style: CoconutTypography.body3_12_NumberBold
+                                .setColor(CoconutColors.white)),
                     ],
                   );
                 }),

--- a/lib/screens/wallet_detail/wallet_detail_receive_address_screen.dart
+++ b/lib/screens/wallet_detail/wallet_detail_receive_address_screen.dart
@@ -156,6 +156,7 @@ class _ReceiveAddressScreenState extends State<ReceiveAddressScreen> {
     CommonBottomSheets.showDraggableBottomSheet(
         context: context,
         childBuilder: (scrollController) => SelectWalletBottomSheet(
+              showOnlyMfpWallets: false,
               scrollController: scrollController,
               currentUnit: context.read<PreferenceProvider>().currentUnit,
               walletId: selectedWalletId,

--- a/lib/utils/wallet_util.dart
+++ b/lib/utils/wallet_util.dart
@@ -3,7 +3,7 @@ import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/services/wallet_add_service.dart';
 
-bool isWalletNonMfp(WalletListItemBase? wallet) {
+bool isWalletWithoutMfp(WalletListItemBase? wallet) {
   if (wallet != null &&
       wallet is! MultisigWalletListItem &&
       (wallet.walletBase as SingleSignatureWallet).keyStore.masterFingerprint ==

--- a/lib/utils/wallet_util.dart
+++ b/lib/utils/wallet_util.dart
@@ -1,0 +1,22 @@
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
+import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
+import 'package:coconut_wallet/services/wallet_add_service.dart';
+
+bool isWalletNonMfp(WalletListItemBase? wallet) {
+  if (wallet != null &&
+      wallet is! MultisigWalletListItem &&
+      (wallet.walletBase as SingleSignatureWallet).keyStore.masterFingerprint ==
+          WalletAddService.masterFingerprintPlaceholder) {
+    return true;
+  }
+  return false;
+}
+
+// MFP가 있는 지갑이 하나라도 존재하는지 여부
+bool hasMfpWallet(List<WalletListItemBase> walletItemList) {
+  return walletItemList.any((wallet) =>
+      wallet is MultisigWalletListItem ||
+      (wallet.walletBase as SingleSignatureWallet).keyStore.masterFingerprint !=
+          WalletAddService.masterFingerprintPlaceholder);
+}


### PR DESCRIPTION
### 변경사항
feat(send_screen): 초기에 MFP 없는 지갑이 선택된 경우, Toast 메시지 출력
 - MFP 없는 지갑의 경우 지갑 이름 - 표시
 - 상단 앱바, MFP 월렛이 있는 경우에만 옵션 바텀시트를 출력하도록 처리

feat(select_with_options_bottom_sheet): MFP가 없는 지갑의 경우, 지갑 이름 - 표시, UTXO 관련 옵션 수정 불가하도록 처리
 - 지갑선택 바텀시트에서 MFP가 있는 지갑만 보여주도록 처리
 - MFP를 가진 지갑이 존재하지 않는 경우, 바텀시트 자체를 출력하지 않도록 처리

### 테스트 방법
어플 실행하여 테스트

[확장공개키 1]
tpubDDt5xij8skd8vfu2ptUKEzCk5HKYuZpyTsJBRuq4WsKHPpmSfExeYm4A2RnpGqu51WVFNtcsVkSPdmX1ctC5am2sPMEvDBvb6xd216itFG6

[확장공개키 2]
vpub5Z6wrDZJQ78faJ3PYfYs7et7ep8d8uCXivpa3cdxw3joZrN2dfkYuP2xfCgFWscYcvQFAHoVDMcPKrmF7ekcrwQiKcn8qQtEBwuqoMSfJte

### 테스트 체크리스트
- [ ] 1. MFP 없는 지갑이 대표지갑인 경우, - 표시하고 토스트 메시지 처리.
- [ ] MFP 있는 지갑이 존재하지 않는 경우, 옵션 바텀시트를 출력하지 않는다. (터치 이벤트 없음, 지갑선택/UTXO 옵션 처리 의미가 없음) 
- [ ] MFP 있는 지갑이 존재하는 경우, 옵션 바텀시트를 띄우고 지갑 이름은 -로 표시된다. (단, UTXO 관련 옵션은 disabled 상태로 처리한다, 이후에 지갑만 변경 가능) 
- [ ] 2. MFP 있는 지갑이 대표지갑인 경우, 지갑 이름과 UTXO 정보를 출력.
- [ ] 옵션 바텀시트를 띄우고 지갑 이름과 UTXO 정보를 출력. (기존 처리)
- [ ] 3. 지갑선택 바텀시트에서 MFP 없는 지갑 제외한다.
- [ ] 4. 보내기 화면 - 내 주소 - 더보기 - 지갑 선택 바텀시트는 전체 지갑 출력
- [ ] 5. 월렛 디테일 화면 - 받기 - 앱바 - 지갑 선택 바텀시트는 전체 지갑 출력
- [ ] 6. MFP 없는 지갑, 홈화면 보내기 버튼 클릭시 진입 가능 / MFP 없는 지갑, 지갑 디테일 화면 보내기 버튼 클릭시 진입 불가(토스트 출력)

#418 