### PR TITLE
[423] 가짜잔액 설정, 홈화면 총액에서 제외 연관 로직 수정, MFP 입력 autofocus 해제

### DIFF
--- a/lib/providers/view_model/home/wallet_home_view_model.dart
+++ b/lib/providers/view_model/home/wallet_home_view_model.dart
@@ -239,8 +239,22 @@ class WalletHomeViewModel extends ChangeNotifier {
     return _fakeBalanceMap[id] ?? _fakeBalanceTotalAmount;
   }
 
-  int? getFakeTotalBalance() {
-    return _fakeBalanceTotalAmount;
+  int getHomeFakeBalanceTotal() {
+    if (_fakeBalanceTotalAmount == null) return 0;
+
+    int totalAmount = 0;
+
+    // excludedFromTotalBalanceWalletIds에 포함되지 않은 지갑들의 가짜 잔액을 더함
+    for (final wallet in walletItemList) {
+      if (!_excludedFromTotalBalanceWalletIds.contains(wallet.id)) {
+        final fakeBalance = _fakeBalanceMap[wallet.id];
+        if (fakeBalance != null && fakeBalance is num) {
+          totalAmount += fakeBalance.toInt();
+        }
+      }
+    }
+
+    return totalAmount;
   }
 
   void onNodeProviderUpdated() {

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -288,8 +288,10 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
         }));
   }
 
-  void showMfpInputBottomSheet(WalletAddInputViewModel viewModel) {
+  void showMfpInputBottomSheet(WalletAddInputViewModel viewModel) async {
     _closeKeyboard();
+
+    await Future.delayed(const Duration(milliseconds: 300));
 
     showModalBottomSheet(
       context: context,

--- a/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
+++ b/lib/screens/home/wallet_add_mfp_input_bottom_sheet.dart
@@ -23,10 +23,7 @@ class _WalletAddMfpInputBottomSheetState extends State<WalletAddMfpInputBottomSh
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await Future.delayed(const Duration(milliseconds: 300));
-      _mfpFocusNode.requestFocus();
-    });
+
     _mfpController.addListener(() {
       if (_mfpController.text.length < 8) {
         setState(() {

--- a/lib/screens/home/wallet_home_screen.dart
+++ b/lib/screens/home/wallet_home_screen.dart
@@ -144,7 +144,7 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
                             onRefresh: viewModel.onRefresh,
                           ),
                           _buildLoadingIndicator(viewModel),
-                          _buildHeader(isBalanceHidden, viewModel.getFakeTotalBalance(),
+                          _buildHeader(isBalanceHidden, viewModel.fakeBalanceTotalAmount,
                               shouldShowLoadingIndicator, viewModel.walletItemList.isEmpty),
                           if (!shouldShowLoadingIndicator)
                             SliverToBoxAdapter(
@@ -424,9 +424,9 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
                                     ? Text(
                                         isBtcUnit
                                             ? BitcoinUnit.btc.displayBitcoinAmount(
-                                                fakeBalanceTotalAmount.toInt())
+                                                _viewModel.getHomeFakeBalanceTotal().toInt())
                                             : BitcoinUnit.sats.displayBitcoinAmount(
-                                                fakeBalanceTotalAmount.toInt()),
+                                                _viewModel.getHomeFakeBalanceTotal().toInt()),
                                         style: CoconutTypography.heading3_21_NumberBold.merge(
                                           const TextStyle(
                                             height: 1.4,


### PR DESCRIPTION
### 변경사항
 - 가짜잔액 활성화 상태에서 홈화면 총액에서 제외된 지갑은 총액에서 가짜잔액만큼 제외 되도록 수정
 - 지갑 추가-직접 입력에서 MFP 입력 바텀시트 호출 시 텍스트 필드에 request Focus 되던 현상 제거
 
#423  