### PR TITLE
[427] 잔액 숨김/보이기 로직과 가짜잔액 로직 분리

### DIFF
--- a/lib/providers/preference_provider.dart
+++ b/lib/providers/preference_provider.dart
@@ -167,11 +167,6 @@ class PreferenceProvider extends ChangeNotifier {
     _isBalanceHidden = isOn;
     await _sharedPrefs.setBool(SharedPrefKeys.kIsBalanceHidden, isOn);
 
-    if (!isOn) {
-      _isFakeBalanceActive = false;
-      await clearFakeBalanceTotalAmount();
-    }
-
     notifyListeners();
   }
 

--- a/lib/providers/preference_provider.dart
+++ b/lib/providers/preference_provider.dart
@@ -1,13 +1,16 @@
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/constants/shared_pref_keys.dart';
 import 'package:coconut_wallet/enums/electrum_enums.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
+import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/repository/realm/wallet_preferences_repository.dart';
 import 'package:coconut_wallet/model/node/electrum_server.dart';
 import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
+import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:flutter/material.dart';
@@ -224,6 +227,76 @@ class PreferenceProvider extends ChangeNotifier {
     _selectedFiat = fiatCode;
     await _sharedPrefs.setString(SharedPrefKeys.kSelectedFiat, fiatCode.code);
     notifyListeners();
+  }
+
+  /// 가짜 잔액 분배 작업
+  Future<void> initializeFakeBalance(List<WalletListItemBase> wallets,
+      {bool? isFakeBalanceActive, double? fakeBalanceTotalAmount}) async {
+    var fakeBalanceTotalBtc =
+        fakeBalanceTotalAmount ?? UnitUtil.convertSatoshiToBitcoin(_fakeBalanceTotalAmount!);
+
+    if (fakeBalanceTotalBtc == 0) {
+      await setFakeBalanceTotalAmount(0);
+
+      final Map<int, dynamic> fakeBalanceMap = {};
+      for (int i = 0; i < wallets.length; i++) {
+        final walletId = wallets[i].id;
+
+        fakeBalanceMap[walletId] = 0;
+        debugPrint('[Wallet $i]Fake Balance: ${fakeBalanceMap[i]} BTC');
+      }
+      await setFakeBalanceMap(fakeBalanceMap);
+      return;
+    }
+
+    final walletCount = wallets.length;
+
+    if (!fakeBalanceTotalBtc.toString().contains('.')) {
+      // input값이 정수 일 때 sats로 환산
+      fakeBalanceTotalBtc = fakeBalanceTotalBtc * 100000000;
+    } else {
+      // input이 소수일 때 소수점 이하 8자리로 맞춘 후 정수로 변환
+      final fixedString = fakeBalanceTotalBtc.toStringAsFixed(8).replaceAll('.', '');
+      fakeBalanceTotalBtc = double.parse(fixedString);
+    }
+
+    if (fakeBalanceTotalBtc < walletCount) return; // 최소 1사토시씩 못 주면 리턴
+
+    final random = Random();
+    // 1. 각 지갑에 최소 1사토시 할당
+    // 2. 남은 사토시를 랜덤 가중치로 분배
+    final List<int> weights = List.generate(walletCount, (_) => random.nextInt(100) + 1); // 1~100
+    final int weightSum = weights.reduce((a, b) => a + b);
+    final int remainingSats = (fakeBalanceTotalBtc - walletCount).toInt();
+    final List<int> splits = [];
+
+    for (int i = 0; i < walletCount; i++) {
+      final int share = (remainingSats * weights[i] / weightSum).floor();
+      splits.add(1 + share); // 최소 1 사토시 보장
+    }
+
+    // 보정: 분할의 총합이 totalSats보다 작을 수 있으므로 마지막 지갑에 부족분 추가
+    final int diff = (fakeBalanceTotalBtc - splits.reduce((a, b) => a + b)).toInt();
+    splits[splits.length - 1] += diff;
+
+    final Map<int, dynamic> fakeBalanceMap = {};
+
+    if (isFakeBalanceActive != null && isFakeBalanceActive != _isFakeBalanceActive) {
+      await changeIsFakeBalanceActive(_isFakeBalanceActive);
+    }
+
+    debugPrint('_fakeBalanceTotalAmount!.toInt(): ${fakeBalanceTotalBtc.toInt()}');
+    await setFakeBalanceTotalAmount(fakeBalanceTotalBtc.toInt());
+
+    for (int i = 0; i < splits.length; i++) {
+      final walletId = wallets[i].id;
+      final fakeBalance = splits[i];
+      fakeBalanceMap[walletId] = fakeBalance;
+      debugPrint('[Wallet $i]Fake Balance: ${splits[i]} Sats');
+    }
+
+    await setFakeBalanceMap(fakeBalanceMap);
+    await changeIsBalanceHidden(false); // 가짜 잔액 설정 시 잔액 숨기기 해제
   }
 
   /// 가짜 잔액 총량 수정

