### PR TITLE
[576] pending utxo 정리 로직 수정

### DIFF
--- a/lib/providers/node_provider/utxo_sync_service.dart
+++ b/lib/providers/node_provider/utxo_sync_service.dart
@@ -193,10 +193,16 @@ class UtxoSyncService {
 
     final orphanUtxoSet = <UtxoState>{};
     for (final utxo in pendingUtxos) {
-      final tx = _transactionRepository.getTransactionRecord(walletItem.id, utxo.transactionHash);
-      // tx가 null이거나 컨펌된 트랜잭션이면 orphan UTXO로 간주
-      if (tx == null || tx.blockHeight > 0) {
-        orphanUtxoSet.add(utxo);
+      if (utxo.status == UtxoStatus.outgoing && utxo.spentByTransactionHash != null) {
+        final tx = _transactionRepository.getTransactionRecord(walletItem.id, utxo.spentByTransactionHash!);
+        if (tx == null || tx.blockHeight > 0) {
+          orphanUtxoSet.add(utxo);
+        }
+      } else if (utxo.status == UtxoStatus.incoming) {
+        final tx = _transactionRepository.getTransactionRecord(walletItem.id, utxo.transactionHash);
+        if (tx == null || tx.blockHeight > 0) {
+          orphanUtxoSet.add(utxo);
+        }
       }
     }
 


### PR DESCRIPTION
### 문제
- pending(outgoing/incoming) utxo를 동일한 기준으로 정리함.
- outgoing utxo는 이전 트랜잭션의 상태, incoming tx는 현재 트랜잭션의 상태를 기준으로 정리해야 함.