### PR TITLE
[557] keystone에서 multicoin firmware일 때 guide 문구 개선

### DIFF
--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -217,7 +217,7 @@ wallet_add_scanner_screen:
     step6_em: " I understand"
     step6_end: " > Export Xpub"
   guide_keystone:
-    step0: "Devices other than the Keystone 3 Pro are not supported."
+    step0: "Devices other than the Keystone 3 Pro are not supported. (Bitcoin-only firmware recommended)"
     step1: "1. On the home screen, "
     step1_em: " More(•••)"
     step2: "2. "

--- a/assets/i18n/jp.i18n.yaml
+++ b/assets/i18n/jp.i18n.yaml
@@ -217,7 +217,7 @@ wallet_add_scanner_screen:
     step6_em: " I understand"
     step6_end: " > Export Xpub"
   guide_keystone:
-    step0: "Keystone 3 Pro以外のデバイスはサポートされていません。"
+    step0: "Keystone 3 Pro以外のデバイスはサポートされていません。（Bitcoin専用FW推奨）"
     step1: "1. ホーム画面で、"
     step1_em: " More(•••)"
     step2: "2. "

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -217,7 +217,7 @@ wallet_add_scanner_screen:
     step6_em: "I understand"
     step6_end: " > Export Xpub"
   guide_keystone:
-    step0: "키스톤 3 프로를 제외한 기기는 호환되지 않습니다."
+    step0: "키스톤 3 프로를 제외한 기기는 호환되지 않습니다. (Bitcoin-only 펌웨어 권장)"
     step1: "1. 홈 화면에서 "
     step1_em: "더보기(•••)"
     step2: "2. "


### PR DESCRIPTION
issue : #557 

-btc only 펌웨어
블루월렛, 스패로우, 넌척, 제우스 가능

-사이퍼펑크 펌웨어, 멀티코인 펌웨어
블루월렛, 스패로우, 제우스, UniSat 가능

## 변경 사항
btc only 펌웨어를 기반으로 적힌 기존의 문구를 수정