--- a/lib/providers/view_model/home/wallet_add_input_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_input_view_model.dart
@@ -80,15 +80,6 @@ class WalletAddInputViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> setFakeBalanceIfEnabled(int? walletId) async {
-    if (fakeBalanceTotalAmount == null || walletId == null) return;
-
-    // 가짜 잔액이 설정되어 있는 경우 FakeBalanceTotalAmount 이하의 값 랜덤 배정
-    final randomFakeBalance = (Random().nextDouble() * fakeBalanceTotalAmount! + 1).toInt();
-
-    await _preferenceProvider.setFakeBalance(walletId, randomFakeBalance);
-  }
-
   Future<ResultOfSyncFromVault> addWallet() async {
     assert(validExtendedPublicKey != null || validDescriptor != null);
     if (validExtendedPublicKey != null) {

--- a/lib/providers/view_model/home/wallet_add_scanner_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_scanner_view_model.dart
@@ -5,7 +5,6 @@ import 'package:coconut_wallet/model/wallet/watch_only_wallet.dart';
 import 'package:coconut_wallet/providers/preference_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/services/wallet_add_service.dart';
-import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/third_party_util.dart';
 import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/bb_qr_scan_data_handler.dart';
 import 'package:flutter/material.dart';
@@ -103,14 +102,5 @@ class WalletAddScannerViewModel extends ChangeNotifier {
 
   String getWalletName(int walletId) {
     return _walletProvider.getWalletById(walletId).name;
-  }
-
-  Future<void> setFakeBalanceIfEnabled(int? walletId) async {
-    if (fakeBalanceTotalAmount == null || walletId == null) return;
-
-    // 가짜 잔액이 설정되어 있는 경우 FakeBalanceTotalAmount 이하의 값 랜덤 배정
-    final randomFakeBalance = (Random().nextDouble() * fakeBalanceTotalAmount! + 1).toInt();
-
-    await _preferenceProvider.setFakeBalance(walletId, randomFakeBalance);
   }
 }

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -430,9 +430,17 @@ class WalletProvider extends ChangeNotifier {
     }
   }
 
-  /// 새 지갑이 추가되었을 때 처리하는 함수(즐겨찾기, 지갑 순서 추가)
-  void _handleNewWalletAdded(int walletId) {
+  /// 새 지갑이 추가되었을 때 처리하는 함수(가짜 잔액 재분배, 즐겨찾기, 지갑 순서 추가)
+  Future<void> _handleNewWalletAdded(int walletId) async {
+    // 가짜 잔액 활성화 상태라면 재분배 작업 수행
+    if (_preferenceProvider.isFakeBalanceActive) {
+      await _preferenceProvider.initializeFakeBalance(_walletItemList);
+    }
+
+    // 지갑 순서 목록에 추가
     addToWalletOrder(walletId);
+
+    // 5개 이하라면 즐겨찾기 목록에 추가
     addToFavoriteWalletsUntilFive(walletId);
   }
 

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -60,13 +60,9 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                       WalletImportSource.extendedPublicKey.name
                 });
 
