### PR TITLE
fix(tor): increase timeout in Tor environment

### DIFF
--- a/lib/constants/isolate_constants.dart
+++ b/lib/constants/isolate_constants.dart
@@ -1,6 +1,6 @@
 const Duration kIsolateInitTimeout = Duration(seconds: 4);
-const Duration kIsolateInitTimeoutForOnion = Duration(seconds: 60);
+const Duration kIsolateInitTimeoutForOnion = Duration(seconds: 90);
 const Duration kIsolateSocketCheckTimeout = Duration(milliseconds: 300);
 const Duration kIsolateResponseTimeout = Duration(seconds: 180);
 const Duration kIsolateSimpleResponseTimeout = Duration(seconds: 3);
-const Duration kIsolateSimpleResponseTimeoutForOnion = Duration(seconds: 60);
+const Duration kIsolateSimpleResponseTimeoutForOnion = Duration(seconds: 75);

--- a/lib/providers/node_provider/isolate/isolate_manager.dart
+++ b/lib/providers/node_provider/isolate/isolate_manager.dart
@@ -322,7 +322,7 @@ class IsolateManager {
       case IsolateControllerCommand.getTransactionRecord:
         return kIsolateResponseTimeout;
 
-      // 간단한 작업: .onion인 경우 30s, 그 외 3s
+      // 간단한 작업: .onion인 경우 kIsolateSimpleResponseTimeoutForOnion, 그 외 kIsolateSimpleResponseTimeout
       case IsolateControllerCommand.broadcast:
       case IsolateControllerCommand.getNetworkMinimumFeeRate:
       case IsolateControllerCommand.getLatestBlock:

--- a/lib/providers/node_provider/node_provider.dart
+++ b/lib/providers/node_provider/node_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/analytics/analytics_event_names.dart';
+import 'package:coconut_wallet/constants/isolate_constants.dart';
 import 'package:coconut_wallet/enums/network_enums.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/model/error/app_error.dart';
@@ -551,7 +552,10 @@ class NodeProvider extends ChangeNotifier {
   }
 
   Future<void> _establishSocketConnection(ElectrumService service, ElectrumServer server) async {
-    await service.connect(server.host, server.port, ssl: server.ssl).timeout(const Duration(seconds: 3));
+    final isOnionHost = server.host.trim().toLowerCase().endsWith('.onion');
+    final connectionTimeout = isOnionHost ? kIsolateInitTimeoutForOnion : kIsolateInitTimeout;
+
+    await service.connect(server.host, server.port, ssl: server.ssl).timeout(connectionTimeout);
 
     if (service.connectionStatus != SocketConnectionStatus.connected) {
       throw Exception('Socket connection failed');


### PR DESCRIPTION
### 변경 사항
- tor 환경 timeout 증가시킴. (initialize 60s -> 90s, simple request: 60s -> 75s)
- node_provider.dart _establishSocketConnection 메서드에서 정의된 timeout 사용하도록 수정