### PR TITLE
[451] 0.4.2 큰 폰트 대응 코드 오적용 부분

### DIFF
--- a/lib/screens/settings/app_info_screen.dart
+++ b/lib/screens/settings/app_info_screen.dart
@@ -252,6 +252,7 @@ class _AppInfoScreenState extends State<AppInfoScreen> {
                 Expanded(
                   child: FittedBox(
                     fit: BoxFit.scaleDown,
+                    alignment: Alignment.centerLeft,
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [

--- a/lib/widgets/input_output_detail_row.dart
+++ b/lib/widgets/input_output_detail_row.dart
@@ -49,6 +49,7 @@ class InputOutputDetailRow extends StatelessWidget {
                   fontSize: 14,
                   height: 16 / 14,
                 ),
+                textScaler: const TextScaler.linear(1.0),
                 maxLines: 1,
               ),
             ),
@@ -112,6 +113,8 @@ class InputOutputDetailRow extends StatelessWidget {
                     child: SizedBox(
                       width: balanceMaxWidth,
                       child: FittedBox(
+                        fit: BoxFit.scaleDown,
+                        alignment: Alignment.centerLeft,
                         child: Text(
                           balanceText,
                           style: CoconutTypography.body2_14_Number.copyWith(


### PR DESCRIPTION
## 1. 변경 사항

### **앱 정보 화면**

<table>
<tr>
<td>최대크기 폰트</td>
<td>기본 폰트</td>
<tr>
<td>
<img width="300" src="https://github.com/user-attachments/assets/70bac00d-f8d0-4ab1-aac3-755b17a8d887" />
</td>
<td>
<img width="300" src="https://github.com/user-attachments/assets/40a364bf-8915-4757-94bf-f3db090d28e8" />
</td>
</tr>
</table>

### **거래 내역**

<table>
<tr>
<td>최대크기 폰트</td>
<td>기본 폰트</td>
<tr>
<td>
<img width="300" src="https://github.com/user-attachments/assets/0455b99c-7538-4647-9f46-73f95e1460ea" />
</td>
<td>
<img width="300" src="https://github.com/user-attachments/assets/86426791-b280-4484-b2ba-81a0dd213b29" />
</td>
</tr>
</table>

## 2. 이슈 번호
#451 