-            // 가짜 잔액 활성화 상태라면 재분배 작업 수행
-            if (Provider.of<PreferenceProvider>(context, listen: false).isFakeBalanceActive) {
-              final wallets = Provider.of<WalletProvider>(context, listen: false).walletItemList;
-              await Provider.of<PreferenceProvider>(context, listen: false)
-                  .initializeFakeBalance(wallets);
+            if (mounted) {
+              Navigator.pop(context, addResult);
             }
-            Navigator.pop(context, addResult);
             break;
           }
         case WalletSyncResult.existingWalletUpdateImpossible:

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -1,9 +1,11 @@
 import 'dart:io';
+import 'dart:math';
 
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/analytics/analytics_event_names.dart';
 import 'package:coconut_wallet/analytics/analytics_parameter_names.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
+import 'package:coconut_wallet/providers/preference_provider.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_add_input_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/screens/home/wallet_add_mfp_input_bottom_sheet.dart';
@@ -58,6 +60,7 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                   AnalyticsParameterNames.walletAddImportSource:
                       WalletImportSource.extendedPublicKey.name
                 });
+            await viewModel.setFakeBalanceIfEnabled(addResult.walletId);
             Navigator.pop(context, addResult);
             break;
           }
@@ -128,6 +131,7 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
     return ChangeNotifierProvider(
         create: (_) => WalletAddInputViewModel(
               context.read<WalletProvider>(),
+              context.read<PreferenceProvider>(),
             ),
         child: Consumer<WalletAddInputViewModel>(builder: (context, viewModel, child) {
           if (!_hasAddedListener) {

--- a/lib/screens/home/wallet_add_input_screen.dart
+++ b/lib/screens/home/wallet_add_input_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:math';
 
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/analytics/analytics_event_names.dart';
@@ -60,7 +59,13 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                   AnalyticsParameterNames.walletAddImportSource:
                       WalletImportSource.extendedPublicKey.name
                 });
-            await viewModel.setFakeBalanceIfEnabled(addResult.walletId);
+
+            // 가짜 잔액 활성화 상태라면 재분배 작업 수행
+            if (Provider.of<PreferenceProvider>(context, listen: false).isFakeBalanceActive) {
+              final wallets = Provider.of<WalletProvider>(context, listen: false).walletItemList;
+              await Provider.of<PreferenceProvider>(context, listen: false)
+                  .initializeFakeBalance(wallets);
+            }
             Navigator.pop(context, addResult);
             break;
           }
@@ -229,9 +234,12 @@ class _WalletAddInputScreenState extends State<WalletAddInputScreen> {
                                                     CoconutColors.white, BlendMode.srcIn),
                                               ),
                                               CoconutLayout.spacing_100w,
-                                              Text(
-                                                  t.wallet_add_input_screen.wallet_description_text,
-                                                  style: CoconutTypography.body2_14)
+                                              Expanded(
+                                                child: Text(
+                                                    t.wallet_add_input_screen
+                                                        .wallet_description_text,
+                                                    style: CoconutTypography.body2_14),
+                                              ),
                                             ],
                                           ),
                                         ),

--- a/lib/screens/home/wallet_add_scanner_screen.dart
+++ b/lib/screens/home/wallet_add_scanner_screen.dart
@@ -326,25 +326,19 @@ class _WalletAddScannerScreenState extends State<WalletAddScannerScreen> {
                   AnalyticsParameterNames.walletAddImportSource: widget.importSource.name
                 });
 
-            // 가짜 잔액 활성화 상태라면 재분배 작업 수행
-            if (Provider.of<PreferenceProvider>(context, listen: false).isFakeBalanceActive) {
-              final wallets = Provider.of<WalletProvider>(context, listen: false).walletItemList;
-              await Provider.of<PreferenceProvider>(context, listen: false)
-                  .initializeFakeBalance(wallets);
-            }
-
             if (widget.onNewWalletAdded != null) {
               widget.onNewWalletAdded!(addResult);
             }
