### PR TITLE
[413] bip21 data에 amount가 있는 경우 보내는 정보로 사용

### DIFF
--- a/lib/providers/view_model/home/wallet_list_view_model.dart
+++ b/lib/providers/view_model/home/wallet_list_view_model.dart
@@ -7,6 +7,7 @@ import 'package:coconut_wallet/providers/auth_provider.dart';
 import 'package:coconut_wallet/providers/connectivity_provider.dart';
 import 'package:coconut_wallet/providers/node_provider/node_provider.dart';
 import 'package:coconut_wallet/providers/preference_provider.dart';
+import 'package:coconut_wallet/providers/price_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
 import 'package:coconut_wallet/utils/vibration_util.dart';
@@ -26,6 +27,7 @@ class WalletListViewModel extends ChangeNotifier {
   late final ConnectivityProvider _connectivityProvider;
   late final AuthProvider _authProvider;
   late final NodeProvider _nodeProvider;
+  late final PriceProvider _priceProvider;
   late Stream<NodeSyncState> _syncNodeStateStream;
   late PreferenceProvider _preferenceProvider;
   late bool? _isNetworkOn;
@@ -58,6 +60,7 @@ class WalletListViewModel extends ChangeNotifier {
     this._authProvider,
     this._nodeProvider,
     this._preferenceProvider,
+    this._priceProvider,
   ) {
     _isNetworkOn = _connectivityProvider.isNetworkOn;
     _walletOrder = _preferenceProvider.walletOrder;
@@ -70,6 +73,15 @@ class WalletListViewModel extends ChangeNotifier {
         .map((key, balance) => MapEntry(key, AnimatedBalanceData(balance.total, balance.total)));
     _walletProvider.walletLoadStateNotifier.addListener(updateWalletBalances);
     _preferenceProvider.addListener(_onPreferenceChanged);
+    _priceProvider.addListener(_updateBitcoinPrice);
+  }
+
+  void _updateBitcoinPrice() {
+    notifyListeners();
+  }
+
+  String getBitcoinPrice(int satoshiAmount) {
+    return _priceProvider.getFiatPrice(satoshiAmount);
   }
 
   void _onPreferenceChanged() {
@@ -332,6 +344,7 @@ class WalletListViewModel extends ChangeNotifier {
   void dispose() {
     _syncNodeStateSubscription?.cancel();
     _preferenceProvider.removeListener(_onPreferenceChanged);
+    _priceProvider.removeListener(_updateBitcoinPrice);
     super.dispose();
   }
 }

--- a/lib/providers/view_model/send/refactor/send_view_model.dart
+++ b/lib/providers/view_model/send/refactor/send_view_model.dart
@@ -697,13 +697,12 @@ class SendViewModel extends ChangeNotifier {
   void validateAllFieldsOnFocusLost() {
     if (_isMaxMode) _adjustLastReceiverAmount();
     for (int i = 0; i < _recipientList.length; ++i) {
-      _updateAmountValidationState(recipientIndex: _currentIndex);
+      _updateAmountValidationState(recipientIndex: i);
       validateAddress(_recipientList[i].address, i);
     }
     checkAndSetDuplicationError();
     _buildTransaction();
     _updateFeeBoardVisibility();
-    Logger.log('--> validateAllFieldsOnFocusLost');
   }
 
   void clearAmountText() {

--- a/lib/providers/view_model/send/refactor/send_view_model.dart
+++ b/lib/providers/view_model/send/refactor/send_view_model.dart
@@ -588,6 +588,16 @@ class SendViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  void setAmountText(String satoshi, int recipientIndex) {
+    if (currentUnit == BitcoinUnit.sats) {
+      _recipientList[recipientIndex].amount = satoshi;
+    } else {
+      _recipientList[recipientIndex].amount =
+          UnitUtil.convertSatoshiToBitcoin(int.parse(satoshi)).toString();
+    }
+    notifyListeners();
+  }
+
   void setFeeRateText(String feeRate) {
     _feeRateText = feeRate;
 

--- a/lib/screens/home/wallet_list_screen.dart
+++ b/lib/screens/home/wallet_list_screen.dart
@@ -6,6 +6,7 @@ import 'package:coconut_wallet/providers/auth_provider.dart';
 import 'package:coconut_wallet/providers/connectivity_provider.dart';
 import 'package:coconut_wallet/providers/node_provider/node_provider.dart';
 import 'package:coconut_wallet/providers/preference_provider.dart';
+import 'package:coconut_wallet/providers/price_provider.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_add_scanner_view_model.dart';
 import 'package:coconut_wallet/screens/common/pin_check_screen.dart';
 import 'package:coconut_wallet/screens/home/wallet_item_setting_bottom_sheet.dart';
@@ -182,43 +183,6 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
     );
   }
 
-  // Positioned _buildOfflineWarningBar(BuildContext context, bool isOffline) {
-  //   return Positioned(
-  //     top: MediaQuery.of(context).padding.top,
-  //     left: 0,
-  //     right: 0,
-  //     child: AnimatedContainer(
-  //       duration: kOfflineWarningBarDuration,
-  //       curve: Curves.easeOut,
-  //       height: isOffline ? kOfflineWarningBarHeight : 0.0,
-  //       width: double.infinity,
-  //       padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-  //       color: CoconutColors.hotPink,
-  //       child: Row(
-  //         mainAxisAlignment: MainAxisAlignment.center,
-  //         children: [
-  //           SvgPicture.asset('assets/svg/triangle-warning.svg'),
-  //           CoconutLayout.spacing_100w,
-  //           Text(
-  //             t.errors.network_not_found,
-  //             style: CoconutTypography.body3_12,
-  //           ),
-  //         ],
-  //       ),
-  //     ),
-  //   );
-  // }
-
-  // Widget _buildPadding(bool isOffline) {
-  //   const kDefaultPadding = Sizes.size12;
-  //   return SliverToBoxAdapter(
-  //       child: AnimatedContainer(
-  //           duration: kOfflineWarningBarDuration,
-  //           height: isOffline ? kOfflineWarningBarHeight + kDefaultPadding : kDefaultPadding,
-  //           curve: Curves.easeInOut,
-  //           child: const SizedBox()));
-  // }
-
   @override
   void initState() {
     super.initState();
@@ -239,6 +203,7 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
       Provider.of<AuthProvider>(context, listen: false),
       Provider.of<NodeProvider>(context, listen: false),
       Provider.of<PreferenceProvider>(context, listen: false),
+      Provider.of<PriceProvider>(context, listen: false),
     );
     return _viewModel;
   }
@@ -369,6 +334,9 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
                       ),
                     ],
                   ),
