### PR TITLE
[501] Fiat Price 보기 옵션 추가

### DIFF
--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -204,6 +204,8 @@ wallet_home_screen:
       fake_balance_input_placeholder: "Please set the total fake balance (in BTC units)"
       fake_balance_input_description: "If you have multiple wallets, each wallet's balance will be calculated automatically."
       fake_balance_input_exceeds_error: "You can set up to 21 million BTC"
+    hide_fiat_price: "Hide Fiat Balance"
+    hide_fiat_price_on_home: "Fiat balance will not be displayed on the home screen."
     category:
       total_balance: "Total\nBalance"
       wallet_list: "Wallet\nList"

--- a/assets/i18n/jp.i18n.yaml
+++ b/assets/i18n/jp.i18n.yaml
@@ -198,6 +198,8 @@ wallet_home_screen:
       fake_balance_input_placeholder: "偽の総残高を設定してください（BTC単位）"
       fake_balance_input_description: "複数のウォレットがある場合、各ウォレットの残高は自動的に計算されます。"
       fake_balance_input_exceeds_error: "最大2100万BTCまで設定できます。"
+    hide_fiat_price: "フィアット残高を非表示"
+    hide_fiat_price_on_home: "ホーム画面にフィアット残高を表示しません。"
     category:
       total_balance: "残高合計"
       wallet_list: "ウォレット\n一覧"

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -204,6 +204,8 @@ wallet_home_screen:
       fake_balance_input_placeholder: "총 가짜 잔액을 설정해 주세요.(BTC 단위)"
       fake_balance_input_description: "여러 지갑이 있을 경우, 각 지갑의 잔액은 자동으로 계산돼요."
       fake_balance_input_exceeds_error: "최대 2100만 BTC까지 설정할 수 있어요"
+    hide_fiat_price: "법정화폐 잔액 숨기기"
+    hide_fiat_price_on_home: "홈 화면에 법정화폐 잔액을 표시하지 않아요."
     category:
       total_balance: "잔액 합계"
       wallet_list: "지갑 목록"