-            Navigator.pushReplacementNamed(
-              context,
-              '/wallet-detail',
-              arguments: {
-                'id': addResult.walletId,
-                'entryPoint': kEntryPointWalletHome,
-              },
-            );
-
+            if (mounted) {
+              Navigator.pushReplacementNamed(
+                context,
+                '/wallet-detail',
+                arguments: {
+                  'id': addResult.walletId,
+                  'entryPoint': kEntryPointWalletHome,
+                },
+              );
+            }
             break;
           }
         case WalletSyncResult.existingWalletUpdated:

--- a/lib/screens/home/wallet_add_scanner_screen.dart
+++ b/lib/screens/home/wallet_add_scanner_screen.dart
@@ -325,7 +325,13 @@ class _WalletAddScannerScreenState extends State<WalletAddScannerScreen> {
                 parameters: {
                   AnalyticsParameterNames.walletAddImportSource: widget.importSource.name
                 });
-            await _viewModel.setFakeBalanceIfEnabled(addResult.walletId!);
+
+            // 가짜 잔액 활성화 상태라면 재분배 작업 수행
+            if (Provider.of<PreferenceProvider>(context, listen: false).isFakeBalanceActive) {
+              final wallets = Provider.of<WalletProvider>(context, listen: false).walletItemList;
+              await Provider.of<PreferenceProvider>(context, listen: false)
+                  .initializeFakeBalance(wallets);
+            }
 
             if (widget.onNewWalletAdded != null) {
               widget.onNewWalletAdded!(addResult);

--- a/lib/screens/home/wallet_home_screen.dart
+++ b/lib/screens/home/wallet_home_screen.dart
@@ -391,7 +391,10 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
                         selector: (_, viewModel) => viewModel.excludedFromTotalBalanceWalletIds,
                         builder: (context, excludedIds, child) {
                           final balance = _viewModel.fakeBalanceTotalAmount != null
-                              ? _viewModel.fakeBalanceTotalAmount!
+                              ? _viewModel.fakeBalanceMap.entries
+                                  .where((entry) => !excludedIds.contains(entry.key))
+                                  .map((entry) => entry.value as int)
+                                  .fold<int>(0, (current, element) => current + element)
                               : Map.fromEntries(
                                   _viewModel.walletBalanceMap.entries.where(
                                     (entry) => !excludedIds.contains(entry.key),

--- a/lib/screens/home/wallet_home_screen.dart
+++ b/lib/screens/home/wallet_home_screen.dart
@@ -383,8 +383,7 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
                   maintainSize: true,
                   maintainAnimation: true,
                   maintainState: true,
-                  visible: (!isBalanceHidden || _viewModel.fakeBalanceTotalAmount != null) &&
-                      _viewModel.walletItemList.isNotEmpty,
+                  visible: (!isBalanceHidden) && _viewModel.walletItemList.isNotEmpty,
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.start,
                     children: [
@@ -420,7 +419,19 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
                         Row(
                           children: [
                             isBalanceHidden
-                                ? fakeBalanceTotalAmount != null
+                                ? Text(
+                                    t.view_balance,
+                                    style: CoconutTypography.heading3_21_NumberBold
+                                        .setColor(
+                                          CoconutColors.gray600,
+                                        )
+                                        .merge(
+                                          const TextStyle(
+                                            height: 1.3,
+                                          ),
+                                        ),
+                                  )
+                                : fakeBalanceTotalAmount != null
                                     ? Text(
                                         isBtcUnit
                                             ? BitcoinUnit.btc.displayBitcoinAmount(
@@ -433,50 +444,40 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
                                           ),
                                         ),
                                       )
-                                    : Text(
-                                        t.view_balance,
-                                        style: CoconutTypography.heading3_21_NumberBold
-                                            .setColor(
-                                              CoconutColors.gray600,
-                                            )
-                                            .merge(
+                                    : Selector<WalletHomeViewModel, List<int>>(
+                                        selector: (_, viewModel) =>
+                                            viewModel.excludedFromTotalBalanceWalletIds,
+                                        builder: (context, excludedIds, child) {
+                                          // 총 잔액에서 숨기기 설정된 지갑 ID는 합에서 제외
+                                          final filteredBalanceMap = Map.fromEntries(
+                                            _viewModel.walletBalanceMap.entries.where(
+                                              (entry) => !excludedIds.contains(entry.key),
+                                            ),
+                                          );
+
+                                          final prevValue = filteredBalanceMap.values
+                                              .map((e) => e.previous)
+                                              .fold(0, (prev, element) => prev + element);
+
+                                          final currentValue = filteredBalanceMap.values
+                                              .map((e) => e.current)
+                                              .fold(0, (current, element) => current + element);
+                                          return AnimatedBalance(
+                                            prevValue: prevValue,
+                                            value: currentValue,
+                                            currentUnit:
+                                                isBtcUnit ? BitcoinUnit.btc : BitcoinUnit.sats,
+                                            textStyle:
+                                                CoconutTypography.heading3_21_NumberBold.merge(
                                               const TextStyle(
-                                                height: 1.3,
+                                                height: 1.4,
                                               ),
                                             ),
-                                      )
-                                : Selector<WalletHomeViewModel, List<int>>(
-                                    selector: (_, viewModel) =>
-                                        viewModel.excludedFromTotalBalanceWalletIds,
-                                    builder: (context, excludedIds, child) {
-                                      // 총 잔액에서 숨기기 설정된 지갑 ID는 합에서 제외
-                                      final filteredBalanceMap = Map.fromEntries(
-                                        _viewModel.walletBalanceMap.entries.where(
-                                          (entry) => !excludedIds.contains(entry.key),
-                                        ),
-                                      );
-
-                                      final prevValue = filteredBalanceMap.values
-                                          .map((e) => e.previous)
-                                          .fold(0, (prev, element) => prev + element);
-
-                                      final currentValue = filteredBalanceMap.values
-                                          .map((e) => e.current)
-                                          .fold(0, (current, element) => current + element);
-                                      return AnimatedBalance(
-                                        prevValue: prevValue,
-                                        value: currentValue,
-                                        currentUnit: isBtcUnit ? BitcoinUnit.btc : BitcoinUnit.sats,
-                                        textStyle: CoconutTypography.heading3_21_NumberBold.merge(
-                                          const TextStyle(
-                                            height: 1.4,
-                                          ),
-                                        ),
-                                      );
-                                    },
-                                  ),
+                                          );
+                                        },
+                                      ),
                             const SizedBox(width: 4.0),
-                            if (!isBalanceHidden || fakeBalanceTotalAmount != null)
+                            if (!isBalanceHidden)
                               Text(
                                 isBtcUnit ? t.btc : t.sats,
                                 style: CoconutTypography.heading3_21_NumberBold,
@@ -488,19 +489,17 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
                             defaultColor: CoconutColors.gray800,
                             pressedColor: CoconutColors.gray750,
                             onPressed: () {
-                              if (fakeBalanceTotalAmount != null) {
-                                _viewModel.clearFakeBlanceTotalAmount();
-                                _viewModel.setIsBalanceHidden(true);
-                                return;
-                              }
+                              // if (fakeBalanceTotalAmount != null) {
+                              //   _viewModel.clearFakeBlanceTotalAmount();
+                              //   _viewModel.setIsBalanceHidden(true);
+                              //   return;
+                              // }
                               _viewModel.setIsBalanceHidden(!isBalanceHidden);
                             },
                             child: Container(
                               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
                               child: Text(
-                                _viewModel.isBalanceHidden && fakeBalanceTotalAmount == null
-                                    ? t.show
-                                    : t.hide,
+                                _viewModel.isBalanceHidden ? t.show : t.hide,
                                 style: CoconutTypography.body3_12,
                               ),
                             ))

--- a/lib/screens/settings/fake_balance_bottom_sheet.dart
+++ b/lib/screens/settings/fake_balance_bottom_sheet.dart
@@ -224,12 +224,20 @@ class _FakeBalanceBottomSheetState extends State<FakeBalanceBottomSheet> {
 
   bool _shouldEnableCompleteButton() {
     if (isLoading) return false;
+    if (_textEditingController.text.isEmpty) return false;
 
     final text = _textEditingController.text;
-    final isTextChanged = text != _preferenceProvider.fakeBalanceTotalAmount.toString();
     final isToggleChanged = _isFakeBalanceActive != _preferenceProvider.isFakeBalanceActive;
 
+    // satoshi를 BTC로 변환
+    double fakeBalanceTotalAmount = (_preferenceProvider.fakeBalanceTotalAmount ?? 0) / 100000000;
+
     if (_isFakeBalanceActive) {
+      // text가 "0"일 때와 fakeBalanceTotalAmount가 0일 때를 동일하게 처리
+      // text를 double로 파싱해서 비교
+      final textAsDouble = double.tryParse(text) ?? 0;
+      final isTextChanged = textAsDouble != fakeBalanceTotalAmount;
+
       if (text.isEmpty || !isTextChanged) return false;
 
       final parsed = double.tryParse(text);

--- a/lib/screens/settings/fake_balance_bottom_sheet.dart
+++ b/lib/screens/settings/fake_balance_bottom_sheet.dart
@@ -69,6 +69,18 @@ class _FakeBalanceBottomSheetState extends State<FakeBalanceBottomSheet> {
         if (_textEditingController.text.isEmpty) {
           _fakeBalanceTotalBtc = null;
         }
+
+        if (_textEditingController.text.length > 1 &&
+            _textEditingController.text[0] == '0' &&
+            _textEditingController.text[1] == '0' &&
+            !_textEditingController.text.contains('.')) {
+          // 정수 자리의 첫번째가 0인 경우 0의 추가입력을 막음
+          _textEditingController.text = _textEditingController.text.substring(1);
+          _textEditingController.selection = TextSelection.fromPosition(
+            TextPosition(offset: _textEditingController.text.length),
+          );
+        }
+
         try {
           input = double.parse(_textEditingController.text);
         } catch (e) {
@@ -229,6 +241,9 @@ class _FakeBalanceBottomSheetState extends State<FakeBalanceBottomSheet> {
     final text = _textEditingController.text;
     final isToggleChanged = _isFakeBalanceActive != _preferenceProvider.isFakeBalanceActive;
 
+    if (_preferenceProvider.fakeBalanceTotalAmount == null) {
+      return isToggleChanged;
+    }
     // satoshi를 BTC로 변환
     double fakeBalanceTotalAmount = (_preferenceProvider.fakeBalanceTotalAmount ?? 0) / 100000000;
 
@@ -323,5 +338,6 @@ class _FakeBalanceBottomSheetState extends State<FakeBalanceBottomSheet> {
     }
 
     await _preferenceProvider.setFakeBalanceMap(fakeBalanceMap);
+    await _preferenceProvider.changeIsBalanceHidden(false); // 가짜 잔액 설정 시 잔액 숨기기 해제
   }
 }

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -112,15 +112,14 @@ class _SettingsScreen extends State<SettingsScreen> {
                                 onChanged: (value) {
                                   viewModel.changeIsBalanceHidden(value);
                                 })),
-                        if (viewModel.isBalanceHidden)
-                          SingleButton(
-                            enableShrinkAnim: true,
-                            title: t.settings_screen.fake_balance.fake_balance_setting,
-                            onPressed: () async {
-                              CommonBottomSheets.showBottomSheet_50(
-                                  context: context, child: const FakeBalanceBottomSheet());
-                            },
-                          ),
+                        SingleButton(
+                          enableShrinkAnim: true,
+                          title: t.settings_screen.fake_balance.fake_balance_setting,
+                          onPressed: () async {
+                            CommonBottomSheets.showBottomSheet_50(
+                                context: context, child: const FakeBalanceBottomSheet());
+                          },
+                        ),
                       ],
                     ),
                   ],

--- a/lib/widgets/card/wallet_item_card.dart
+++ b/lib/widgets/card/wallet_item_card.dart
@@ -141,7 +141,12 @@ class WalletItemCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 isBalanceHidden
-                    ? fakeBalance != null
+                    ? Text(
+                        t.view_balance,
+                        style:
+                            CoconutTypography.body2_14_Bold.copyWith(color: CoconutColors.gray600),
+                      )
+                    : fakeBalance != null
                         ? FittedBox(
                             fit: BoxFit.scaleDown,
                             alignment: Alignment.centerLeft,
@@ -161,33 +166,28 @@ class WalletItemCard extends StatelessWidget {
                               ],
                             ),
                           )
-                        : Text(
-                            t.view_balance,
-                            style: CoconutTypography.body2_14_Bold
-                                .copyWith(color: CoconutColors.gray600),
-                          )
-                    : FittedBox(
-                        fit: BoxFit.scaleDown,
-                        alignment: Alignment.centerLeft,
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            AnimatedBalance(
-                                prevValue: animatedBalanceData.previous,
-                                value: animatedBalanceData.current,
-                                currentUnit: currentUnit == BitcoinUnit.btc
-                                    ? BitcoinUnit.btc
-                                    : BitcoinUnit.sats,
-                                textStyle: CoconutTypography.body2_14_NumberBold
-                                    .setColor(CoconutColors.white)),
-                            Text(
-                              " ${currentUnit == BitcoinUnit.btc ? t.btc : t.sats}",
-                              style: CoconutTypography.body2_14_NumberBold
-                                  .setColor(CoconutColors.white),
+                        : FittedBox(
+                            fit: BoxFit.scaleDown,
+                            alignment: Alignment.centerLeft,
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                AnimatedBalance(
+                                    prevValue: animatedBalanceData.previous,
+                                    value: animatedBalanceData.current,
+                                    currentUnit: currentUnit == BitcoinUnit.btc
+                                        ? BitcoinUnit.btc
+                                        : BitcoinUnit.sats,
+                                    textStyle: CoconutTypography.body2_14_NumberBold
+                                        .setColor(CoconutColors.white)),
+                                Text(
+                                  " ${currentUnit == BitcoinUnit.btc ? t.btc : t.sats}",
+                                  style: CoconutTypography.body2_14_NumberBold
+                                      .setColor(CoconutColors.white),
+                                ),
+                              ],
                             ),
-                          ],
-                        ),
-                      ),
+                          ),
                 Row(
                   children: [
                     Flexible(


### PR DESCRIPTION
### 변경사항
[기존]
- 잔액 숨겨진 상태에서 보기 상태로 전환 시 가짜잔액이 활성화 상태더라도 자동으로 비활성화 상태가 됩니다.
- 이로 인해 홈화면에서 가짜 잔액 표시 상태에서 숨기기 -> 보기 전환시 실제 잔액으로 표기되는 현상이 있습니다.
- 이 현상이 일어나는 이유는 설정화면에서 잔액 숨기기 토글 버튼을 활성화->비활성화 상태로 전환 시 자동으로 가짜 잔액도 활성화 -> 비활성화 하기 위해 구현된 로직이 원인이었습니다.

[변경]
- 가짜 잔액 로직과 잔액 숨기기 로직을 분리하였습니다.
- 다음과 같이 동작합니다.
  - ex: 가짜 잔액 1BTC로 설정
    - 잔액 숨기기 시 '잔액 보기'로 전환
    - 잔액 숨기기 해제 시 1BTC로 표시
  - ex: 가짜 잔액 설정 안함
    - 잔액 숨기기 시 '잔액 보기'로 전환
    - 잔액 숨기기 해제 시 실제 잔액으로 표시

#427 