### PR TITLE
[634] enhance(FeeBumping): MFP 없는 지갑 빨리 받기, 빨리 보내기 클릭시 안내 프롬프트 띄움

### DIFF
--- a/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/transaction_detail_view_model.dart
@@ -14,6 +14,7 @@ import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/screens/wallet_detail/transaction_detail_screen.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
+import 'package:coconut_wallet/services/wallet_add_service.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:flutter/material.dart';
@@ -44,8 +45,8 @@ class TransactionDetailViewModel extends ChangeNotifier {
   TransactionStatus? _transactionStatus = TransactionStatus.receiving;
   bool _isSendType = false;
 
-  bool? _canBumpingTx;
-  bool get canBumpingTx => _canBumpingTx == true;
+  bool? _needsMfp;
+  bool get needsMfp => _needsMfp == true;
 
   bool _disposed = false;
   bool get isDisposed => _disposed;
@@ -69,19 +70,19 @@ class TransactionDetailViewModel extends ChangeNotifier {
     this._sendInfoProvider,
     this._blockExplorerProvider,
   ) {
-    _setCanBumpingTx();
+    setNeedsMfp();
     _initTransactionList();
   }
 
-  void _setCanBumpingTx() {
+  void setNeedsMfp() {
     final wallet = _walletProvider.getWalletById(_walletId);
     if (wallet is MultisigWalletListItem) {
-      _canBumpingTx = true;
+      _needsMfp = false;
       return;
     }
 
     final masterFingerprint = (wallet.walletBase as SingleSignatureWallet).keyStore.masterFingerprint;
-    _canBumpingTx = masterFingerprint != "00000000";
+    _needsMfp = masterFingerprint == WalletAddService.masterFingerprintPlaceholder;
   }
 
   BlockTimestamp? get currentBlock => _currentBlock;

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -16,6 +16,7 @@ import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/transaction_provider.dart';
 import 'package:coconut_wallet/providers/utxo_tag_provider.dart';
 import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
+import 'package:coconut_wallet/screens/wallet_detail/wallet_info_screen.dart';
 import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/providers/view_model/wallet_detail/transaction_detail_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
@@ -23,6 +24,7 @@ import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/screens/wallet_detail/transaction_fee_bumping_screen.dart';
 import 'package:coconut_wallet/utils/datetime_util.dart';
 import 'package:coconut_wallet/utils/transaction_util.dart';
+import 'package:coconut_wallet/utils/wallet_util.dart';
 import 'package:coconut_wallet/widgets/button/copy_text_container.dart';
 import 'package:coconut_wallet/widgets/card/send_transaction_flow_card.dart';
 import 'package:coconut_wallet/widgets/card/transaction_input_output_card.dart';
@@ -361,7 +363,6 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> with 
     if (_viewModel.transactionStatus == null || _viewModel.isSendType == null) {
       return Container();
     }
-    bool canBumpingTx = _viewModel.canBumpingTx;
 
     return Container(
       width: MediaQuery.sizeOf(context).width,
@@ -428,7 +429,30 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> with 
                         return;
                       }
 
-                      if (!canBumpingTx) return;
+                      if (_viewModel.needsMfp) {
+                        final bool? result = await showNoMfpDialog(context, () {
+                          if (context.mounted) {
+                            Navigator.of(context).pop(true);
+                          }
+                        });
+
+                        if (result == false) {
+                          return;
+                        }
+
+                        await Navigator.pushNamed(
+                          context,
+                          '/wallet-info',
+                          arguments: {
+                            'id': widget.id,
+                            'isMultisig': false,
+                            'entryPoint': kEntryPointWalletHome,
+                            'showMfpInput': true,
+                          },
+                        );
+                        _viewModel.setNeedsMfp();
+                        return;
+                      }
 
                       _viewModel.clearSendInfo();
                       Navigator.pushNamed(
@@ -447,9 +471,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> with 
                       child: Text(
                         _viewModel.isSendType! ? t.quick_send : t.quick_receive,
                         style: CoconutTypography.body2_14.setColor(
-                          _viewModel.isSendType!
-                              ? CoconutColors.primary.withValues(alpha: canBumpingTx ? 1.0 : 0.5)
-                              : CoconutColors.cyan.withValues(alpha: canBumpingTx ? 1.0 : 0.5),
+                          _viewModel.isSendType! ? CoconutColors.primary : CoconutColors.cyan,
                         ),
                       ),
                     ),

--- a/lib/utils/wallet_util.dart
+++ b/lib/utils/wallet_util.dart
@@ -28,8 +28,8 @@ bool hasMfpWallet(List<WalletListItemBase> walletItemList) {
   );
 }
 
-void showNoMfpDialog(BuildContext context, VoidCallback onTapConfirm) {
-  showDialog(
+Future<bool?> showNoMfpDialog(BuildContext context, VoidCallback onTapConfirm) async {
+  return await showDialog(
     context: context,
     builder: (BuildContext context) {
       return CoconutPopup(
@@ -39,7 +39,7 @@ void showNoMfpDialog(BuildContext context, VoidCallback onTapConfirm) {
         leftButtonText: t.alert.without_mfp.skip_button,
         rightButtonText: t.alert.without_mfp.confirm_button,
         onTapLeft: () {
-          Navigator.of(context).pop();
+          Navigator.of(context).pop(false);
         },
         onTapRight: () {
           onTapConfirm();


### PR DESCRIPTION
[기존 동작]
지갑에 MFP 없을 때,
빨리 받기, 빨리 보내기 버튼 비활성화 상태

[변경 후]
지갑에 MFP 없을 때,
빨리 받기, 빨리 보내기 버튼 활성 상태
누르면 showNoMfpDialog 함수 호출로
'보내기' 시도 했을 때랑 똑같이 동작하도록 수정 

[테스트 사항]
MFP 없는 지갑의 pending tx detail screen에서
빨리 받기, 빨리 보내기 버튼 눌렀을 때 다이얼로그 뜸 
- '취소' 클릭 시 프롬프트 닫힘
- '추가하기' 클릭 시 지갑 상세 화면으로 이동하고 MFP 입력 바텀싯 뜸

기존의 '보내기' 버튼 눌렀을 때의 동작도 확인 했습니다.