+                  // 전체 총액 - Fiat Price
+                  Text(_viewModel.getBitcoinPrice(totalBalance),
+                      style: CoconutTypography.body2_14_Number.setColor(CoconutColors.gray500)),
 
                   // 홈 화면 총액 (애니메이션)
                   AnimatedSwitcher(
@@ -413,24 +381,34 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
     required int amount,
     required bool isBtcUnit,
   }) {
-    return Row(
+    return Column(
       children: [
-        Text(
-          label,
-          style: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
+        Row(
+          children: [
+            Text(
+              label,
+              style: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
+            ),
+            const Spacer(),
+            Text(
+              isBtcUnit
+                  ? BitcoinUnit.btc.displayBitcoinAmount(amount)
+                  : BitcoinUnit.sats.displayBitcoinAmount(amount),
+              style: CoconutTypography.body2_14_Number.setColor(CoconutColors.gray300),
+            ),
+            CoconutLayout.spacing_100w,
+            Text(
+              isBtcUnit ? t.btc : t.sats,
+              style: CoconutTypography.body2_14_Number.setColor(CoconutColors.gray300),
+            ),
+          ],
         ),
-        const Spacer(),
-        Text(
-          isBtcUnit
-              ? BitcoinUnit.btc.displayBitcoinAmount(amount)
-              : BitcoinUnit.sats.displayBitcoinAmount(amount),
-          style: CoconutTypography.body2_14_Number.setColor(CoconutColors.gray300),
-        ),
-        CoconutLayout.spacing_100w,
-        Text(
-          isBtcUnit ? t.btc : t.sats,
-          style: CoconutTypography.body2_14_Number.setColor(CoconutColors.gray300),
-        ),
+        // Fiat price
+        Row(children: [
+          const Spacer(),
+          Text(_viewModel.getBitcoinPrice(amount),
+              style: CoconutTypography.body3_12_Number.setColor(CoconutColors.gray500))
+        ]),
       ],
     );
   }

--- a/lib/screens/send/refactor/send_screen.dart
+++ b/lib/screens/send/refactor/send_screen.dart
@@ -1263,7 +1263,7 @@ class _SendScreenState extends State<SendScreen>
 
   Future<void> _showAddressScanner(int index) async {
     final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
-    final String? scannedAddress = await CommonBottomSheets.showBottomSheet_100(
+    final String? scannedData = await CommonBottomSheets.showBottomSheet_100(
         context: context,
         child: Scaffold(
             backgroundColor: CoconutColors.black,
@@ -1289,8 +1289,19 @@ class _SendScreenState extends State<SendScreen>
                   Navigator.of(context).pop<String>('');
                 }),
             body: SendAddressBody(qrKey: qrKey, onQrViewCreated: _onQRViewCreated)));
-    if (scannedAddress != null) {
-      _addressControllerList[index].text = scannedAddress;
+    if (scannedData != null) {
+      if (scannedData.startsWith('bitcoin:')) {
+        final bip21Data = parseBip21Uri(scannedData);
+        _addressControllerList[index].text = bip21Data.address;
+        _viewModel.setAddressText(bip21Data.address, index);
+
+        // amount 파라미터가 있는 경우
+        if (bip21Data.amount != null) {
+          _amountController.text = bip21Data.amount.toString();
+        }
+      } else {
+        _addressControllerList[index].text = scannedData;
+      }
     }
     _disposeQrViewController();
   }

--- a/lib/utils/address_util.dart
+++ b/lib/utils/address_util.dart
@@ -6,6 +6,14 @@ String shortenAddress(String address, {int head = 8, int tail = 8}) {
   return '${address.substring(0, head)}...${address.substring(address.length - tail)}';
 }
 
+class Bip21Data {
+  final String address;
+  final int? amount;
+  final Map<String, String>? parameters;
+
+  Bip21Data({required this.address, this.amount, this.parameters});
+}
+
 /// Bip21 주소를 정규화
 /// Bech32 (P2WPKH, P2WSH) 주소인 경우 소문자 변환
 String normalizeAddress(String input) {
@@ -26,6 +34,54 @@ String extractAddressFromBip21(String input) {
   }
 
   return withoutScheme.substring(0, queryIndex);
+}
+
+Bip21Data parseBip21Uri(String input) {
+  if (!input.toLowerCase().startsWith('bitcoin:')) {
+    return Bip21Data(
+      address: input,
+      parameters: {},
+    );
+  }
+
+  final withoutScheme = input.substring(8);
+  final queryIndex = withoutScheme.indexOf('?');
+
+  String address;
+  Map<String, String> parameters = {};
+  int? amount;
+
+  if (queryIndex == -1) {
+    address = withoutScheme;
+  } else {
+    address = withoutScheme.substring(0, queryIndex);
+    final queryString = withoutScheme.substring(queryIndex + 1);
+
+    final queryParams = queryString.split('&');
+    for (final param in queryParams) {
+      final equalIndex = param.indexOf('=');
+      if (equalIndex != -1) {
+        final key = param.substring(0, equalIndex);
+        final value = param.substring(equalIndex + 1);
+        parameters[key] = value;
+
+        if (key == 'amount') {
+          try {
+            final satoshiAmount = double.parse(value);
+            amount = (satoshiAmount * 100000000).toInt();
+          } catch (e) {
+            // amount 파싱 실패 시 무시
+          }
+        }
+      }
+    }
+  }
+
+  return Bip21Data(
+    address: address.toLowerCase(),
+    amount: amount,
+    parameters: parameters,
+  );
 }
 
 bool isBech32(String address) {


### PR DESCRIPTION
### 테스트 방법
1. 블루월렛을 사용하여 amount 지정하여 받을 주소 정보 생성
   -  받기 - 금액 명시 후 받기 - 금액 입력 - [생성하기]
2. 코코넛 월렛 send 화면에서 주소 입력란 우측 - 스캔 아이콘 클릭하여 bip21 QR 스캔
3. 블루월렛에서 명시한 금액이 코코넛 월렛 보내기 화면 보낼 금액에 추가됨.
4. (추가) 주소 qr 스캔 시 prefix 'bitcoin:' 제거되는지 확인

#413 