### PR TITLE
[542] 백업 데이터 생성 위치 변경

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -254,12 +254,7 @@ class _CoconutWalletAppState extends State<CoconutWalletApp> {
                 '/wallet-backup-data':
                     (context) => buildScreenWithArgs(
                       context,
-                      (args) => WalletBackupDataScreen(
-                        id: args['id'],
-                        walletName: args['walletName'],
-                        qrDataMap: (args['qrDataMap'] as Map).cast<String, String>(),
-                        textDataMap: (args['textDataMap'] as Map).cast<String, String>(),
-                      ),
+                      (args) => WalletBackupDataScreen(id: args['id'], walletName: args['walletName']),
                     ),
                 '/confirm-backup-data':
                     (context) => buildScreenWithArgs(

--- a/lib/screens/wallet_detail/wallet_backup_data_screen.dart
+++ b/lib/screens/wallet_detail/wallet_backup_data_screen.dart
@@ -1,55 +1,53 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
+import 'package:coconut_wallet/providers/view_model/wallet_detail/coordinator_bsms_qr_view_model.dart';
+import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/screens/common/qr_with_copy_text_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
 
-class WalletBackupDataScreen extends StatefulWidget {
+class WalletBackupDataScreen extends StatelessWidget {
   final int id;
   final String walletName;
 
-  final Map<String, String> qrDataMap;
-  final Map<String, String> textDataMap;
+  const WalletBackupDataScreen({super.key, required this.id, required this.walletName});
 
-  const WalletBackupDataScreen({
-    super.key,
-    required this.id,
-    required this.walletName,
-    required this.qrDataMap,
-    required this.textDataMap,
-  });
-
-  @override
-  State<WalletBackupDataScreen> createState() => _WalletBackupDataScreenState();
-}
-
-class _WalletBackupDataScreenState extends State<WalletBackupDataScreen> {
   @override
   Widget build(BuildContext context) {
-    String defaultQrData =
-        widget.qrDataMap['BSMS'] ?? (widget.qrDataMap.isNotEmpty ? widget.qrDataMap.values.first : '');
+    return ChangeNotifierProvider<CoordinatorBsmsQrViewModel>(
+      create: (_) => CoordinatorBsmsQrViewModel(Provider.of<WalletProvider>(context, listen: false), id),
+      child: Consumer<CoordinatorBsmsQrViewModel>(
+        builder: (context, viewModel, child) {
+          final qrDataMap = viewModel.walletQrDataMap;
+          final textDataMap = viewModel.walletTextDataMap;
 
-    return QrWithCopyTextScreen(
-      qrData: defaultQrData,
-      title: t.wallet_info_screen.view_wallet_backup_data,
+          String defaultQrData = qrDataMap['BSMS'] ?? (qrDataMap.isNotEmpty ? qrDataMap.values.first : '');
 
-      qrDataMap: widget.qrDataMap,
-      textDataMap: widget.textDataMap,
-      showPulldownMenu: true,
+          return QrWithCopyTextScreen(
+            qrData: defaultQrData,
+            title: t.wallet_info_screen.view_wallet_backup_data,
 
-      tooltipDescription: Container(
-        margin: const EdgeInsets.only(top: 4, bottom: 16),
-        child: CoconutToolTip(
-          backgroundColor: CoconutColors.gray800,
-          borderColor: CoconutColors.gray800,
-          icon: SvgPicture.asset(
-            'assets/svg/circle-info.svg',
-            width: 20,
-            colorFilter: const ColorFilter.mode(CoconutColors.white, BlendMode.srcIn),
-          ),
-          tooltipType: CoconutTooltipType.fixed,
-          richText: RichText(text: TextSpan(text: t.wallet_info_screen.tooltip.wallet_backup_data)),
-        ),
+            qrDataMap: qrDataMap,
+            textDataMap: textDataMap,
+            showPulldownMenu: true,
+
+            tooltipDescription: Container(
+              margin: const EdgeInsets.only(top: 4, bottom: 16),
+              child: CoconutToolTip(
+                backgroundColor: CoconutColors.gray800,
+                borderColor: CoconutColors.gray800,
+                icon: SvgPicture.asset(
+                  'assets/svg/circle-info.svg',
+                  width: 20,
+                  colorFilter: const ColorFilter.mode(CoconutColors.white, BlendMode.srcIn),
+                ),
+                tooltipType: CoconutTooltipType.fixed,
+                richText: RichText(text: TextSpan(text: t.wallet_info_screen.tooltip.wallet_backup_data)),
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/screens/wallet_detail/wallet_info_screen.dart
+++ b/lib/screens/wallet_detail/wallet_info_screen.dart
@@ -46,23 +46,15 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider<WalletInfoViewModel>(
-          create:
-              (_) => WalletInfoViewModel(
-                widget.id,
-                Provider.of<AuthProvider>(context, listen: false),
-                Provider.of<WalletProvider>(context, listen: false),
-                Provider.of<NodeProvider>(context, listen: false),
-                widget.isMultisig,
-              ),
-        ),
-        if (widget.isMultisig)
-          ChangeNotifierProvider<CoordinatorBsmsQrViewModel>(
-            create: (_) => CoordinatorBsmsQrViewModel(Provider.of<WalletProvider>(context, listen: false), widget.id),
+    return ChangeNotifierProvider<WalletInfoViewModel>(
+      create:
+          (_) => WalletInfoViewModel(
+            widget.id,
+            Provider.of<AuthProvider>(context, listen: false),
+            Provider.of<WalletProvider>(context, listen: false),
+            Provider.of<NodeProvider>(context, listen: false),
+            widget.isMultisig,
           ),
-      ],
       child: Consumer<WalletInfoViewModel>(
         builder: (innerContext, viewModel, child) {
           return Stack(
@@ -170,20 +162,11 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
                                     title: t.wallet_info_screen.view_wallet_backup_data,
                                     onPressed: () {
                                       _removeTooltip();
-                                      final bsmsViewModel = Provider.of<CoordinatorBsmsQrViewModel>(
-                                        innerContext,
-                                        listen: false,
-                                      );
 
                                       Navigator.pushNamed(
                                         context,
                                         '/wallet-backup-data',
-                                        arguments: {
-                                          'id': widget.id,
-                                          'walletName': viewModel.walletName,
-                                          'qrDataMap': bsmsViewModel.walletQrDataMap,
-                                          'textDataMap': bsmsViewModel.walletTextDataMap,
-                                        },
+                                        arguments: {'id': widget.id, 'walletName': viewModel.walletName},
                                       );
                                     },
                                   ),


### PR DESCRIPTION
백업 데이터 생성되는 위치를 wallet_info_screen에서 wallet_backup_data_screen으로 변경

## 변경사항
- wallet_info_screen에서 MultiProvider, bsmsViewModel로 생성되던 백업 데이터 제거
- 위에서 제거되었던 백업 데이터들을 wallet_backup_data_screen에서  불러올 수 있도록 수정
- app 라우터에서 백업 데이터 파라미터 제거