### PR TITLE
[471] seedsigner wallet add - bc-ur 지원

### DIFF
--- a/lib/providers/view_model/home/wallet_add_scanner_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_scanner_view_model.dart
@@ -36,7 +36,8 @@ class WalletAddScannerViewModel extends ChangeNotifier {
         break;
       case WalletImportSource.keystone:
       case WalletImportSource.jade:
-        _qrDataHandler = BcUrQrScanDataHandler();
+        _qrDataHandler =
+            BcUrQrScanDataHandler(expectedUrType: [UrType.cryptoAccount, UrType.accountDescriptor]);
         break;
       case WalletImportSource.seedSigner:
       case WalletImportSource.krux:

--- a/lib/providers/view_model/home/wallet_add_scanner_view_model.dart
+++ b/lib/providers/view_model/home/wallet_add_scanner_view_model.dart
@@ -7,6 +7,7 @@ import 'package:coconut_wallet/utils/file_logger.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/third_party_util.dart';
 import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/bb_qr_scan_data_handler.dart';
+import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/composed_scan_data_handler.dart';
 import 'package:flutter/material.dart';
 import 'package:ur/ur.dart';
 import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/bc_ur_qr_scan_data_handler.dart';
@@ -40,6 +41,9 @@ class WalletAddScannerViewModel extends ChangeNotifier {
             BcUrQrScanDataHandler(expectedUrType: [UrType.cryptoAccount, UrType.accountDescriptor]);
         break;
       case WalletImportSource.seedSigner:
+        _qrDataHandler = ComposedScanDataHandler(
+            expectedUrType: [UrType.cryptoAccount, UrType.accountDescriptor]);
+        break;
       case WalletImportSource.krux:
         _qrDataHandler = DescriptorQrScanDataHandler();
         break;
@@ -58,61 +62,33 @@ class WalletAddScannerViewModel extends ChangeNotifier {
   int? get fakeBalanceTotalAmount => _preferenceProvider.fakeBalanceTotalAmount;
 
   Future<ResultOfSyncFromVault> addWallet(dynamic additionInfo) async {
+    assert(_walletImportSource != WalletImportSource.extendedPublicKey,
+        '확장공개키 지갑 추가는 wallet_add_scanner에서 지원 안함');
+
     const methodName = 'addWallet';
 
     FileLogger.log(className, methodName,
         'addWallet called with ${_walletImportSource.name} additionInfo type: ${additionInfo.runtimeType}');
 
     try {
-      switch (_walletImportSource) {
-        case WalletImportSource.coconutVault:
-          return addCoconutVaultWallet(additionInfo as WatchOnlyWallet);
-        case WalletImportSource.keystone:
-        case WalletImportSource.jade:
-          return _addBcUrWallet(_walletImportSource, additionInfo as UR);
-        case WalletImportSource.seedSigner:
-        case WalletImportSource.krux:
-          return _addDescriptorWallet(_walletImportSource, additionInfo as String);
-        case WalletImportSource.coldCard:
-          return _addBbQrWallet(_walletImportSource, additionInfo as Map<String, dynamic>);
-        case WalletImportSource.extendedPublicKey:
-          throw 'No Support extendedPublicKey';
-        default:
-          FileLogger.error(
-              className, methodName, 'wrong wallet import source: $_walletImportSource');
-          throw 'wrong wallet import source: $_walletImportSource';
+      if (additionInfo is WatchOnlyWallet) {
+        return _addCoconutVaultWallet(additionInfo);
+      } else if (additionInfo is UR) {
+        return _addBcUrWallet(_walletImportSource, additionInfo);
+      } else if (additionInfo is String) {
+        return _addDescriptorWallet(_walletImportSource, additionInfo);
+      } else if (additionInfo is Map<String, dynamic>) {
+        return _addBbQrWallet(_walletImportSource, additionInfo);
       }
+      throw 'Unknown additionInfo type: ${additionInfo.runtimeType}';
     } catch (e, stackTrace) {
       FileLogger.error(className, methodName, 'addWallet failed: $e', stackTrace);
       rethrow;
     }
   }
 
-  Future<ResultOfSyncFromVault> addCoconutVaultWallet(WatchOnlyWallet watchOnlyWallet) async {
+  Future<ResultOfSyncFromVault> _addCoconutVaultWallet(WatchOnlyWallet watchOnlyWallet) async {
     return await _walletProvider.syncFromCoconutVault(watchOnlyWallet);
-  }
-
-  Future<ResultOfSyncFromVault> addKeystoneWallet(UR ur) async {
-    const methodName = 'addKeystoneWallet';
-    FileLogger.log(className, methodName,
-        'addKeystoneWallet called UR type: ${ur.type} cbor length: ${ur.cbor.length}');
-    Logger.log('--> ${ur.type} ${ur.cbor.length}');
-    Logger.logLongString(ur.cbor.toString());
-
-    try {
-      final name = getNextThirdPartyWalletName(
-          WalletImportSource.keystone, _walletProvider.walletItemList.map((e) => e.name).toList());
-      final wallet = _walletAddService.createKeystoneWallet(ur, name);
-      FileLogger.log(className, methodName, 'createKeystoneWallet completed: $name');
-
-      final result = await _walletProvider.syncFromThirdParty(wallet);
-      FileLogger.log(className, methodName,
-          'syncFromThirdParty completed: ${result.result.name} named: $name');
-      return result;
-    } catch (e, stackTrace) {
-      FileLogger.error(className, methodName, 'addKeystoneWallet failed: $e', stackTrace);
-      rethrow;
-    }
   }
 
   Future<ResultOfSyncFromVault> _addBcUrWallet(WalletImportSource walletImportSource, UR ur) async {

--- a/lib/screens/send/signed_psbt_scanner_screen.dart
+++ b/lib/screens/send/signed_psbt_scanner_screen.dart
@@ -113,7 +113,7 @@ class _SignedPsbtScannerScreenState extends State<SignedPsbtScannerScreen> {
       _isHandlerInitialized = true;
     } else {
       // 다른 하드웨어 지갑은 BcUr 핸들러 사용
-      _qrScanDataHandler = BcUrQrScanDataHandler();
+      _qrScanDataHandler = BcUrQrScanDataHandler(expectedUrType: [UrType.cryptoPsbt, UrType.psbt]);
       _isHandlerInitialized = true;
     }
   }

--- a/lib/services/wallet_add_service.dart
+++ b/lib/services/wallet_add_service.dart
@@ -10,18 +10,6 @@ import 'package:ur/ur.dart';
 
 class WalletAddService {
   static const String masterFingerprintPlaceholder = '00000000';
-  WatchOnlyWallet createSeedSignerWallet(String descriptor, String name) {
-    return createWalletFromDescriptor(
-        descriptor: descriptor, name: name, walletImportSource: WalletImportSource.seedSigner);
-  }
-
-  WatchOnlyWallet createKeystoneWallet(UR ur, String name) {
-    return createWalletFromUR(ur: ur, name: name, walletImportSource: WalletImportSource.keystone);
-  }
-
-  WatchOnlyWallet createJadeWallet(UR ur, String name) {
-    return createWalletFromUR(ur: ur, name: name, walletImportSource: WalletImportSource.jade);
-  }
 
   WatchOnlyWallet createBbQrWallet({
     required Map<String, dynamic> json,

--- a/lib/widgets/animated_qr/scan_data_handler/bc_ur_qr_scan_data_handler.dart
+++ b/lib/widgets/animated_qr/scan_data_handler/bc_ur_qr_scan_data_handler.dart
@@ -4,11 +4,23 @@ import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/i_fragmente
 import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/scan_data_handler_exceptions.dart';
 import 'package:ur/ur_decoder.dart';
 
+enum UrType {
+  cryptoAccount('crypto-account'),
+  cryptoPsbt('crypto-psbt'),
+  psbt('psbt'),
+  accountDescriptor('account-descriptor');
+
+  final String value;
+  const UrType(this.value);
+}
+
 class BcUrQrScanDataHandler implements IFragmentedQrScanDataHandler {
   URDecoder _urDecoder;
   int? _sequenceLength;
+  final List<UrType>? expectedUrType;
+  UrType? _currentUrType; // expectedUrType이 있으면 그 중 하나의 값이어야 한다.
 
-  BcUrQrScanDataHandler() : _urDecoder = URDecoder();
+  BcUrQrScanDataHandler({this.expectedUrType}) : _urDecoder = URDecoder();
 
   @override
   dynamic get result => _urDecoder.result;
@@ -29,6 +41,15 @@ class BcUrQrScanDataHandler implements IFragmentedQrScanDataHandler {
       if (sequenceLength == null) return false;
       _sequenceLength = sequenceLength;
     }
+
+    if (expectedUrType != null && _currentUrType == null) {
+      (String, List<String>) result = URDecoder.parse(data);
+      // INFO: validateFormat 결과가 false 일 때 joinData를 호출하지 않아야 합니다.
+      // 만약 해당 상황에서 joinData 호출 시 StateError가 발생합니다.
+      _currentUrType = expectedUrType!.firstWhere((type) => type.value == result.$1);
+      _urDecoder.expectedType = _currentUrType!.value;
+    }
+
     FileLogger.log('BcUrQrScanDataHandler', 'joinData', data);
     Logger.log('--> [QR] joinData: $data');
     final receivePartResult = _urDecoder.receivePart(data);
@@ -53,6 +74,9 @@ class BcUrQrScanDataHandler implements IFragmentedQrScanDataHandler {
   bool validateFormat(String data) {
     try {
       (String, List<String>) result = URDecoder.parse(data);
+      if (expectedUrType != null && !expectedUrType!.any((type) => type.value == result.$1)) {
+        return false;
+      }
       URDecoder.parseSequenceComponent(result.$2[0]);
       return true;
     } catch (_) {

--- a/lib/widgets/animated_qr/scan_data_handler/composed_scan_data_handler.dart
+++ b/lib/widgets/animated_qr/scan_data_handler/composed_scan_data_handler.dart
@@ -1,0 +1,74 @@
+import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/bc_ur_qr_scan_data_handler.dart';
+import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/descriptor_qr_scan_data_handler.dart';
+import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/i_fragmented_qr_scan_data_handler.dart';
+import 'package:coconut_wallet/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
+
+/// TODO: 우선 seedsigner 지갑 추가가 안되는 문제부터 해결합니다.
+/// 추후 필요 시 다른 qr scan handler도 추가합니다.
+class ComposedScanDataHandler implements IFragmentedQrScanDataHandler {
+  //final List<UrType>? expectedUrType;
+  final BcUrQrScanDataHandler _bcUrQrScanDataHandler;
+  final DescriptorQrScanDataHandler _descriptorQrScanDataHandler;
+  IQrScanDataHandler? _selected;
+
+  ComposedScanDataHandler({List<UrType>? expectedUrType})
+      : _bcUrQrScanDataHandler = BcUrQrScanDataHandler(expectedUrType: expectedUrType),
+        _descriptorQrScanDataHandler = DescriptorQrScanDataHandler();
+
+  @override
+  dynamic get result => _selected?.result;
+
+  @override
+  double get progress => _selected?.progress ?? 0.0;
+
+  @override
+  bool isCompleted() {
+    return _selected?.isCompleted() ?? false;
+  }
+
+  @override
+  bool joinData(String data) {
+    assert(_selected != null, "validateFormat()을 먼저 호출, 결과가 true일 때 호출 해야 합니다.");
+    return _selected!.joinData(data);
+  }
+
+  @override
+  bool validateFormat(String data) {
+    try {
+      if (_selected == null) {
+        if (_descriptorQrScanDataHandler.validateFormat(data)) {
+          _selected = _descriptorQrScanDataHandler;
+        } else if (_bcUrQrScanDataHandler.validateFormat(data)) {
+          _selected = _bcUrQrScanDataHandler;
+        } else {
+          return false;
+        }
+      }
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  @override
+  void reset() {
+    _bcUrQrScanDataHandler.reset();
+    _descriptorQrScanDataHandler.reset();
+  }
+
+  @override
+  int? get sequenceLength {
+    if (_selected is IFragmentedQrScanDataHandler) {
+      return (_selected as IFragmentedQrScanDataHandler).sequenceLength;
+    }
+    return null;
+  }
+
+  @override
+  bool validateSequenceLength(String data) {
+    if (_selected is IFragmentedQrScanDataHandler) {
+      return (_selected as IFragmentedQrScanDataHandler).validateSequenceLength(data);
+    }
+    return false;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,9 +17,9 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
 # iOS
-#version: 3.2.0+3
+#version: 3.3.0+2
 # AOS
-#version: 3.1.8+44
+#version: 3.3.0+48
 # iOS Mainnet
 #version: 0.4.4+3
 # AOS Mainnet


### PR DESCRIPTION
### 변경 사항
1. 지갑 추가 > 시드사이너 선택 > descriptor QR 뿐만 아니라 bc-ur animated QR도 인식 가능하도록 수정
(composedScanDataHandler 생성)

### 테스트 방법
지갑 추가 > 시드사이너 선택
1. 기존 시드사이너의 descriptor QR로 지갑 추가 가능
2. 현재 v0.8.6이상이 설치된 시드사이너가 없으므로 키스톤이나 Jade의 지갑 내보내기 QR을 스캔했을 때도 지갑 추가 가능