### PR TITLE
[594] prevent pending utxo state change

### DIFF
--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -594,6 +594,7 @@ utxo_list_screen:
   total_balance: "Total Balance"
   utxo_locked_button: "Lock"
   utxo_unlocked_button: "Unlock"
+  pending_utxo: "Pending transactions cannot be selected."
 
 transaction_detail_screen:
   confirmation: "$height ($count confirmations)"

--- a/assets/i18n/es.i18n.yaml
+++ b/assets/i18n/es.i18n.yaml
@@ -595,6 +595,7 @@ utxo_list_screen:
   total_balance: "Saldo total"
   utxo_locked_button: "Bloquear"
   utxo_unlocked_button: "Desbloquear"
+  pending_utxo: "Las transacciones pendientes no se pueden seleccionar."
 
 transaction_detail_screen:
   confirmation: "$height ($count confirmaciones)"

--- a/assets/i18n/jp.i18n.yaml
+++ b/assets/i18n/jp.i18n.yaml
@@ -596,6 +596,7 @@ utxo_list_screen:
   total_balance: "総残高"
   utxo_locked_button: "使用ロック"
   utxo_unlocked_button: "使用可能にする"
+  pending_utxo: "保留中のトランザクションは選択できません。"
 
 transaction_detail_screen:
   confirmation: "$height（$count確認）"

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -594,6 +594,7 @@ utxo_list_screen:
   total_balance: "총 잔액"
   utxo_locked_button: "사용 잠금"
   utxo_unlocked_button: "사용 가능으로 전환"
+  pending_utxo: "대기 중인 트랜잭션은 선택할 수 없습니다."
 
 transaction_detail_screen:
   confirmation: "$height ($count승인)"

--- a/lib/screens/wallet_detail/utxo_list_screen.dart
+++ b/lib/screens/wallet_detail/utxo_list_screen.dart
@@ -700,6 +700,11 @@ class _UtxoListState extends State<UtxoList> {
           isSelectionMode: isSelectionMode,
           onPressed: () {
             if (isSelectionMode) {
+              if (utxo.status == UtxoStatus.outgoing || utxo.status == UtxoStatus.incoming) {
+                CoconutToast.showToast(context: context, text: t.utxo_list_screen.pending_utxo, isVisibleIcon: false);
+
+                return;
+              }
               setState(() {
                 if (_selectedUtxoIds.contains(utxo.utxoId)) {
                   _selectedUtxoIds.remove(utxo.utxoId);


### PR DESCRIPTION
issue : #594 

대기 중인 트랜잭션의 UTXO들이 UTXO 선택 화면(다중 선택)에서 선택 가능한 문제
-> UTXO 상태가 변경 가능 -> 대기 중인 UTXO로 새로운 트랜잭션 생성 -> 오류 가능성 높아짐

## 변경 사항
- 사용 중인 트랜잭션을 UTXO 선택 화면에서 상태 변경 불가능하도록 변경
- 사용 중인 트랜잭션을 클릭해서 선택 시도 시 토스트메시지 출력 및 선택 불가능