### PR TITLE
최근 24시간 거래 내역 위젯 수정사항

### DIFF
--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -397,7 +397,11 @@ class WalletProvider extends ChangeNotifier {
     final dateRange = Tuple2<DateTime, DateTime>(start, end);
 
     for (int walletId in walletIds) {
-      final pendingTxs = _transactionRepository.getUnconfirmedTransactionRecordList(walletId, excludeReplaced: true);
+      final pendingTxs =
+          _transactionRepository
+              .getUnconfirmedTransactionRecordList(walletId, excludeReplaced: true)
+              .where((tx) => tx.createdAt.isAfter(start))
+              .toList();
       final confirmedTxs = getConfirmedTransactionRecordListWithinDateRange([walletId], dateRange);
 
       if (pendingTxs.isNotEmpty || confirmedTxs.isNotEmpty) {


### PR DESCRIPTION
최근 24시간 거래 내역에서 pending상태인 tx는 24시간 이상 지나도 남아있는 현상 해결
- WalletProvider: getPendingAndDaysAgoTransactions()
  