--- a/lib/constants/shared_pref_keys.dart
+++ b/lib/constants/shared_pref_keys.dart
@@ -19,6 +19,7 @@ class SharedPrefKeys {
   static const String kIsReceivingTooltipDisabled = "IS_RECEIVING_TOOLTIP_DISABLED";
   static const String kIsChangeTooltipDisabled = "IS_CHANGE_TOOLTIP_DISABLED";
   static const String kIsBalanceHidden = "IS_BALANCE_HIDDEN";
+  static const String kIsFiatBalanceHidden = "IS_FIAT_BALANCE_HIDDEN";
   static const String kHideTermsShortcut = "IS_OPEN_TERMS_SCREEN";
   static const String kNextIdField = 'nextId';
   static const String kUtxoSortOrder = 'UTXO_SORT_ORDER';
@@ -32,8 +33,7 @@ class SharedPrefKeys {
   static const String kAnalysisPeriod = "ANALYSIS_PERIOD"; // 분석 위젯에 사용되는 조회 기간
   static const String kAnalysisPeriodStart = "ANALYSIS_PERIOD_START"; // 분석 위젯에 사용되는 조회 기간 시작 날짜
   static const String kAnalysisPeriodEnd = "ANALYSIS_PERIOD_END"; // 분석 위젯에 사용되는 조회 기간 종료 날짜
-  static const String kSelectedTransactionTypeIndices =
-      "SELECTED_TRANSACTION_TYPE_INDICES"; // 분석 위젯에 사용되는 거래 유형
+  static const String kSelectedTransactionTypeIndices = "SELECTED_TRANSACTION_TYPE_INDICES"; // 분석 위젯에 사용되는 거래 유형
 
   /// 리뷰 요청 관련
   static const String kHaveSent = 'HAVE_SENT';

--- a/lib/providers/preference_provider.dart
+++ b/lib/providers/preference_provider.dart
@@ -31,6 +31,9 @@ class PreferenceProvider extends ChangeNotifier {
   late bool _isFakeBalanceActive;
   bool get isFakeBalanceActive => _isFakeBalanceActive;
 
+  late bool _isFiatBalanceHidden;
+  bool get isFiatBalanceHidden => _isFiatBalanceHidden;
+
   /// 가짜 잔액 총량
   late int? _fakeBalanceTotalBtc;
   int? get fakeBalanceTotalAmount => _fakeBalanceTotalBtc;
@@ -98,6 +101,7 @@ class PreferenceProvider extends ChangeNotifier {
 
   PreferenceProvider(this._walletPreferencesRepository) {
     _fakeBalanceTotalBtc = _sharedPrefs.getIntOrNull(SharedPrefKeys.kFakeBalanceTotal);
+    _isFiatBalanceHidden = _sharedPrefs.getBool(SharedPrefKeys.kIsFiatBalanceHidden);
     _isFakeBalanceActive = _fakeBalanceTotalBtc != null;
     _isBalanceHidden = _sharedPrefs.getBool(SharedPrefKeys.kIsBalanceHidden);
     _isBtcUnit =
@@ -203,6 +207,14 @@ class PreferenceProvider extends ChangeNotifier {
   Future<void> changeIsBalanceHidden(bool isOn) async {
     _isBalanceHidden = isOn;
     await _sharedPrefs.setBool(SharedPrefKeys.kIsBalanceHidden, isOn);
+
+    notifyListeners();
+  }
+
+  /// 홈 화면 법정화폐 잔액 숨기기
+  Future<void> changeIsFiatBalanceHidden(bool isOn) async {
+    _isFiatBalanceHidden = isOn;
+    await _sharedPrefs.setBool(SharedPrefKeys.kIsFiatBalanceHidden, isOn);
 
     notifyListeners();
   }

--- a/lib/providers/view_model/home/wallet_home_edit_view_model.dart
+++ b/lib/providers/view_model/home/wallet_home_edit_view_model.dart
@@ -11,6 +11,7 @@ class WalletHomeEditViewModel extends ChangeNotifier {
   WalletProvider _walletProvider;
   late final PreferenceProvider _preferenceProvider;
   late bool _isBalanceHidden;
+  late bool _isFiatBalanceHidden;
   late bool _isFakeBalanceActive;
 
   late int minimumSatoshi;
@@ -27,6 +28,7 @@ class WalletHomeEditViewModel extends ChangeNotifier {
   // temp datas
   late List<HomeFeature> _tempHomeFeatures;
   late bool _tempIsBalanceHidden;
+  late bool _tempIsFiatBalanceHidden;
   late bool _tempIsFakeBalanceActive;
   late double? _tempFakeBalanceTotalBtc;
   late int? _tempFakeBalanceTotalAmount;
@@ -37,6 +39,7 @@ class WalletHomeEditViewModel extends ChangeNotifier {
     //     .map((key, balance) => MapEntry(key, AnimatedBalanceData(balance.total, balance.total)));
     minimumSatoshi = _walletProvider.walletItemList.length;
     _isBalanceHidden = _preferenceProvider.isBalanceHidden;
+    _isFiatBalanceHidden = _preferenceProvider.isFiatBalanceHidden;
     _isFakeBalanceActive = _preferenceProvider.isFakeBalanceActive;
     _fakeBalanceTotalAmount = _preferenceProvider.fakeBalanceTotalAmount;
     _fakeBalanceMap = _preferenceProvider.getFakeBalanceMap();
@@ -68,12 +71,14 @@ class WalletHomeEditViewModel extends ChangeNotifier {
             )
             .toList();
     _tempIsBalanceHidden = isBalanceHidden;
+    _tempIsFiatBalanceHidden = isFiatBalanceHidden;
     _tempIsFakeBalanceActive = isFakeBalanceActive;
     _tempFakeBalanceTotalBtc = fakeBalanceTotalBtc;
     _tempFakeBalanceTotalAmount = fakeBalanceTotalAmount;
   }
 
   bool get isBalanceHidden => _isBalanceHidden;
+  bool get isFiatBalanceHidden => _isFiatBalanceHidden;
   bool get isFakeBalanceActive => _isFakeBalanceActive;
   int? get fakeBalanceTotalAmount => _fakeBalanceTotalAmount;
   double? get fakeBalanceTotalBtc => _fakeBalanceTotalBtc;
@@ -85,6 +90,7 @@ class WalletHomeEditViewModel extends ChangeNotifier {
 
   List<HomeFeature> get tempHomeFeatures => _tempHomeFeatures;
   bool get tempIsBalanceHidden => _tempIsBalanceHidden;
+  bool get tempIsFiatBalanceHidden => _tempIsFiatBalanceHidden;
   bool get tempIsFakeBalanceActive => _tempIsFakeBalanceActive;
   double? get tempFakeBalanceTotalBtc => _tempFakeBalanceTotalBtc;
   int? get tempFakeBalanceTotalAmount => _tempFakeBalanceTotalAmount;
@@ -105,6 +111,11 @@ class WalletHomeEditViewModel extends ChangeNotifier {
       _setFakeBalanceTotalAmount(_preferenceProvider.fakeBalanceTotalAmount);
       _setFakeBlanceMap(_preferenceProvider.getFakeBalanceMap());
     }
+
+    /// 잔액 숨기기 변동 체크
+    if (_isFiatBalanceHidden != _preferenceProvider.isFiatBalanceHidden) {
+      setIsFiatBalanceHidden(_preferenceProvider.isFiatBalanceHidden);
+    }
     notifyListeners();
   }
 
@@ -121,6 +132,17 @@ class WalletHomeEditViewModel extends ChangeNotifier {
       _tempFakeBalanceTotalAmount = null;
       // _tempIsFakeBalanceActive = false;
     }
+    notifyListeners();
+  }
+
+  void setIsFiatBalanceHidden(bool value) {
+    _preferenceProvider.changeIsFiatBalanceHidden(value);
+    _isFiatBalanceHidden = value;
+    notifyListeners();
+  }
+
+  void setTempIsFiatBalanceHidden(bool value) {
+    _tempIsFiatBalanceHidden = value;
     notifyListeners();
   }
 
@@ -190,6 +212,7 @@ class WalletHomeEditViewModel extends ChangeNotifier {
 
   Future<void> onComplete() async {
     setIsBalanceHidden(_tempIsBalanceHidden);
+    setIsFiatBalanceHidden(_tempIsFiatBalanceHidden);
     _setHomeFeatureEnabled();
     await _setFakeBalance();
   }

--- a/lib/providers/view_model/home/wallet_home_view_model.dart
+++ b/lib/providers/view_model/home/wallet_home_view_model.dart
@@ -37,6 +37,7 @@ class WalletHomeViewModel extends ChangeNotifier {
   late final PreferenceProvider _preferenceProvider;
   late bool _isTermsShortcutVisible;
   late bool _isBalanceHidden;
+  late bool _isFiatBalanceHidden;
   late final bool _isReviewScreenVisible;
   late final ConnectivityProvider _connectivityProvider;
   late bool? _isNetworkOn;
@@ -114,6 +115,7 @@ class WalletHomeViewModel extends ChangeNotifier {
     _nodeProvider.addListener(_onNodeProviderChanged);
 
     _isBalanceHidden = _preferenceProvider.isBalanceHidden;
+    _isFiatBalanceHidden = _preferenceProvider.isFiatBalanceHidden;
     _fakeBalanceTotalAmount = _preferenceProvider.fakeBalanceTotalAmount;
     _fakeBalanceMap = _preferenceProvider.getFakeBalanceMap();
     _excludedFromTotalBalanceWalletIds = _preferenceProvider.excludedFromTotalBalanceWalletIds;
@@ -128,6 +130,7 @@ class WalletHomeViewModel extends ChangeNotifier {
 
   bool get isEmptyFavoriteWallet => _isEmptyFavoriteWallet;
   bool get isBalanceHidden => _isBalanceHidden;
+  bool get isFiatBalanceHidden => _isFiatBalanceHidden;
   bool get isReviewScreenVisible => _isReviewScreenVisible;
   bool get isTermsShortcutVisible => _isTermsShortcutVisible;
   bool get shouldShowLoadingIndicator => !_isFirstLoaded && _nodeSyncState == NodeSyncState.syncing;
@@ -262,6 +265,11 @@ class WalletHomeViewModel extends ChangeNotifier {
       setIsBalanceHidden(_preferenceProvider.isBalanceHidden);
     }
 
+    /// 법정화폐잔액숨기기 변동 체크
+    if (_isFiatBalanceHidden != _preferenceProvider.isFiatBalanceHidden) {
+      setIsFiatBalanceHidden(_preferenceProvider.isFiatBalanceHidden);
+    }
+
     /// 가짜 잔액 총량 변동 체크 (on/off 판별)
     if (_fakeBalanceTotalAmount != _preferenceProvider.fakeBalanceTotalAmount) {
       _setFakeBlancTotalAmount(_preferenceProvider.fakeBalanceTotalAmount);
@@ -305,6 +313,12 @@ class WalletHomeViewModel extends ChangeNotifier {
   void setIsBalanceHidden(bool value) {
     _preferenceProvider.changeIsBalanceHidden(value);
     _isBalanceHidden = value;
+    notifyListeners();
+  }
+
+  void setIsFiatBalanceHidden(bool value) {
+    _preferenceProvider.changeIsFiatBalanceHidden(value);
+    _isFiatBalanceHidden = value;
     notifyListeners();
   }
 

--- a/lib/screens/home/wallet_home_edit_bottom_sheet.dart
+++ b/lib/screens/home/wallet_home_edit_bottom_sheet.dart
@@ -6,7 +6,6 @@ import 'package:coconut_wallet/providers/view_model/home/wallet_home_edit_view_m
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/widgets/button/fixed_bottom_button.dart';
-import 'package:coconut_wallet/widgets/button/multi_button.dart';
 import 'package:coconut_wallet/widgets/button/shrink_animation_button.dart';
 import 'package:coconut_wallet/widgets/button/single_button.dart';
 import 'package:flutter/cupertino.dart';
@@ -249,7 +248,7 @@ class _WalletHomeEditBottomSheetState extends State<WalletHomeEditBottomSheet> w
                                       title: t.wallet_home_screen.edit.fake_balance.fake_balance_display,
                                       subtitle: t.wallet_home_screen.edit.fake_balance.fake_balance_input_description,
                                       subtitleStyle: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
-                                      customPadding: const EdgeInsets.fromLTRB(20, 10, 20, 16),
+                                      customPadding: const EdgeInsets.fromLTRB(20, 10, 20, 10),
                                       betweenGap: 16,
                                       onPressed: () async {
                                         if (_textFieldFocusNode.hasFocus) {
@@ -274,6 +273,32 @@ class _WalletHomeEditBottomSheetState extends State<WalletHomeEditBottomSheet> w
                                       ),
                                     ),
                                     _buildDelayedFakeBalanceInput(),
+                                    SingleButton(
+                                      isVerticalSubtitle: true,
+                                      title: t.wallet_home_screen.edit.hide_fiat_price,
+                                      subtitle: t.wallet_home_screen.edit.hide_fiat_price_on_home,
+                                      subtitleStyle: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
+                                      customPadding: const EdgeInsets.fromLTRB(20, 10, 20, 16),
+                                      onPressed: () async {
+                                        if (_textFieldFocusNode.hasFocus) {
+                                          FocusScope.of(context).unfocus();
+                                          return;
+                                        }
+                                        viewModel.setTempIsFiatBalanceHidden(!viewModel.tempIsFiatBalanceHidden);
+                                      },
+                                      betweenGap: 16,
+                                      backgroundColor: CoconutColors.black,
+                                      rightElement: CoconutSwitch(
+                                        isOn: viewModel.tempIsFiatBalanceHidden,
+                                        scale: 0.7,
+                                        activeColor: CoconutColors.gray100,
+                                        trackColor: CoconutColors.gray600,
+                                        thumbColor: CoconutColors.gray800,
+                                        onChanged: (value) {
+                                          viewModel.setTempIsFiatBalanceHidden(value);
+                                        },
+                                      ),
+                                    ),
                                   ],
                                 );
                               },
@@ -354,6 +379,7 @@ class _WalletHomeEditBottomSheetState extends State<WalletHomeEditBottomSheet> w
     final isToggleChanged =
         _viewModel.tempIsFakeBalanceActive != _viewModel.isFakeBalanceActive || // 가짜잔액표시 변동
         _viewModel.tempIsBalanceHidden != _viewModel.isBalanceHidden || // 잔액숨기기 변동
+        _viewModel.tempIsFiatBalanceHidden != _viewModel.isFiatBalanceHidden || // 법정화폐잔액숨기기 변동
         !_viewModel.tempHomeFeatures.every((tempFeature) {
           // 홈 화면 기능 변동
           final original = _viewModel.homeFeatures.firstWhere(
@@ -574,7 +600,7 @@ class _WalletHomeEditBottomSheetState extends State<WalletHomeEditBottomSheet> w
         }
         return AnimatedCrossFade(
           duration: const Duration(milliseconds: 300),
-          firstChild: const SizedBox(height: 6),
+          firstChild: const SizedBox(height: 0),
           secondChild: Column(
             children: [
               Container(


### PR DESCRIPTION
# 주요 변경 사항

법정화폐 잔액 숨기기 기능 및 UI 구현


## 🛠️ 테스트 항목
1. 홈화면 하단의 '홈 화면 편집하기' 버튼을 눌러 홈화면편집화면으로 이동 후 '법정 화폐 숨기기' 토글 버튼을 확인한다.
2. 토글 버튼을 눌러 ON으로 설정한 뒤 아래 '완료' 버튼을 누른다.
3. 홈화면으로 돌아와 상단 헤더 부분에 FiatPrice가 없어졌는지 확인한다.

### 이슈 번호
#501