### PR TITLE
[613] ios에서 P2P 계산 결과 공유기능이 작동하지 않는 현상 해결

### DIFF
--- a/lib/screens/utility/p2p_calculator_screen.dart
+++ b/lib/screens/utility/p2p_calculator_screen.dart
@@ -312,7 +312,9 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> {
       await file.writeAsBytes(pngBytes);
 
       AppGuard.disablePrivacyScreen();
-      await Share.shareXFiles([XFile(file.path)], text: t.utility.p2p_calculator.transaction_bill);
+      await SharePlus.instance.share(
+        ShareParams(files: [XFile(file.path)], text: t.utility.p2p_calculator.transaction_bill),
+      );
     } catch (e) {
       debugPrint('Failed to capture and share: $e');
     } finally {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -91,7 +91,7 @@ dependencies:
       ref: main
   coconut_lib: 1.0.4
   base32: ^2.1.3
-  share_plus: ^10.0.0
+  share_plus: ^11.1.0
   mobile_scanner: 7.0.1
   firebase_core: ^3.15.2
   firebase_analytics: ^11.6.0


### PR DESCRIPTION
- SharePlus 패키지의 현재 최신버전은 12.0.1이지만 Gradle/Kotlin 버전이 충족되지 못해 11.1.0으로 적용

#613