### PR TITLE
[540] 갤럭시 폴드 펼쳤을 때 QR 너무 큼

### DIFF
--- a/lib/screens/common/qrcode_bottom_sheet.dart
+++ b/lib/screens/common/qrcode_bottom_sheet.dart
@@ -1,0 +1,52 @@
+import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:coconut_wallet/widgets/qrcode_info.dart';
+
+// Usage:
+// address_list_screen.dart
+// wallet_info_screen.dart
+class QrcodeBottomSheet extends StatelessWidget {
+  const QrcodeBottomSheet({super.key, required this.qrData, this.qrcodeTopWidget, this.title, this.isAddress = false});
+
+  final String qrData;
+  final Widget? qrcodeTopWidget;
+  final String? title;
+  final bool isAddress;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(CoconutStyles.radius_400),
+      child: Scaffold(
+        backgroundColor: CoconutColors.black,
+        appBar: AppBar(
+          title: Text(title ?? ''),
+          centerTitle: true,
+          backgroundColor: CoconutColors.black,
+          titleTextStyle: CoconutTypography.heading4_18,
+          toolbarTextStyle: CoconutTypography.body3_12,
+          leading: IconButton(
+            color: CoconutColors.white,
+            focusColor: CoconutColors.gray400,
+            icon: const Icon(CupertinoIcons.xmark, size: 20),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+          automaticallyImplyLeading: false,
+        ),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Container(
+              width: MediaQuery.of(context).size.width,
+              height: MediaQuery.of(context).size.height * 0.9,
+              color: CoconutColors.black,
+              child: QrCodeInfo(qrData: qrData, qrcodeTopWidget: qrcodeTopWidget, isAddress: isAddress),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/send/unsigned_transaction_qr_screen.dart
+++ b/lib/screens/send/unsigned_transaction_qr_screen.dart
@@ -11,6 +11,7 @@ import 'package:coconut_wallet/styles.dart';
 import 'package:coconut_wallet/utils/bb_qr/bb_qr_encoder.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/vibration_util.dart';
+import 'package:coconut_wallet/widgets/adaptive_qr_image.dart';
 import 'package:coconut_wallet/widgets/animated_qr/animated_qr_view.dart';
 import 'package:coconut_wallet/widgets/animated_qr/view_data_handler/bc_ur_qr_view_handler.dart';
 import 'package:coconut_wallet/widgets/button/fixed_bottom_button.dart';
@@ -134,42 +135,29 @@ class _UnsignedTransactionQrScreenState extends State<UnsignedTransactionQrScree
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final qrSize = _getQrSize(constraints);
             return Stack(
               children: [
                 SafeArea(
                   child: SingleChildScrollView(
-                    child: Container(
+                    child: SizedBox(
                       width: MediaQuery.of(context).size.width,
-                      padding: Paddings.container,
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.center,
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Padding(padding: const EdgeInsets.only(top: 8), child: _buildToolTip()),
-                          Container(
-                            margin: const EdgeInsets.only(top: 40),
-                            // width: qrSize, // 테스트용(갤폴드에서 보이는 QR사이즈)
-                            // height: qrSize, // 테스트용(갤폴드에서 보이는 QR사이즈)
-                            width: qrSize,
-                            height: qrSize,
-                            decoration: BoxDecoration(
-                              color: CoconutColors.white,
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: Center(
-                              child:
-                                  _isBbQrType() && _bbqrParts.isNotEmpty
-                                      ? QrImageView(data: _bbqrParts[_currentBbqrIndex], version: QrVersions.auto)
-                                      : AnimatedQrView(
-                                        key: ValueKey(_qrScanDensity),
-                                        qrScanDensity: _qrScanDensity,
-                                        qrViewDataHandler: BcUrQrViewHandler(_psbtBase64, _qrScanDensity, {
-                                          'urType': 'crypto-psbt',
-                                        }),
-                                      ),
-                            ),
+                          Padding(
+                            padding: const EdgeInsets.only(top: 8, bottom: 40, left: 16, right: 16),
+                            child: _buildToolTip(),
                           ),
+                          AdaptiveQrImage(
+                            qrData: _isBbQrType() && _bbqrParts.isNotEmpty ? _bbqrParts[_currentBbqrIndex] : null,
+                            qrDensity: _qrScanDensity,
+                            qrViewDataHandler:
+                                _isBbQrType() && _bbqrParts.isNotEmpty
+                                    ? null
+                                    : BcUrQrViewHandler(_psbtBase64, _qrScanDensity, {'urType': 'crypto-psbt'}),
+                          ),
+
                           if (!_isBbQrType()) ...[CoconutLayout.spacing_800h, _buildDensitySliderWidget(context)],
                           Container(height: 150),
                         ],
@@ -254,11 +242,6 @@ class _UnsignedTransactionQrScreenState extends State<UnsignedTransactionQrScree
         ),
       ),
     );
-  }
-
-  double _getQrSize(BoxConstraints constraints) {
-    final shortestScreenWidth = Math.min(constraints.maxWidth, constraints.maxHeight);
-    return shortestScreenWidth.clamp(220, 360);
   }
 
   bool _isBbQrType() {

--- a/lib/widgets/adaptive_qr_image.dart
+++ b/lib/widgets/adaptive_qr_image.dart
@@ -1,0 +1,51 @@
+import 'dart:math' as math;
+
+import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_wallet/screens/send/unsigned_transaction_qr_screen.dart';
+import 'package:coconut_wallet/widgets/animated_qr/animated_qr_view.dart';
+import 'package:coconut_wallet/widgets/animated_qr/view_data_handler/i_qr_view_data_handler.dart';
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class AdaptiveQrImage extends StatelessWidget {
+  const AdaptiveQrImage({super.key, this.qrData, this.qrDensity, this.qrViewDataHandler});
+
+  final String? qrData;
+  final QrScanDensity? qrDensity;
+  final IQrViewDataHandler? qrViewDataHandler;
+
+  @override
+  Widget build(BuildContext context) {
+    assert(qrData != null || qrViewDataHandler != null, 'Either qrData or qrViewDataHandler must be provided');
+
+    return Container(
+      padding: const EdgeInsets.all(10),
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: CoconutBoxDecoration.shadowBoxDecoration,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final qrSize = _getQrSize(constraints);
+          if (qrData != null) {
+            return QrImageView(data: qrData!, size: qrSize);
+          }
+
+          if (qrViewDataHandler != null) {
+            return AnimatedQrView(
+              key: ValueKey(qrDensity ?? QrScanDensity.normal),
+              qrViewDataHandler: qrViewDataHandler!,
+              qrScanDensity: qrDensity ?? QrScanDensity.normal,
+              qrSize: qrSize,
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+
+  double _getQrSize(BoxConstraints constraints) {
+    final shortestScreenWidth = math.min(constraints.maxWidth, constraints.maxHeight);
+    return shortestScreenWidth.clamp(220, 360);
+  }
+}

--- a/lib/widgets/animated_qr/animated_qr_view.dart
+++ b/lib/widgets/animated_qr/animated_qr_view.dart
@@ -11,11 +11,13 @@ class AnimatedQrView extends StatefulWidget {
   final int milliSeconds;
   final QrScanDensity qrScanDensity;
   final IQrViewDataHandler qrViewDataHandler;
+  final double qrSize;
 
   const AnimatedQrView({
     super.key,
     required this.qrViewDataHandler,
     required this.qrScanDensity,
+    required this.qrSize,
     this.milliSeconds = 600,
   });
 
@@ -69,7 +71,7 @@ class _AnimatedQrViewState extends State<AnimatedQrView> {
       // QR 전환이 바로 안될 때를 대비한 위젯 - 실제로는 렌더링 되지 않을 가능성 높음
       return Stack(
         children: [
-          QrImageView(data: _qrData, version: _qrVersion),
+          QrImageView(data: _qrData, version: _qrVersion, size: widget.qrSize),
           Positioned(
             left: 70,
             right: 70,
@@ -93,7 +95,7 @@ class _AnimatedQrViewState extends State<AnimatedQrView> {
     // 시드사이너가 QR version 10 인 경우 빠르게 인식이 안되어 9로 설정합니다.
     // 아래 QrImageView의 maxInputLength는 2192bits(274bytes)
 
-    return QrImageView(data: _qrData, version: _qrVersion);
+    return QrImageView(data: _qrData, version: _qrVersion, size: widget.qrSize);
   }
 
   @override

--- a/lib/widgets/qrcode_info.dart
+++ b/lib/widgets/qrcode_info.dart
@@ -1,7 +1,7 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_wallet/widgets/adaptive_qr_image.dart';
 import 'package:coconut_wallet/widgets/button/copy_text_container.dart';
 import 'package:flutter/material.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 
 class QrCodeInfo extends StatefulWidget {
   final String qrData;
@@ -17,31 +17,21 @@ class QrCodeInfo extends StatefulWidget {
 class _QrCodeInfoState extends State<QrCodeInfo> {
   @override
   Widget build(BuildContext context) {
-    final double qrSize = MediaQuery.of(context).size.width * 275 / 375;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 36),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          if (widget.qrcodeTopWidget != null) ...[widget.qrcodeTopWidget!, CoconutLayout.spacing_400h],
-          Stack(
-            children: [
-              Container(
-                width: qrSize,
-                height: qrSize,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(CoconutStyles.radius_200),
-                  color: CoconutColors.white,
-                ),
-              ),
-              QrImageView(data: widget.qrData, version: QrVersions.auto, size: qrSize),
-            ],
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        if (widget.qrcodeTopWidget != null) ...[widget.qrcodeTopWidget!, CoconutLayout.spacing_400h],
+        AdaptiveQrImage(qrData: widget.qrData),
+        const SizedBox(height: 32),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: CopyTextContainer(
+            text: widget.qrData,
+            textStyle: CoconutTypography.body2_14,
+            isAddress: widget.isAddress,
           ),
-          CoconutLayout.spacing_600h,
-          CopyTextContainer(text: widget.qrData, textStyle: CoconutTypography.body2_14, isAddress: widget.isAddress),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## 변경사항
unsignedTransactionQrScreen에서 qrSize를 디바이스 짧은 변을 기준으로 80% 크기로 렌더링 하도록 구현
- 갤럭시 폴드 펼친 화면에서 QR이 화면을 가득 채우는 현상 해결
- 키스톤, 시드사이너, 제이드, 크럭스, 콜드카드 테스트 완료

#540 