### PR TITLE
[500] 내 주소 목록 - 짧은 기기 개선

### DIFF
--- a/lib/screens/send/refactor/send_screen.dart
+++ b/lib/screens/send/refactor/send_screen.dart
@@ -4,7 +4,6 @@ import 'package:coconut_wallet/extensions/string_extensions.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/connectivity_provider.dart';
-import 'package:coconut_wallet/providers/node_provider/node_provider.dart';
 import 'package:coconut_wallet/providers/preference_provider.dart';
 import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/view_model/send/refactor/send_view_model.dart';
@@ -16,7 +15,6 @@ import 'package:coconut_wallet/styles.dart';
 import 'package:coconut_wallet/utils/address_util.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/utils/dashed_border_painter.dart';
-import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/text_field_filter_util.dart';
 import 'package:coconut_wallet/utils/vibration_util.dart';
 import 'package:coconut_wallet/utils/wallet_util.dart';
@@ -46,6 +44,7 @@ class SendScreen extends StatefulWidget {
 }
 
 class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateMixin, WidgetsBindingObserver {
+  final GlobalKey _viewMoreButtonKey = GlobalKey();
   final Color keyboardToolbarGray = const Color(0xFF2E2E2E);
   final Color feeRateFieldGray = const Color(0xFF2B2B2B);
   // 스크롤 범위 연산에 사용하는 값들
@@ -65,6 +64,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
   final _recipientPageController = PageController();
   int _focusedPageIndex = 0;
 
+  final ScrollController _screenScrollController = ScrollController();
   final ScrollController _addressListScrollController = ScrollController();
 
   final List<TextEditingController> _addressControllerList = [];
@@ -245,6 +245,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
             child: Stack(
               children: [
                 SingleChildScrollView(
+                  controller: _screenScrollController,
                   child: Selector<SendViewModel, bool>(
                     selector: (_, viewModel) => viewModel.showAddressBoard,
                     builder: (context, data, child) {
@@ -1248,6 +1249,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
                         child: Padding(
                           padding: const EdgeInsets.only(left: 14, bottom: 14),
                           child: CoconutUnderlinedButton(
+                            key: _viewMoreButtonKey,
                             text: t.view_more,
                             onTap: () {
                               _clearFocus();
@@ -1625,6 +1627,21 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
         if (!focusNode.hasFocus) {
           _viewModel.validateAllFieldsOnFocusLost();
         }
+        Future.delayed(const Duration(milliseconds: 1000), () {
+          final viewMoreButtonRect = _viewMoreButtonKey.currentContext?.findRenderObject() as RenderBox;
+          final viewMoreButtonPosition = viewMoreButtonRect.localToGlobal(Offset.zero);
+          final viewMoreButtonHeight = viewMoreButtonRect.size.height;
+          final viewMoreButtonBottom = viewMoreButtonPosition.dy + viewMoreButtonHeight;
+          bool isViewMoreButtonVisible =
+              viewMoreButtonBottom < MediaQuery.of(context).size.height - MediaQuery.of(context).viewInsets.bottom;
+          if (!isViewMoreButtonVisible) {
+            _screenScrollController.animateTo(
+              _screenScrollController.position.maxScrollExtent,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+            );
+          }
+        });
       }),
     );
     _addressFocusNodeList.add(focusNode);


### PR DESCRIPTION
### 변경 사항
- 보내기 화면에서 '내 주소'가 펼쳐질 때, '더보기' 버튼이 키보드 영역에 가려지게 되면 자동으로 스크롤 되도록 기능 추가

<img width="300" src="https://github.com/user-attachments/assets/5e01426a-09f7-4220-b7db-9f6ec91a8eba"/>
<img width="300" src="https://github.com/user-attachments/assets/39cec6d1-78b3-46f2-841c-281787be54dc"/>

(좌: '더보기' 버튼이 가려졌을 때, 우: '더보기' 버튼이 가려지지 않았을 때)

#500 