### PR TITLE
[646] UtxoSplitBuilder 생성 

### DIFF
--- a/lib/core/exceptions/utxo_split/utxo_split_exception.dart
+++ b/lib/core/exceptions/utxo_split/utxo_split_exception.dart
@@ -1,0 +1,23 @@
+/// Base exception class for all UTXO split related exceptions
+class UtxoSplitException implements Exception {
+  final String message;
+  final double? estimatedFee;
+
+  const UtxoSplitException({required this.message, required this.estimatedFee});
+
+  @override
+  String toString() => message;
+}
+
+/// Exception thrown when split would create dust outputs (<=546 sats)
+class SplitOutputDustException extends UtxoSplitException {
+  const SplitOutputDustException({super.message = 'Split would create dust outputs.', super.estimatedFee});
+}
+
+/// Exception thrown when input amounts + fee exceed UTXO amount
+class SplitInsufficientAmountException extends UtxoSplitException {
+  const SplitInsufficientAmountException({
+    super.message = 'Input amounts + fee exceed UTXO amount.',
+    super.estimatedFee,
+  });
+}

--- a/lib/core/transaction/transaction_builder.dart
+++ b/lib/core/transaction/transaction_builder.dart
@@ -245,14 +245,8 @@ class TransactionBuilder {
           walletListItemBase.walletBase,
         );
         if (tx.outputs.first.amount <= dustLimit) {
-          throw SendAmountTooLowException(
-            estimatedFee: tx.estimateFee(
-              feeRate,
-              walletListItemBase.walletType.addressType,
-              requiredSignature: walletListItemBase.multisigConfig?.requiredSignature,
-              totalSigner: walletListItemBase.multisigConfig?.totalSigner,
-            ),
-          );
+          final outputSum = tx.outputs.fold(0, (previousValue, element) => previousValue + element.amount);
+          throw SendAmountTooLowException(estimatedFee: totalInputAmount - outputSum);
         }
         return tx;
       } on TransactionCreationException catch (_) {
@@ -365,14 +359,8 @@ class TransactionBuilder {
           walletListItemBase.walletBase,
         );
         if (tx.outputs.last.amount <= dustLimit) {
-          throw SendAmountTooLowException(
-            estimatedFee: tx.estimateFee(
-              feeRate,
-              walletListItemBase.walletType.addressType,
-              requiredSignature: walletListItemBase.multisigConfig?.requiredSignature,
-              totalSigner: walletListItemBase.multisigConfig?.totalSigner,
-            ),
-          );
+          final outputSum = tx.outputs.fold(0, (previousValue, element) => previousValue + element.amount);
+          throw SendAmountTooLowException(estimatedFee: totalInputAmount - outputSum);
         }
         return tx;
       } on Exception catch (e) {

--- a/lib/core/transaction/utxo_split_builder.dart
+++ b/lib/core/transaction/utxo_split_builder.dart
@@ -48,31 +48,33 @@ class UtxoSplitBuilder {
   final WalletListItemBase walletListItemBase;
   final AddressRepository addressRepository;
   late final int _nextReceiveAddressIndex;
-  late final double _outputCountVarIntFeeMargin;
   double? _outputVBytes;
   double? _oneOutputTxVBytes;
+  List<int>? _cachedNiceSplitCounts;
 
   static const int _outputCountVarIntThreshold = 253;
-  static const List<double> niceAmounts = [
-    0.0001,
-    0.0002,
-    0.0005,
-    0.001,
-    0.002,
-    0.005,
-    0.01,
-    0.02,
-    0.05,
-    0.1,
-    0.2,
-    0.5,
-    1,
-    2,
-    5,
-    10,
-    20,
-    50,
+  static const List<int> niceAmounts = [
+    10000,
+    20000,
+    50000,
+    100000,
+    200000,
+    500000,
+    1000000,
+    2000000,
+    5000000,
+    10000000,
+    20000000,
+    50000000,
+    100000000,
+    200000000,
+    500000000,
+    1000000000,
+    2000000000,
+    5000000000,
   ];
+
+  double get _outputCountVarIntFeeMargin => 2 * feeRate;
 
   double get feeRate => _feeRate;
   set feeRate(double value) {
@@ -80,6 +82,7 @@ class UtxoSplitBuilder {
       throw ArgumentError('feeRate must be greater than 0. Given: $value');
     }
     _feeRate = value;
+    _cachedNiceSplitCounts = null;
   }
 
   UtxoSplitBuilder({
@@ -95,7 +98,6 @@ class UtxoSplitBuilder {
      * output length: if (0 ~ 252) → 1 byte, if (253 ~ 65535) → 3 bytes, if (65536 ~ 4294967295) → 5 bytes
      * output이 65535개 초과인 경우는 커버 X
      */
-    _outputCountVarIntFeeMargin = 2 * feeRate;
     _nextReceiveAddressIndex = addressRepository.getReceiveAddress(walletListItemBase.id).index;
   }
 
@@ -183,34 +185,7 @@ class UtxoSplitBuilder {
     if (amountPerOutput <= dustLimit) {
       throw const SplitOutputDustException(); // 0.0000 0547 BTC부터 전송할 수 있어요
     }
-
-    double firstLeft = utxo.amount - (_oneOutputTxVBytes! * feeRate) - amountPerOutput;
-    final feePerOutput = _outputVBytes! * feeRate;
-    if (firstLeft <= dustLimit + feePerOutput) {
-      throw const SplitInsufficientAmountException(); // 수수료를 포함하면 나눌 수 없는 금액이에요.
-    }
-
-    var neededSatsPerOneMore = amountPerOutput + feePerOutput;
-    double left = firstLeft;
-
-    // amountPerOutput을 최대한 많이 넣을 수 있는 개수를 구함
-    // left에서 neededSatsPerOneMore를 차감한 후 마지막 sweep output이 dustLimit 이상인지 확인
-    // exactAmounts: 정확한 금액의 output 리스트 (sweep output 제외)
-    List<int> exactAmounts = [amountPerOutput];
-    int count = 1;
-    while (left - neededSatsPerOneMore > dustLimit + feePerOutput) {
-      if (count + 1 == _outputCountVarIntThreshold) {
-        if (left - _outputCountVarIntFeeMargin - neededSatsPerOneMore <= dustLimit + feePerOutput) {
-          break;
-        } else {
-          left -= _outputCountVarIntFeeMargin;
-        }
-      }
-
-      left -= neededSatsPerOneMore;
-      exactAmounts.add(amountPerOutput);
-      count++;
-    }
+    List<int> exactAmounts = _getFixedSplitExactAmounts(amountPerOutput);
 
     var txBuildResult = await _buildTransaction(exactAmounts);
     if (txBuildResult.isFailure) {
@@ -268,32 +243,36 @@ class UtxoSplitBuilder {
     return _buildSuccessResult(txBuildResult.transaction!);
   }
 
-  /// UTXO를 niceNumbers로 나눠지게 하는 count 최대 5개를 반환
-  // List<int> getNiceSplitCounts(double value) {
-  //   final raw = value / 10;
+  /// UTXO를 niceAmounts로 나눠지게 하는 count 최대 5개를 반환
+  Future<List<int>> getNiceSplitCounts() async {
+    if (_cachedNiceSplitCounts != null) {
+      return _cachedNiceSplitCounts!;
+    }
 
-  //   const List<double> niceNumbers = [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 20, 50];
+    // niceAmounts 중 utxo.amount보다 작으면서 가장 큰 값으로부터 최대 5개를 찾아 subList로 만든다.
+    // subList가 0개면 빈 배열을 반환한다.
+    // subList에 있는 값의 근사값으로 나눠지려면 count 몇으로 나눠야하는지 찾아서 배열로 반환한다.
+    await _initOutputVBytes();
+    final selectableNiceAmounts = niceAmounts.where((element) => element < utxo.amount).toList().reversed;
+    final List<int> niceSplitCounts = [];
 
-  //   const maxOutputs = 20;
+    for (final amount in selectableNiceAmounts) {
+      try {
+        final exactAmounts = _getFixedSplitExactAmounts(amount);
+        niceSplitCounts.add(exactAmounts.length + 1);
+        if (niceSplitCounts.length == 5) {
+          break;
+        }
+      } on SplitOutputDustException {
+        continue;
+      } on SplitInsufficientAmountException {
+        continue;
+      }
+    }
 
-  //   double best = niceNumbers.first;
-  //   double minDiff = double.infinity;
-
-  //   for (final n in niceNumbers) {
-  //     final count = value / n;
-
-  //     if (count > maxOutputs) continue;
-
-  //     final diff = (raw - n).abs();
-
-  //     if (diff < minDiff) {
-  //       minDiff = diff;
-  //       best = n;
-  //     }
-  //   }
-
-  //   return best;
-  // }
+    _cachedNiceSplitCounts = niceSplitCounts;
+    return _cachedNiceSplitCounts!;
+  }
 
   // ----------- Internal methods -----------
   // ----------- Handle Result -----------
@@ -343,9 +322,36 @@ class UtxoSplitBuilder {
   }
 
   /// sweep 방식의 recipients 생성
-  /// [exactAmounts]: 정확한 금액의 output 리스트 (sweep output 미포함)
-  /// sweep output이 마지막에 자동으로 추가됨 (utxo.amount - sum(exactAmounts) - fee)
-  /// TransactionBuilder가 isFeeSubtractedFromAmount: true로 마지막에서 fee 차감
+  /// [exactAmounts]: 확정된 금액의 output 리스트, last output은 미포함
+  List<int> _getFixedSplitExactAmounts(int amountPerOutput) {
+    double firstLeft = utxo.amount - (_oneOutputTxVBytes! * feeRate) - amountPerOutput;
+    final feePerOutput = _outputVBytes! * feeRate;
+    if (firstLeft <= dustLimit + feePerOutput) {
+      throw const SplitInsufficientAmountException();
+    }
+
+    var neededSatsPerOneMore = amountPerOutput + feePerOutput;
+    double left = firstLeft;
+    List<int> exactAmounts = [amountPerOutput];
+    int count = 1;
+
+    while (left - neededSatsPerOneMore > dustLimit + feePerOutput) {
+      if (count + 1 == _outputCountVarIntThreshold) {
+        if (left - _outputCountVarIntFeeMargin - neededSatsPerOneMore <= dustLimit + feePerOutput) {
+          break;
+        } else {
+          left -= _outputCountVarIntFeeMargin;
+        }
+      }
+
+      left -= neededSatsPerOneMore;
+      exactAmounts.add(amountPerOutput);
+      count++;
+    }
+
+    return exactAmounts;
+  }
+
   Future<Map<String, int>> _buildSweepRecipients(List<int> exactAmounts) async {
     final totalOutputCount = exactAmounts.length + 1; // +1 for sweep output
 

--- a/lib/core/transaction/utxo_split_builder.dart
+++ b/lib/core/transaction/utxo_split_builder.dart
@@ -4,10 +4,8 @@ import 'package:coconut_wallet/core/exceptions/transaction_creation/transaction_
 import 'package:coconut_wallet/core/exceptions/utxo_split/utxo_split_exception.dart';
 import 'package:coconut_wallet/core/transaction/transaction_builder.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
-import 'package:coconut_wallet/extensions/transaction_extension.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
-import 'package:coconut_wallet/model/wallet/wallet_address.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/utils/logger.dart';
@@ -49,11 +47,12 @@ class UtxoSplitBuilder {
   double _feeRate;
   final WalletListItemBase walletListItemBase;
   final AddressRepository addressRepository;
-  late final WalletAddress _nextReceiveAddress;
   late final int _nextReceiveAddressIndex;
-  late final double _lastAmountMargin;
+  late final double _outputCountVarIntFeeMargin;
   double? _outputVBytes;
   double? _oneOutputTxVBytes;
+
+  static const int _outputCountVarIntThreshold = 253;
   static const List<double> niceAmounts = [
     0.0001,
     0.0002,
@@ -89,10 +88,14 @@ class UtxoSplitBuilder {
     required this.walletListItemBase,
     required this.addressRepository,
   }) : assert(feeRate > 0, 'feeRate must be greater than 0'),
-       assert(utxo.amount >= 20000, 'utxo.amount must be at least 20000'),
+       assert(utxo.amount >= 50000, 'utxo.amount must be at least 50000'),
        _feeRate = feeRate {
-    _nextReceiveAddress = addressRepository.getReceiveAddress(walletListItemBase.id);
-    _lastAmountMargin = 10 * feeRate;
+    /** output 개수가 253 이상일 때 tx 크기가 2 증가
+     * Segwit tx에서 witness가 아닌 base 영역이 2bytes 증가하므로 수수료도 2 * feeRate 증가
+     * output length: if (0 ~ 252) → 1 byte, if (253 ~ 65535) → 3 bytes, if (65536 ~ 4294967295) → 5 bytes
+     * output이 65535개 초과인 경우는 커버 X
+     */
+    _outputCountVarIntFeeMargin = 2 * feeRate;
     _nextReceiveAddressIndex = addressRepository.getReceiveAddress(walletListItemBase.id).index;
   }
 
@@ -118,21 +121,31 @@ class UtxoSplitBuilder {
     // 조건: (utxo.amount - fee) >= (dustLimit + 1) * n
     double feePerOutput = _outputVBytes! * feeRate;
     // INFO: _lastAmountMargin 필요한 이유: coconut_lib 트랜잭션 생성 시 예상 수수료가 여기서 예상한 것보다 큰 경우 마지막 Output Amount가 dustLimit 이하가 되는 경우를 방지
-    final left = utxo.amount - (_oneOutputTxVBytes! * feeRate) - _lastAmountMargin;
-    // left - feePerOutput * (n-1) >= (546 + 1) * n
-    // left + feePerOutput >= 547 * n + feePerOutput * n
-    // left + feePerOutput >= n * (547 + feePerOutput)
-    // n <= (left + feePerOutput) / (547 + feePerOutput)
-    return (left + feePerOutput) ~/ (dustLimit + 1 + feePerOutput);
+    var left = utxo.amount - (_oneOutputTxVBytes! * feeRate);
+    /** left - feePerOutput * (n-1) >= (546 + 1) * n
+        left + feePerOutput >= 547 * n + feePerOutput * n
+        left + feePerOutput >= n * (547 + feePerOutput)
+        n <= (left + feePerOutput) / (547 + feePerOutput) */
+    var result = (left + feePerOutput) ~/ (dustLimit + 1 + feePerOutput);
+    if (result < _outputCountVarIntThreshold) {
+      return result;
+    }
+
+    left = utxo.amount - (_oneOutputTxVBytes! * feeRate) - _outputCountVarIntFeeMargin;
+    result = (left + feePerOutput) ~/ (dustLimit + 1 + feePerOutput);
+    return result;
   }
 
   /// 균등하게 나누기
   Future<UtxoSplitResult> buildEqualSplit({required int splitCount}) async {
     assert(splitCount >= 2);
+    Logger.log("--> splitCount: $splitCount");
     await _initOutputVBytes();
     // INFO: _lastAmountMargin 필요한 이유: coconut_lib 트랜잭션 생성 시 예상 수수료가 여기서 예상한 것보다 큰 경우 마지막 Output Amount가 dustLimit 이하가 되는 경우를 방지
-    final fee = (_oneOutputTxVBytes! + (_outputVBytes! * (splitCount - 1))) * feeRate + _lastAmountMargin;
-
+    var fee =
+        (_oneOutputTxVBytes! + (_outputVBytes! * (splitCount - 1))) * feeRate +
+        (splitCount >= _outputCountVarIntThreshold ? _outputCountVarIntFeeMargin : 0);
+    Logger.log('--> UtxoSplitBuilder 균등분할 estimatedFee: $fee');
     if (fee >= utxo.amount) {
       throw SplitInsufficientAmountException(estimatedFee: fee); // 수수료가 UTXO 금액보다 커요
     }
@@ -155,9 +168,7 @@ class UtxoSplitBuilder {
     }
 
     // 트랜잭션 생성 (마지막 output에 fee 포함하여 sweep)
-    var recipients = await _buildSweepRecipients(desiredAmounts.sublist(0, desiredAmounts.length - 1));
-    var txBuildResult = _buildTransaction(recipients);
-
+    var txBuildResult = await _buildTransaction(desiredAmounts.sublist(0, desiredAmounts.length - 1));
     if (txBuildResult.isFailure) {
       _throwIfBuildFailed(txBuildResult);
     }
@@ -173,7 +184,7 @@ class UtxoSplitBuilder {
       throw const SplitOutputDustException(); // 0.0000 0547 BTC부터 전송할 수 있어요
     }
 
-    var firstLeft = utxo.amount - _lastAmountMargin - (_oneOutputTxVBytes! * feeRate) - amountPerOutput;
+    double firstLeft = utxo.amount - (_oneOutputTxVBytes! * feeRate) - amountPerOutput;
     final feePerOutput = _outputVBytes! * feeRate;
     if (firstLeft <= dustLimit + feePerOutput) {
       throw const SplitInsufficientAmountException(); // 수수료를 포함하면 나눌 수 없는 금액이에요.
@@ -186,21 +197,28 @@ class UtxoSplitBuilder {
     // left에서 neededSatsPerOneMore를 차감한 후 마지막 sweep output이 dustLimit 이상인지 확인
     // exactAmounts: 정확한 금액의 output 리스트 (sweep output 제외)
     List<int> exactAmounts = [amountPerOutput];
+    int count = 1;
     while (left - neededSatsPerOneMore > dustLimit + feePerOutput) {
+      if (count + 1 == _outputCountVarIntThreshold) {
+        if (left - _outputCountVarIntFeeMargin - neededSatsPerOneMore <= dustLimit + feePerOutput) {
+          break;
+        } else {
+          left -= _outputCountVarIntFeeMargin;
+        }
+      }
+
       left -= neededSatsPerOneMore;
       exactAmounts.add(amountPerOutput);
+      count++;
     }
 
-    var recipients = await _buildSweepRecipients(exactAmounts);
-    var txBuildResult = _buildTransaction(recipients);
-
+    var txBuildResult = await _buildTransaction(exactAmounts);
     if (txBuildResult.isFailure) {
       if (txBuildResult.exception is SendAmountTooLowException) {
         if (exactAmounts.length > 2) {
           // 1개 줄여서 다시 시도
           exactAmounts.removeLast();
-          recipients = await _buildSweepRecipients(exactAmounts);
-          txBuildResult = _buildTransaction(recipients);
+          txBuildResult = await _buildTransaction(exactAmounts);
         }
         if (txBuildResult.isFailure) {
           _throwIfBuildFailed(txBuildResult);
@@ -229,8 +247,10 @@ class UtxoSplitBuilder {
     final totalRequested = amountCountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
     final totalOutputCount = amountCountMap.values.fold<int>(0, (sum, count) => sum + count);
 
-    final double estimatedFee = (_oneOutputTxVBytes! + _outputVBytes! * (totalOutputCount - 1)) * feeRate;
-    final left = utxo.amount - _lastAmountMargin - totalRequested - estimatedFee;
+    final double estimatedFee =
+        (_oneOutputTxVBytes! + _outputVBytes! * (totalOutputCount - 1)) * feeRate +
+        (totalOutputCount >= _outputCountVarIntThreshold ? _outputCountVarIntFeeMargin : 0);
+    final left = utxo.amount - totalRequested - estimatedFee;
     if (left < 0) {
       throw SplitInsufficientAmountException(estimatedFee: estimatedFee); // 금액이 부족해요
     }
@@ -240,10 +260,7 @@ class UtxoSplitBuilder {
     }
 
     final flattenedAmounts = amountCountMap.entries.expand((entry) => List.filled(entry.value, entry.key)).toList();
-
-    var recipients = await _buildSweepRecipients(flattenedAmounts);
-    var txBuildResult = _buildTransaction(recipients);
-
+    var txBuildResult = await _buildTransaction(flattenedAmounts);
     if (txBuildResult.isFailure) {
       _throwIfBuildFailed(txBuildResult);
     }
@@ -358,12 +375,13 @@ class UtxoSplitBuilder {
     return recipients;
   }
 
-  TransactionBuildResult _buildTransaction(Map<String, int> recipients) {
+  Future<TransactionBuildResult> _buildTransaction(List<int> exactAmounts) async {
+    final firstRecipients = await _buildSweepRecipients(exactAmounts);
     final changeAddress = addressRepository.getChangeAddress(walletListItemBase.id);
 
     return TransactionBuilder(
       availableUtxos: [utxo],
-      recipients: recipients,
+      recipients: firstRecipients,
       feeRate: feeRate,
       changeDerivationPath: changeAddress.derivationPath,
       walletListItemBase: walletListItemBase,

--- a/lib/core/transaction/utxo_split_builder.dart
+++ b/lib/core/transaction/utxo_split_builder.dart
@@ -1,0 +1,354 @@
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
+import 'package:coconut_wallet/core/exceptions/transaction_creation/transaction_creation_exception.dart';
+import 'package:coconut_wallet/core/exceptions/utxo_split/utxo_split_exception.dart';
+import 'package:coconut_wallet/core/transaction/transaction_builder.dart';
+import 'package:coconut_wallet/enums/wallet_enums.dart';
+import 'package:coconut_wallet/extensions/transaction_extension.dart';
+import 'package:coconut_wallet/model/utxo/utxo_state.dart';
+import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
+import 'package:coconut_wallet/model/wallet/wallet_address.dart';
+import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
+import 'package:coconut_wallet/repository/realm/address_repository.dart';
+import 'package:coconut_wallet/utils/logger.dart';
+
+class UtxoSplitResult {
+  final Transaction? transaction;
+  final Map<int, int> splitAmountMap;
+  final int estimatedFee;
+  final double feeRatio;
+  final Exception? exception;
+
+  bool get isSuccess => transaction != null;
+  bool get isFailure => transaction == null;
+
+  const UtxoSplitResult({
+    required this.transaction,
+    required this.splitAmountMap,
+    required this.estimatedFee,
+    required this.feeRatio,
+    this.exception,
+  });
+
+  @override
+  String toString() {
+    final buffer = StringBuffer();
+    buffer.writeln("┌──────────────── UTXO Split Result Info ────────────────┐");
+    buffer.writeln("│ isSuccess = $isSuccess");
+    buffer.writeln("│ splitAmountMap = $splitAmountMap");
+    buffer.writeln("│ estimatedFee = $estimatedFee");
+    buffer.writeln("│ feeRatio = $feeRatio%");
+    buffer.writeln("│ exception = $exception");
+    buffer.writeln("└───────────────────────────────────────────────────────┘");
+    return buffer.toString();
+  }
+}
+
+class UtxoSplitBuilder {
+  final UtxoState utxo;
+  double _feeRate;
+  final WalletListItemBase walletListItemBase;
+  final AddressRepository addressRepository;
+  late final WalletAddress _nextReceiveAddress;
+  late final int _nextReceiveAddressIndex;
+  late final double _lastAmountMargin;
+  double? _outputVBytes;
+  double? _oneOutputTxVBytes;
+
+  double get feeRate => _feeRate;
+  set feeRate(double value) {
+    if (value <= 0) {
+      throw ArgumentError('feeRate must be greater than 0. Given: $value');
+    }
+    _feeRate = value;
+  }
+
+  UtxoSplitBuilder({
+    required this.utxo,
+    required double feeRate,
+    required this.walletListItemBase,
+    required this.addressRepository,
+  }) : assert(feeRate > 0, 'feeRate must be greater than 0'),
+       assert(utxo.amount >= 20000, 'utxo.amount must be at least 20000'),
+       _feeRate = feeRate {
+    _nextReceiveAddress = addressRepository.getReceiveAddress(walletListItemBase.id);
+    _lastAmountMargin = 10 * feeRate;
+    _nextReceiveAddressIndex = addressRepository.getReceiveAddress(walletListItemBase.id).index;
+  }
+
+  Future<void> _initOutputVBytes() async {
+    if (_outputVBytes != null) return;
+
+    if (walletListItemBase.walletType == WalletType.singleSignature) {
+      _oneOutputTxVBytes = 110;
+      _outputVBytes = 31;
+    } else {
+      final wallet = walletListItemBase as MultisigWalletListItem;
+      _oneOutputTxVBytes = 132 + (wallet.signers.length - 2) * 8 + (wallet.requiredSignatureCount - 1) * 18;
+      _outputVBytes = 43;
+    }
+    assert(_outputVBytes != null && _oneOutputTxVBytes != null);
+  }
+
+  /// 최대 균등 분할 수를 계산하고 실제 빌드로 검증하여 조정
+  Future<int> getMaxEqualSplitCount() async {
+    await _initOutputVBytes();
+
+    // fee = (_oneOutputTxVBytes + _outputVBytes * (n - 1)) * feeRate
+    // 조건: (utxo.amount - fee) >= (dustLimit + 1) * n
+    double feePerOutput = _outputVBytes! * feeRate;
+    // INFO: _lastAmountMargin 필요한 이유: coconut_lib 트랜잭션 생성 시 예상 수수료가 여기서 예상한 것보다 큰 경우 마지막 Output Amount가 dustLimit 이하가 되는 경우를 방지
+    final left = utxo.amount - (_oneOutputTxVBytes! * feeRate) - _lastAmountMargin;
+    // left - feePerOutput * (n-1) >= (546 + 1) * n
+    // left + feePerOutput >= 547 * n + feePerOutput * n
+    // left + feePerOutput >= n * (547 + feePerOutput)
+    // n <= (left + feePerOutput) / (547 + feePerOutput)
+    return (left + feePerOutput) ~/ (dustLimit + 1 + feePerOutput);
+  }
+
+  /// 균등하게 나누기
+  Future<UtxoSplitResult> buildEqualSplit({required int splitCount}) async {
+    assert(splitCount >= 2);
+    await _initOutputVBytes();
+    // INFO: _lastAmountMargin 필요한 이유: coconut_lib 트랜잭션 생성 시 예상 수수료가 여기서 예상한 것보다 큰 경우 마지막 Output Amount가 dustLimit 이하가 되는 경우를 방지
+    final fee = (_oneOutputTxVBytes! + (_outputVBytes! * (splitCount - 1))) * feeRate + _lastAmountMargin;
+
+    if (fee >= utxo.amount) {
+      throw SplitInsufficientAmountException(estimatedFee: fee); // 수수료가 UTXO 금액보다 커요
+    }
+
+    final availableAmount = utxo.amount - fee;
+    final baseAmount = availableAmount ~/ splitCount;
+
+    if (baseAmount <= dustLimit) {
+      throw SplitOutputDustException(estimatedFee: fee); // 이 개수로 나누면 dust가 생성돼요
+    }
+
+    // 원하는 output 금액 리스트 생성
+    final remainder = availableAmount % splitCount;
+    List<int> desiredAmounts = [];
+    for (int i = 0; i < splitCount - remainder; i++) {
+      desiredAmounts.add(baseAmount);
+    }
+    for (int i = 0; i < remainder; i++) {
+      desiredAmounts.add(baseAmount + 1);
+    }
+
+    // 트랜잭션 생성 (마지막 output에 fee 포함하여 sweep)
+    var recipients = await _buildSweepRecipients(desiredAmounts.sublist(0, desiredAmounts.length - 1));
+    var txBuildResult = _buildTransaction(recipients);
+
+    if (txBuildResult.isFailure) {
+      _throwIfBuildFailed(txBuildResult);
+    }
+
+    return _buildSuccessResult(txBuildResult.transaction!);
+  }
+
+  /// 일정 금액으로 나누기
+  Future<UtxoSplitResult> buildFixedAmountSplit({required int amountPerOutput}) async {
+    assert(amountPerOutput > 0);
+    await _initOutputVBytes();
+    if (amountPerOutput <= dustLimit) {
+      throw const SplitOutputDustException(); // 0.0000 0547 BTC부터 전송할 수 있어요
+    }
+
+    var firstLeft = utxo.amount - _lastAmountMargin - (_oneOutputTxVBytes! * feeRate) - amountPerOutput;
+    final feePerOutput = _outputVBytes! * feeRate;
+    if (firstLeft <= dustLimit + feePerOutput) {
+      throw const SplitInsufficientAmountException(); // 수수료를 포함하면 나눌 수 없는 금액이에요.
+    }
+
+    var neededSatsPerOneMore = amountPerOutput + feePerOutput;
+    double left = firstLeft;
+
+    // amountPerOutput을 최대한 많이 넣을 수 있는 개수를 구함
+    // left에서 neededSatsPerOneMore를 차감한 후 마지막 sweep output이 dustLimit 이상인지 확인
+    // exactAmounts: 정확한 금액의 output 리스트 (sweep output 제외)
+    List<int> exactAmounts = [amountPerOutput];
+    while (left - neededSatsPerOneMore > dustLimit + feePerOutput) {
+      left -= neededSatsPerOneMore;
+      exactAmounts.add(amountPerOutput);
+    }
+
+    var recipients = await _buildSweepRecipients(exactAmounts);
+    var txBuildResult = _buildTransaction(recipients);
+
+    if (txBuildResult.isFailure) {
+      if (txBuildResult.exception is SendAmountTooLowException) {
+        if (exactAmounts.length > 2) {
+          // 1개 줄여서 다시 시도
+          exactAmounts.removeLast();
+          recipients = await _buildSweepRecipients(exactAmounts);
+          txBuildResult = _buildTransaction(recipients);
+        }
+        if (txBuildResult.isFailure) {
+          _throwIfBuildFailed(txBuildResult);
+        }
+      } else {
+        throw UtxoSplitException(
+          estimatedFee: txBuildResult.estimatedFee.toDouble(),
+          message: txBuildResult.exception!.toString(),
+        );
+      }
+    }
+
+    return _buildSuccessResult(txBuildResult.transaction!);
+  }
+
+  /// 직접 나누기
+  Future<UtxoSplitResult> buildCustomSplit({required Map<int, int> amountCountMap}) async {
+    await _initOutputVBytes();
+    // dust 검증
+    for (final amount in amountCountMap.keys) {
+      if (amount <= dustLimit) {
+        throw const SplitOutputDustException(); // 0.0000 0547부터 전송할 수 있어요 -> 이건 나누기 화면에서 미리 잡아야함
+      }
+    }
+
+    final totalRequested = amountCountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+    final totalOutputCount = amountCountMap.values.fold<int>(0, (sum, count) => sum + count);
+
+    final double estimatedFee = (_oneOutputTxVBytes! + _outputVBytes! * (totalOutputCount - 1)) * feeRate;
+    final left = utxo.amount - _lastAmountMargin - totalRequested - estimatedFee;
+    if (left < 0) {
+      throw SplitInsufficientAmountException(estimatedFee: estimatedFee); // 금액이 부족해요
+    }
+
+    if (left <= dustLimit) {
+      throw const SplitOutputDustException(); // dust가 생성돼요
+    }
+
+    final flattenedAmounts = amountCountMap.entries.expand((entry) => List.filled(entry.value, entry.key)).toList();
+
+    var recipients = await _buildSweepRecipients(flattenedAmounts);
+    var txBuildResult = _buildTransaction(recipients);
+
+    if (txBuildResult.isFailure) {
+      _throwIfBuildFailed(txBuildResult);
+    }
+
+    return _buildSuccessResult(txBuildResult.transaction!);
+  }
+
+  /// UTXO를 niceNumbers로 나눠지게 하는 count 최대 5개를 반환
+  // List<int> getNiceSplitCounts(double value) {
+  //   final raw = value / 10;
+
+  //   const List<double> niceNumbers = [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 20, 50];
+
+  //   const maxOutputs = 20;
+
+  //   double best = niceNumbers.first;
+  //   double minDiff = double.infinity;
+
+  //   for (final n in niceNumbers) {
+  //     final count = value / n;
+
+  //     if (count > maxOutputs) continue;
+
+  //     final diff = (raw - n).abs();
+
+  //     if (diff < minDiff) {
+  //       minDiff = diff;
+  //       best = n;
+  //     }
+  //   }
+
+  //   return best;
+  // }
+
+  // ----------- Internal methods -----------
+  // ----------- Handle Result -----------
+  UtxoSplitResult _buildSuccessResult(Transaction transaction) {
+    final realFee = _calculateRealFee(transaction);
+    final actualSplitMap = _buildSplitAmountMapFromTx(transaction);
+
+    return UtxoSplitResult(
+      transaction: transaction,
+      splitAmountMap: actualSplitMap,
+      estimatedFee: realFee,
+      feeRatio: _calculateFeeRatio(realFee, utxo.amount),
+    );
+  }
+
+  double _calculateFeeRatio(int fee, int denominator) {
+    return ((fee / denominator * 100) * 100).roundToDouble() / 100;
+  }
+
+  Never _throwIfBuildFailed(TransactionBuildResult txBuildResult) {
+    if (!txBuildResult.isFailure) {
+      throw ArgumentError('txBuildResult must be failure');
+    }
+
+    if (txBuildResult.exception is SendAmountTooLowException) {
+      throw SplitOutputDustException(estimatedFee: txBuildResult.estimatedFee.toDouble());
+    }
+
+    throw UtxoSplitException(
+      estimatedFee: txBuildResult.estimatedFee.toDouble(),
+      message: txBuildResult.exception!.toString(),
+    );
+  }
+
+  int _calculateRealFee(Transaction transaction) {
+    final outputSum = transaction.outputs.fold(0, (sum, output) => sum + output.amount);
+    return utxo.amount - outputSum;
+  }
+
+  /// 실제 트랜잭션의 output 금액으로 splitAmountMap을 생성
+  Map<int, int> _buildSplitAmountMapFromTx(Transaction transaction) {
+    final Map<int, int> result = {};
+    for (final output in transaction.outputs) {
+      result[output.amount] = (result[output.amount] ?? 0) + 1;
+    }
+    return result;
+  }
+
+  /// sweep 방식의 recipients 생성
+  /// [exactAmounts]: 정확한 금액의 output 리스트 (sweep output 미포함)
+  /// sweep output이 마지막에 자동으로 추가됨 (utxo.amount - sum(exactAmounts) - fee)
+  /// TransactionBuilder가 isFeeSubtractedFromAmount: true로 마지막에서 fee 차감
+  Future<Map<String, int>> _buildSweepRecipients(List<int> exactAmounts) async {
+    final totalOutputCount = exactAmounts.length + 1; // +1 for sweep output
+
+    final addresses = await addressRepository.getWalletAddressList(
+      walletListItemBase,
+      _nextReceiveAddressIndex,
+      totalOutputCount,
+      false,
+      true,
+    );
+
+    if (addresses.length < totalOutputCount) {
+      throw StateError('Not enough unused addresses. Required: $totalOutputCount, Available: ${addresses.length}');
+    }
+
+    final Map<String, int> recipients = {};
+
+    int sumOfExact = 0;
+    for (int i = 0; i < exactAmounts.length; i++) {
+      recipients[addresses[i].address] = exactAmounts[i];
+      sumOfExact += exactAmounts[i];
+    }
+
+    // sweep output: 나머지 전부 (fee 포함) → tx 생성 시 여기서 fee 차감
+    recipients[addresses[totalOutputCount - 1].address] = utxo.amount - sumOfExact;
+
+    return recipients;
+  }
+
+  TransactionBuildResult _buildTransaction(Map<String, int> recipients) {
+    final changeAddress = addressRepository.getChangeAddress(walletListItemBase.id);
+
+    return TransactionBuilder(
+      availableUtxos: [utxo],
+      recipients: recipients,
+      feeRate: feeRate,
+      changeDerivationPath: changeAddress.derivationPath,
+      walletListItemBase: walletListItemBase,
+      isFeeSubtractedFromAmount: true,
+      isUtxoFixed: true,
+    ).build();
+  }
+}

--- a/lib/core/transaction/utxo_split_builder.dart
+++ b/lib/core/transaction/utxo_split_builder.dart
@@ -91,7 +91,7 @@ class UtxoSplitBuilder {
     required this.walletListItemBase,
     required this.addressRepository,
   }) : assert(feeRate > 0, 'feeRate must be greater than 0'),
-       assert(utxo.amount >= 50000, 'utxo.amount must be at least 50000'),
+       assert(utxo.amount >= 20000, 'utxo.amount must be at least 20000'),
        _feeRate = feeRate {
     /** output 개수가 253 이상일 때 tx 크기가 2 증가
      * Segwit tx에서 witness가 아닌 base 영역이 2bytes 증가하므로 수수료도 2 * feeRate 증가

--- a/lib/core/transaction/utxo_split_builder.dart
+++ b/lib/core/transaction/utxo_split_builder.dart
@@ -122,7 +122,6 @@ class UtxoSplitBuilder {
     // fee = (_oneOutputTxVBytes + _outputVBytes * (n - 1)) * feeRate
     // 조건: (utxo.amount - fee) >= (dustLimit + 1) * n
     double feePerOutput = _outputVBytes! * feeRate;
-    // INFO: _lastAmountMargin 필요한 이유: coconut_lib 트랜잭션 생성 시 예상 수수료가 여기서 예상한 것보다 큰 경우 마지막 Output Amount가 dustLimit 이하가 되는 경우를 방지
     var left = utxo.amount - (_oneOutputTxVBytes! * feeRate);
     /** left - feePerOutput * (n-1) >= (546 + 1) * n
         left + feePerOutput >= 547 * n + feePerOutput * n
@@ -143,7 +142,6 @@ class UtxoSplitBuilder {
     assert(splitCount >= 2);
     Logger.log("--> splitCount: $splitCount");
     await _initOutputVBytes();
-    // INFO: _lastAmountMargin 필요한 이유: coconut_lib 트랜잭션 생성 시 예상 수수료가 여기서 예상한 것보다 큰 경우 마지막 Output Amount가 dustLimit 이하가 되는 경우를 방지
     var fee =
         (_oneOutputTxVBytes! + (_outputVBytes! * (splitCount - 1))) * feeRate +
         (splitCount >= _outputCountVarIntThreshold ? _outputCountVarIntFeeMargin : 0);

--- a/lib/core/transaction/utxo_split_builder.dart
+++ b/lib/core/transaction/utxo_split_builder.dart
@@ -247,9 +247,6 @@ class UtxoSplitBuilder {
       return _cachedNiceSplitCounts!;
     }
 
-    // niceAmounts 중 utxo.amount보다 작으면서 가장 큰 값으로부터 최대 5개를 찾아 subList로 만든다.
-    // subList가 0개면 빈 배열을 반환한다.
-    // subList에 있는 값의 근사값으로 나눠지려면 count 몇으로 나눠야하는지 찾아서 배열로 반환한다.
     await _initOutputVBytes();
     final selectableNiceAmounts = niceAmounts.where((element) => element < utxo.amount).toList().reversed;
     final List<int> niceSplitCounts = [];

--- a/lib/core/transaction/utxo_split_builder.dart
+++ b/lib/core/transaction/utxo_split_builder.dart
@@ -54,6 +54,26 @@ class UtxoSplitBuilder {
   late final double _lastAmountMargin;
   double? _outputVBytes;
   double? _oneOutputTxVBytes;
+  static const List<double> niceAmounts = [
+    0.0001,
+    0.0002,
+    0.0005,
+    0.001,
+    0.002,
+    0.005,
+    0.01,
+    0.02,
+    0.05,
+    0.1,
+    0.2,
+    0.5,
+    1,
+    2,
+    5,
+    10,
+    20,
+    50,
+  ];
 
   double get feeRate => _feeRate;
   set feeRate(double value) {

--- a/lib/core/transaction/utxo_split_transaction_builder.dart
+++ b/lib/core/transaction/utxo_split_transaction_builder.dart
@@ -42,7 +42,7 @@ class UtxoSplitResult {
   }
 }
 
-class UtxoSplitBuilder {
+class UtxoSplitTransactionBuilder {
   final UtxoState utxo;
   double _feeRate;
   final WalletListItemBase walletListItemBase;
@@ -85,7 +85,7 @@ class UtxoSplitBuilder {
     _cachedNiceSplitCounts = null;
   }
 
-  UtxoSplitBuilder({
+  UtxoSplitTransactionBuilder({
     required this.utxo,
     required double feeRate,
     required this.walletListItemBase,
@@ -138,7 +138,7 @@ class UtxoSplitBuilder {
   }
 
   /// 균등하게 나누기
-  Future<UtxoSplitResult> buildEqualSplit({required int splitCount}) async {
+  Future<UtxoSplitResult> buildEqualAmountSplit({required int splitCount}) async {
     assert(splitCount >= 2);
     Logger.log("--> splitCount: $splitCount");
     await _initOutputVBytes();
@@ -208,7 +208,7 @@ class UtxoSplitBuilder {
   }
 
   /// 직접 나누기
-  Future<UtxoSplitResult> buildCustomSplit({required Map<int, int> amountCountMap}) async {
+  Future<UtxoSplitResult> buildCustomAmountSplit({required Map<int, int> amountCountMap}) async {
     await _initOutputVBytes();
     // dust 검증
     for (final amount in amountCountMap.keys) {

--- a/test/core/transaction/multisig_utxo_split_builder_test.dart
+++ b/test/core/transaction/multisig_utxo_split_builder_test.dart
@@ -61,13 +61,13 @@ void main() {
     // generatedReceiveIndex, generatedChangeIndex 업데이트
     realmManager.realm.write(() {
       final savedWallet = realmManager.realm.find<RealmWalletBase>(wallet.id)!;
-      savedWallet.generatedReceiveIndex = 49;
+      savedWallet.generatedReceiveIndex = 399;
       savedWallet.generatedChangeIndex = 19;
     });
 
-    // receive 주소 50개, change 주소 20개 생성
+    // receive 주소 400개, change 주소 20개 생성
     final List<WalletAddress> addresses = [];
-    for (int i = 0; i < 50; i++) {
+    for (int i = 0; i < 400; i++) {
       final address = wallet.walletBase.getAddress(i, isChange: false);
       final derivationPath = "${wallet.walletBase.derivationPath}/0/$i";
       addresses.add(WalletAddress(address, derivationPath, i, false, false, 0, 0, 0));
@@ -122,6 +122,7 @@ void main() {
 
       expect(result.feeRatio, isA<double>());
       expect(result.feeRatio.toString().split('.').last.length, lessThanOrEqualTo(2));
+      printSplitOutputs(result, '기본 균등 분할');
     });
 
     test('나머지 없이 딱 떨어지는 경우', () async {
@@ -135,17 +136,18 @@ void main() {
 
       final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
       expect(totalCount, 5);
+      printSplitOutputs(result, '균등분할: 나머지 없이 딱 떨어지는 경우');
     });
 
     test('dust 발생 시 SplitOutputDustException', () async {
-      final utxo = createUtxo(20000);
+      final utxo = createUtxo(50000);
       final builder = createBuilder(utxo);
 
       expect(() => builder.buildEqualSplit(splitCount: 200), throwsA(isA<SplitOutputDustException>()));
     });
 
     test('fee가 UTXO amount 대비 너무 크면 SplitInsufficientAmountException', () async {
-      final utxo = createUtxo(20000);
+      final utxo = createUtxo(50000);
       final builder = createBuilder(utxo, feeRate: 1000.0);
 
       expect(() => builder.buildEqualSplit(splitCount: 2), throwsA(isA<SplitInsufficientAmountException>()));
@@ -191,6 +193,42 @@ void main() {
       printSplitOutputs(result, '100000 sats UTXO, 5000 sats per output');
     });
 
+    test('1BTC UTXO를 300000 sats씩 나누기 - outputCount varInt threshold 초과', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildFixedAmountSplit(amountPerOutput: 300000);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap.containsKey(300000), isTrue);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
+      expect(totalCount, greaterThanOrEqualTo(253));
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, '1BTC UTXO, 300000 sats per output');
+    });
+
+    test('1BTC UTXO를 300000 sats씩 나누기 - feeRate 12.5, outputCount varInt threshold 초과', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo, feeRate: 12.5);
+
+      final result = await builder.buildFixedAmountSplit(amountPerOutput: 300000);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap.containsKey(300000), isTrue);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
+      expect(totalCount, greaterThanOrEqualTo(253));
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, '1BTC UTXO, 300000 sats per output, feeRate 12.5');
+    });
+
     test('amountPerOutput이 너무 커서 fee 포함 불가 → SplitInsufficientAmountException', () async {
       // multisig fee가 singlesig보다 크므로 firstLeft는 더욱 음수
       // firstLeft = 100000 - margin - (oneOutputTxVBytes × 1.0) - 99990 ≤ dustLimit + feePerOutput
@@ -230,6 +268,42 @@ void main() {
       final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
       expect(totalAmount + result.estimatedFee, utxo.amount);
       printSplitOutputs(result, 'CustomSplit: 1BTC UTXO, 0.1 x 5, 0.05 x 9 and extra');
+    });
+
+    test('1BTC를 300000 sats 332개로 나누기', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 1.0);
+
+      final result = await builder.buildCustomSplit(amountCountMap: {300000: 332});
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap[300000], 332);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, count) => sum + count);
+      expect(totalCount, 333);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, 'CustomSplit: 1BTC UTXO, 300000 sats x 332 and extra');
+    });
+
+    test('1BTC를 300000 sats 332개로 나누기, feeRate 12.5', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 12.5);
+
+      final result = await builder.buildCustomSplit(amountCountMap: {300000: 332});
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap[300000], 332);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, count) => sum + count);
+      expect(totalCount, 333);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, 'CustomSplit: 1BTC UTXO, 300000 sats x 332, feeRate 12.5 and extra');
     });
 
     test('1BTC를 0.1 x 5, 0.05 x 10로 나누려 하면 SplitInsufficientAmountException', () async {
@@ -321,16 +395,14 @@ void main() {
   group('getMaxEqualSplitCount로 buildEqualSplit 성공 검증', () {
     final testCases = [
       // (amount, feeRate, description)
-      (20000, 1.0, '최소 허용 금액'),
-      (30000, 1.0, '소액 UTXO'),
-      (50000, 1.0, '5만 sats'),
+      (50000, 1.0, '최소 허용 금액 (50000)'),
       (100000, 1.0, '10만 sats'),
       (1000000, 1.0, '100만 sats'),
       (10000000, 1.0, '0.1 BTC'),
-      (100000000, 1.0, '1 BTC'),
       (100000, 5.0, '높은 feeRate'),
       (100000, 50.0, '매우 높은 feeRate'),
       (10000000, 100.0, '높은 금액 + 높은 feeRate'),
+      // (100000000, 1.0, '1 BTC'), // output 약 173010개: 너무 많아서 10분으로도 부족함
     ];
 
     for (final (amount, feeRate, description) in testCases) {

--- a/test/core/transaction/multisig_utxo_split_builder_test.dart
+++ b/test/core/transaction/multisig_utxo_split_builder_test.dart
@@ -263,6 +263,22 @@ void main() {
       expect(counts, orderedEquals([...counts]..sort()));
     });
 
+    test('추천 count로 균등 분할하면 output amount가 대응 nice amount 근사값이 된다', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo);
+
+      final counts = await builder.getNiceSplitCounts();
+
+      expect(counts, [2, 5, 10, 20, 50]);
+      await expectEqualSplitAmountsNearNiceAmounts(builder, {
+        2: 50000000,
+        5: 20000000,
+        10: 10000000,
+        20: 5000000,
+        50: 2000000,
+      });
+    });
+
     test('utxo.amount가 50000일 때 가능한 nice split count만 반환한다', () async {
       final utxo = createUtxo(50000);
       final builder = createBuilder(utxo);
@@ -271,6 +287,16 @@ void main() {
 
       expect(counts, [3, 5]);
       expect(counts, orderedEquals([...counts]..sort()));
+    });
+
+    test('utxo.amount가 50000일 때 추천 count로 균등 분할하면 output amount가 대응 nice amount 근사값이 된다', () async {
+      final utxo = createUtxo(50000);
+      final builder = createBuilder(utxo);
+
+      final counts = await builder.getNiceSplitCounts();
+
+      expect(counts, [3, 5]);
+      await expectEqualSplitAmountsNearNiceAmounts(builder, {3: 20000, 5: 10000});
     });
 
     test('같은 feeRate에서는 캐시된 동일 인스턴스를 반환하고 feeRate 변경 후에는 새로 계산한다', () async {

--- a/test/core/transaction/multisig_utxo_split_builder_test.dart
+++ b/test/core/transaction/multisig_utxo_split_builder_test.dart
@@ -251,6 +251,45 @@ void main() {
     });
   });
 
+  group('Nice Split Counts', () {
+    test('성공 가능한 nice amount 기준 count를 오름차순으로 최대 5개 반환한다', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo);
+
+      final counts = await builder.getNiceSplitCounts();
+
+      expect(counts, [2, 5, 10, 20, 50]);
+      expect(counts.length, lessThanOrEqualTo(5));
+      expect(counts, orderedEquals([...counts]..sort()));
+    });
+
+    test('utxo.amount가 50000일 때 가능한 nice split count만 반환한다', () async {
+      final utxo = createUtxo(50000);
+      final builder = createBuilder(utxo);
+
+      final counts = await builder.getNiceSplitCounts();
+
+      expect(counts, [3, 5]);
+      expect(counts, orderedEquals([...counts]..sort()));
+    });
+
+    test('같은 feeRate에서는 캐시된 동일 인스턴스를 반환하고 feeRate 변경 후에는 새로 계산한다', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo, feeRate: 1.0);
+
+      final first = await builder.getNiceSplitCounts();
+      final cached = await builder.getNiceSplitCounts();
+      expect(cached, same(first));
+
+      builder.feeRate = 50.0;
+
+      final afterFeeChange = await builder.getNiceSplitCounts();
+
+      expect(afterFeeChange, [2, 5, 10, 20, 50]);
+      expect(afterFeeChange, isNot(same(first)));
+    });
+  });
+
   group('직접 나누기 (Custom Split)', () {
     test('1BTC를 0.1 x 5, 0.05 x 9로 나누기', () async {
       final utxo = createUtxo(100000000); // 1 BTC

--- a/test/core/transaction/multisig_utxo_split_builder_test.dart
+++ b/test/core/transaction/multisig_utxo_split_builder_test.dart
@@ -459,7 +459,9 @@ void main() {
   group('getMaxEqualSplitCount로 buildEqualSplit 성공 검증', () {
     final testCases = [
       // (amount, feeRate, description)
-      (50000, 1.0, '최소 허용 금액 (50000)'),
+      (20000, 1.0, '최소 허용 금액 (20000)'),
+      (30000, 1.0, '소액 UTXO'),
+      (50000, 1.0, '5만 sats'),
       (100000, 1.0, '10만 sats'),
       (1000000, 1.0, '100만 sats'),
       (10000000, 1.0, '0.1 BTC'),

--- a/test/core/transaction/multisig_utxo_split_builder_test.dart
+++ b/test/core/transaction/multisig_utxo_split_builder_test.dart
@@ -42,7 +42,7 @@ void main() {
     }
   }
 
-  setUp(() async {
+  setUpAll(() async {
     realmManager = await setupTestRealmManager();
     final realmWalletBase = RealmWalletBase(
       wallet.id,
@@ -98,8 +98,7 @@ void main() {
     });
   });
 
-  tearDown(() {
-    realmManager.reset();
+  tearDownAll(() {
     realmManager.dispose();
   });
 

--- a/test/core/transaction/multisig_utxo_split_builder_test.dart
+++ b/test/core/transaction/multisig_utxo_split_builder_test.dart
@@ -1,6 +1,6 @@
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/core/exceptions/utxo_split/utxo_split_exception.dart';
-import 'package:coconut_wallet/core/transaction/utxo_split_builder.dart';
+import 'package:coconut_wallet/core/transaction/utxo_split_transaction_builder.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
@@ -32,8 +32,12 @@ void main() {
     timestamp: DateTime.now(),
   );
 
-  UtxoSplitBuilder createBuilder(UtxoState utxo, {double feeRate = 1.0}) =>
-      UtxoSplitBuilder(utxo: utxo, feeRate: feeRate, walletListItemBase: wallet, addressRepository: addressRepository);
+  UtxoSplitTransactionBuilder createBuilder(UtxoState utxo, {double feeRate = 1.0}) => UtxoSplitTransactionBuilder(
+    utxo: utxo,
+    feeRate: feeRate,
+    walletListItemBase: wallet,
+    addressRepository: addressRepository,
+  );
 
   void printSplitOutputs(UtxoSplitResult result, String label) {
     print('--- $label ---');
@@ -108,7 +112,7 @@ void main() {
       final utxo = createUtxo(100000);
       final builder = createBuilder(utxo);
 
-      final result = await builder.buildEqualSplit(splitCount: 5);
+      final result = await builder.buildEqualAmountSplit(splitCount: 5);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -128,7 +132,7 @@ void main() {
       final utxo = createUtxo(100270);
       final builder = createBuilder(utxo);
 
-      final result = await builder.buildEqualSplit(splitCount: 5);
+      final result = await builder.buildEqualAmountSplit(splitCount: 5);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -142,14 +146,14 @@ void main() {
       final utxo = createUtxo(50000);
       final builder = createBuilder(utxo);
 
-      expect(() => builder.buildEqualSplit(splitCount: 200), throwsA(isA<SplitOutputDustException>()));
+      expect(() => builder.buildEqualAmountSplit(splitCount: 200), throwsA(isA<SplitOutputDustException>()));
     });
 
     test('fee가 UTXO amount 대비 너무 크면 SplitInsufficientAmountException', () async {
       final utxo = createUtxo(50000);
       final builder = createBuilder(utxo, feeRate: 1000.0);
 
-      expect(() => builder.buildEqualSplit(splitCount: 2), throwsA(isA<SplitInsufficientAmountException>()));
+      expect(() => builder.buildEqualAmountSplit(splitCount: 2), throwsA(isA<SplitInsufficientAmountException>()));
     });
   });
 
@@ -321,7 +325,7 @@ void main() {
       final utxo = createUtxo(100000000); // 1 BTC
       final builder = createBuilder(utxo, feeRate: 1.0);
 
-      final result = await builder.buildCustomSplit(amountCountMap: {10000000: 5, 5000000: 9});
+      final result = await builder.buildCustomAmountSplit(amountCountMap: {10000000: 5, 5000000: 9});
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -338,7 +342,7 @@ void main() {
       final utxo = createUtxo(100000000); // 1 BTC
       final builder = createBuilder(utxo, feeRate: 1.0);
 
-      final result = await builder.buildCustomSplit(amountCountMap: {300000: 332});
+      final result = await builder.buildCustomAmountSplit(amountCountMap: {300000: 332});
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -356,7 +360,7 @@ void main() {
       final utxo = createUtxo(100000000); // 1 BTC
       final builder = createBuilder(utxo, feeRate: 12.5);
 
-      final result = await builder.buildCustomSplit(amountCountMap: {300000: 332});
+      final result = await builder.buildCustomAmountSplit(amountCountMap: {300000: 332});
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -375,7 +379,7 @@ void main() {
       final builder = createBuilder(utxo, feeRate: 1.0);
 
       expect(
-        () => builder.buildCustomSplit(amountCountMap: {10000000: 5, 5000000: 10}),
+        () => builder.buildCustomAmountSplit(amountCountMap: {10000000: 5, 5000000: 10}),
         throwsA(isA<SplitInsufficientAmountException>()),
       );
     });
@@ -385,7 +389,7 @@ void main() {
       final builder = createBuilder(utxo, feeRate: 1.0);
       // 50000000 - 219 = 49999781
       expect(
-        () => builder.buildCustomSplit(amountCountMap: {50000000: 1, 49999781: 1}),
+        () => builder.buildCustomAmountSplit(amountCountMap: {50000000: 1, 49999781: 1}),
         throwsA(isA<SplitOutputDustException>()),
       );
     });
@@ -395,7 +399,7 @@ void main() {
       final builder = createBuilder(utxo, feeRate: 10000000);
 
       try {
-        await builder.buildCustomSplit(amountCountMap: {5000000: 20});
+        await builder.buildCustomAmountSplit(amountCountMap: {5000000: 20});
         fail('SplitInsufficientAmountException should be thrown');
       } on SplitInsufficientAmountException catch (e) {
         expect(e.estimatedFee, isNotNull);
@@ -408,7 +412,7 @@ void main() {
       final utxo = createUtxo(100000);
       final builder = createBuilder(utxo);
 
-      final result = await builder.buildEqualSplit(splitCount: 3);
+      final result = await builder.buildEqualAmountSplit(splitCount: 3);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -421,7 +425,7 @@ void main() {
       final utxo = createUtxo(1000000);
       final builder = createBuilder(utxo);
 
-      final result = await builder.buildEqualSplit(splitCount: 3);
+      final result = await builder.buildEqualAmountSplit(splitCount: 3);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -434,7 +438,7 @@ void main() {
       final utxo = createUtxo(100000);
       final builder = createBuilder(utxo, feeRate: 3.5);
 
-      final result = await builder.buildEqualSplit(splitCount: 3);
+      final result = await builder.buildEqualAmountSplit(splitCount: 3);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -448,7 +452,7 @@ void main() {
       final utxo = createUtxo(1000000);
       final builder = createBuilder(utxo, feeRate: 100.0);
 
-      final result = await builder.buildEqualSplit(splitCount: 2);
+      final result = await builder.buildEqualAmountSplit(splitCount: 2);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -482,13 +486,13 @@ void main() {
         if (maxCount < 2) {
           print('[$description] maxCount < 2 → split 불가, 예외 발생 확인');
           expect(
-            () => builder.buildEqualSplit(splitCount: 2),
+            () => builder.buildEqualAmountSplit(splitCount: 2),
             throwsA(anyOf(isA<SplitOutputDustException>(), isA<SplitInsufficientAmountException>())),
           );
           return;
         }
 
-        final result = await builder.buildEqualSplit(splitCount: maxCount);
+        final result = await builder.buildEqualAmountSplit(splitCount: maxCount);
 
         print('[$description] buildEqualSplit 결과: isSuccess=${result.isSuccess}, estimatedFee=${result.estimatedFee}');
         print('[$description] splitAmountMap: ${result.splitAmountMap}');

--- a/test/core/transaction/multisig_utxo_split_builder_test.dart
+++ b/test/core/transaction/multisig_utxo_split_builder_test.dart
@@ -1,0 +1,368 @@
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/core/exceptions/utxo_split/utxo_split_exception.dart';
+import 'package:coconut_wallet/core/transaction/utxo_split_builder.dart';
+import 'package:coconut_wallet/enums/wallet_enums.dart';
+import 'package:coconut_wallet/model/utxo/utxo_state.dart';
+import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
+import 'package:coconut_wallet/model/wallet/wallet_address.dart';
+import 'package:coconut_wallet/repository/realm/address_repository.dart';
+import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'utxo_split_test_helper.dart';
+import '../../mock/wallet_mock.dart';
+import '../../repository/realm/test_realm_manager.dart';
+
+void main() {
+  NetworkType.setNetworkType(NetworkType.regtest);
+
+  late TestRealmManager realmManager;
+  late AddressRepository addressRepository;
+  final MultisigWalletListItem wallet = WalletMock.createMultiSigWalletItem();
+  const int walletId = 1;
+
+  UtxoState createUtxo(int amount) => UtxoState(
+    transactionHash: 'd77dc64d3eb3454e9c65e5e36989af0eef349d824593dfe2a086fb9dadf7dfc4',
+    index: 0,
+    amount: amount,
+    blockHeight: 100,
+    to: 'bcrt1qh22yl57ys0vaaln9nfp4zczj2fshjnl6gnsh66',
+    derivationPath: "m/48'/1'/0'/2'/0/0",
+    timestamp: DateTime.now(),
+  );
+
+  UtxoSplitBuilder createBuilder(UtxoState utxo, {double feeRate = 1.0}) =>
+      UtxoSplitBuilder(utxo: utxo, feeRate: feeRate, walletListItemBase: wallet, addressRepository: addressRepository);
+
+  void printSplitOutputs(UtxoSplitResult result, String label) {
+    print('--- $label ---');
+    for (final entry in result.splitAmountMap.entries) {
+      print('${entry.key} x ${entry.value}');
+    }
+  }
+
+  setUp(() async {
+    realmManager = await setupTestRealmManager();
+    final realmWalletBase = RealmWalletBase(
+      wallet.id,
+      wallet.colorIndex,
+      wallet.iconIndex,
+      wallet.descriptor,
+      wallet.name,
+      WalletType.multiSignature.name,
+    );
+    addressRepository = AddressRepository(realmManager);
+
+    realmManager.realm.write(() {
+      realmManager.realm.add(realmWalletBase);
+    });
+
+    // generatedReceiveIndex, generatedChangeIndex 업데이트
+    realmManager.realm.write(() {
+      final savedWallet = realmManager.realm.find<RealmWalletBase>(wallet.id)!;
+      savedWallet.generatedReceiveIndex = 49;
+      savedWallet.generatedChangeIndex = 19;
+    });
+
+    // receive 주소 50개, change 주소 20개 생성
+    final List<WalletAddress> addresses = [];
+    for (int i = 0; i < 50; i++) {
+      final address = wallet.walletBase.getAddress(i, isChange: false);
+      final derivationPath = "${wallet.walletBase.derivationPath}/0/$i";
+      addresses.add(WalletAddress(address, derivationPath, i, false, false, 0, 0, 0));
+    }
+    for (int i = 0; i < 20; i++) {
+      final address = wallet.walletBase.getAddress(i, isChange: true);
+      final derivationPath = "${wallet.walletBase.derivationPath}/1/$i";
+      addresses.add(WalletAddress(address, derivationPath, i, true, false, 0, 0, 0));
+    }
+
+    realmManager.realm.write(() {
+      realmManager.realm.addAll<RealmWalletAddress>([
+        ...addresses.map(
+          (addr) => RealmWalletAddress(
+            getWalletAddressId(walletId, addr.index, addr.address),
+            walletId,
+            addr.address,
+            addr.index,
+            addr.isChange,
+            addr.derivationPath,
+            false,
+            0,
+            0,
+            0,
+          ),
+        ),
+      ]);
+    });
+  });
+
+  tearDown(() {
+    realmManager.reset();
+    realmManager.dispose();
+  });
+
+  group('균등 나누기 (Equal Split)', () {
+    test('기본 균등 분할 - 나머지가 있는 경우', () async {
+      // P2WSH (2-of-3 multisig): vSize가 P2WPKH보다 큼
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildEqualSplit(splitCount: 5);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
+      expect(totalCount, 5);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+
+      expect(result.feeRatio, isA<double>());
+      expect(result.feeRatio.toString().split('.').last.length, lessThanOrEqualTo(2));
+    });
+
+    test('나머지 없이 딱 떨어지는 경우', () async {
+      final utxo = createUtxo(100270);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildEqualSplit(splitCount: 5);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
+      expect(totalCount, 5);
+    });
+
+    test('dust 발생 시 SplitOutputDustException', () async {
+      final utxo = createUtxo(20000);
+      final builder = createBuilder(utxo);
+
+      expect(() => builder.buildEqualSplit(splitCount: 200), throwsA(isA<SplitOutputDustException>()));
+    });
+
+    test('fee가 UTXO amount 대비 너무 크면 SplitInsufficientAmountException', () async {
+      final utxo = createUtxo(20000);
+      final builder = createBuilder(utxo, feeRate: 1000.0);
+
+      expect(() => builder.buildEqualSplit(splitCount: 2), throwsA(isA<SplitInsufficientAmountException>()));
+    });
+  });
+
+  group('일정 금액으로 나누기 (Fixed Amount Split)', () {
+    test('기본 성공 케이스 - 1BTC UTXO, 1000000 sats per output', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildFixedAmountSplit(amountPerOutput: 1000000);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap.containsKey(1000000), isTrue);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, '1BTC UTXO, 1000000 sats per output');
+    });
+
+    test('dust 금액 → SplitOutputDustException', () async {
+      // amountPerOutput(100) <= dustLimit(546)
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      expect(() => builder.buildFixedAmountSplit(amountPerOutput: 100), throwsA(isA<SplitOutputDustException>()));
+    });
+
+    test('기본 성공 케이스 - 100000 sats UTXO, 5000 sats per output', () async {
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildFixedAmountSplit(amountPerOutput: 5000);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap.containsKey(5000), isTrue);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, '100000 sats UTXO, 5000 sats per output');
+    });
+
+    test('amountPerOutput이 너무 커서 fee 포함 불가 → SplitInsufficientAmountException', () async {
+      // multisig fee가 singlesig보다 크므로 firstLeft는 더욱 음수
+      // firstLeft = 100000 - margin - (oneOutputTxVBytes × 1.0) - 99990 ≤ dustLimit + feePerOutput
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      expect(
+        () => builder.buildFixedAmountSplit(amountPerOutput: 99990),
+        throwsA(isA<SplitInsufficientAmountException>()),
+      );
+    });
+
+    test('feeRate가 너무 높아서 fee 포함 불가 → SplitInsufficientAmountException', () async {
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo, feeRate: 100000);
+
+      expect(
+        () => builder.buildFixedAmountSplit(amountPerOutput: 5000),
+        throwsA(isA<SplitInsufficientAmountException>()),
+      );
+    });
+  });
+
+  group('직접 나누기 (Custom Split)', () {
+    test('1BTC를 0.1 x 5, 0.05 x 9로 나누기', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 1.0);
+
+      final result = await builder.buildCustomSplit(amountCountMap: {10000000: 5, 5000000: 9});
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap[10000000], 5);
+      expect(result.splitAmountMap[5000000], 9);
+      expect(result.splitAmountMap.keys.length, 3);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, 'CustomSplit: 1BTC UTXO, 0.1 x 5, 0.05 x 9 and extra');
+    });
+
+    test('1BTC를 0.1 x 5, 0.05 x 10로 나누려 하면 SplitInsufficientAmountException', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 1.0);
+
+      expect(
+        () => builder.buildCustomSplit(amountCountMap: {10000000: 5, 5000000: 10}),
+        throwsA(isA<SplitInsufficientAmountException>()),
+      );
+    });
+
+    test('1BTC를 0.5 x 1, 0.49999828 x 1로 나누려 하면 SplitOutputDustException', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 1.0);
+      // 50000000 - 219 = 49999781
+      expect(
+        () => builder.buildCustomSplit(amountCountMap: {50000000: 1, 49999781: 1}),
+        throwsA(isA<SplitOutputDustException>()),
+      );
+    });
+
+    test('feeRate 10000000에서 0.1BTC를 0.05 x 20으로 나누려 하면 SplitInsufficientAmountException이고 estimatedFee가 있다', () async {
+      final utxo = createUtxo(10000000); // 0.1 BTC
+      final builder = createBuilder(utxo, feeRate: 10000000);
+
+      try {
+        await builder.buildCustomSplit(amountCountMap: {5000000: 20});
+        fail('SplitInsufficientAmountException should be thrown');
+      } on SplitInsufficientAmountException catch (e) {
+        expect(e.estimatedFee, isNotNull);
+      }
+    });
+  });
+
+  group('수수료 계산', () {
+    test('estimatedFee 검증', () async {
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildEqualSplit(splitCount: 3);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.estimatedFee, greaterThan(0));
+      expect(result.estimatedFee, lessThan(utxo.amount));
+    });
+
+    test('multisig fee가 singlesig보다 큼', () async {
+      // P2WSH multisig는 P2WPKH singlesig보다 input witness가 크므로 fee가 더 높아야 함
+      final utxo = createUtxo(1000000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildEqualSplit(splitCount: 3);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      // 2-of-3 P2WSH: 1 input, 3 outputs → singlesig 대비 fee가 높음
+      // singlesig 동일 조건에서 약 170 sats, multisig는 그보다 높아야 함
+      expect(result.estimatedFee, greaterThan(170));
+    });
+
+    test('feeRatio 소숫점 2자리 검증', () async {
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo, feeRate: 3.5);
+
+      final result = await builder.buildEqualSplit(splitCount: 3);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      final ratioStr = result.feeRatio.toString();
+      if (ratioStr.contains('.')) {
+        expect(ratioStr.split('.').last.length, lessThanOrEqualTo(2));
+      }
+    });
+
+    test('높은 fee rate에서도 정상 동작', () async {
+      final utxo = createUtxo(1000000);
+      final builder = createBuilder(utxo, feeRate: 100.0);
+
+      final result = await builder.buildEqualSplit(splitCount: 2);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.estimatedFee, greaterThan(0));
+    });
+  });
+
+  group('getMaxEqualSplitCount로 buildEqualSplit 성공 검증', () {
+    final testCases = [
+      // (amount, feeRate, description)
+      (20000, 1.0, '최소 허용 금액'),
+      (30000, 1.0, '소액 UTXO'),
+      (50000, 1.0, '5만 sats'),
+      (100000, 1.0, '10만 sats'),
+      (1000000, 1.0, '100만 sats'),
+      (10000000, 1.0, '0.1 BTC'),
+      (100000000, 1.0, '1 BTC'),
+      (100000, 5.0, '높은 feeRate'),
+      (100000, 50.0, '매우 높은 feeRate'),
+      (10000000, 100.0, '높은 금액 + 높은 feeRate'),
+    ];
+
+    for (final (amount, feeRate, description) in testCases) {
+      test('$description (amount: $amount, feeRate: $feeRate)', () async {
+        final utxo = createUtxo(amount);
+        final builder = createBuilder(utxo, feeRate: feeRate);
+        final maxCount = await builder.getMaxEqualSplitCount();
+
+        print('[$description] amount: $amount, feeRate: $feeRate, maxCount: $maxCount');
+
+        if (maxCount < 2) {
+          print('[$description] maxCount < 2 → split 불가, 예외 발생 확인');
+          expect(
+            () => builder.buildEqualSplit(splitCount: 2),
+            throwsA(anyOf(isA<SplitOutputDustException>(), isA<SplitInsufficientAmountException>())),
+          );
+          return;
+        }
+
+        final result = await builder.buildEqualSplit(splitCount: maxCount);
+
+        print('[$description] buildEqualSplit 결과: isSuccess=${result.isSuccess}, estimatedFee=${result.estimatedFee}');
+        print('[$description] splitAmountMap: ${result.splitAmountMap}');
+        print('[$description] outputs: ${result.transaction!.outputs.map((o) => o.amount).toList()}');
+
+        expect(result.isSuccess, isTrue, reason: 'getMaxEqualSplitCount=$maxCount, buildEqualSplit 실패');
+        expectSuccessfulTransaction(result);
+
+        final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+        print('[$description] totalAmount: $totalAmount, fee: ${result.estimatedFee}, utxo.amount: ${utxo.amount}');
+        expect(totalAmount + result.estimatedFee, utxo.amount);
+      }, timeout: const Timeout(Duration(minutes: 10)));
+    }
+  });
+}

--- a/test/core/transaction/singlesig_utxo_split_builder_test.dart
+++ b/test/core/transaction/singlesig_utxo_split_builder_test.dart
@@ -1,6 +1,6 @@
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/core/exceptions/utxo_split/utxo_split_exception.dart';
-import 'package:coconut_wallet/core/transaction/utxo_split_builder.dart';
+import 'package:coconut_wallet/core/transaction/utxo_split_transaction_builder.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/singlesig_wallet_list_item.dart';
@@ -32,8 +32,12 @@ void main() {
     timestamp: DateTime.now(),
   );
 
-  UtxoSplitBuilder createBuilder(UtxoState utxo, {double feeRate = 1.0}) =>
-      UtxoSplitBuilder(utxo: utxo, feeRate: feeRate, walletListItemBase: wallet, addressRepository: addressRepository);
+  UtxoSplitTransactionBuilder createBuilder(UtxoState utxo, {double feeRate = 1.0}) => UtxoSplitTransactionBuilder(
+    utxo: utxo,
+    feeRate: feeRate,
+    walletListItemBase: wallet,
+    addressRepository: addressRepository,
+  );
 
   void printSplitOutputs(UtxoSplitResult result, String label) {
     print('--- $label ---');
@@ -112,7 +116,7 @@ void main() {
       final utxo = createUtxo(100000);
       final builder = createBuilder(utxo);
 
-      final result = await builder.buildEqualSplit(splitCount: 5);
+      final result = await builder.buildEqualAmountSplit(splitCount: 5);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -139,7 +143,7 @@ void main() {
       final utxo = createUtxo(100270);
       final builder = createBuilder(utxo);
 
-      final result = await builder.buildEqualSplit(splitCount: 5);
+      final result = await builder.buildEqualAmountSplit(splitCount: 5);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -157,14 +161,14 @@ void main() {
       final utxo = createUtxo(50000);
       final builder = createBuilder(utxo);
 
-      expect(() => builder.buildEqualSplit(splitCount: 200), throwsA(isA<SplitOutputDustException>()));
+      expect(() => builder.buildEqualAmountSplit(splitCount: 200), throwsA(isA<SplitOutputDustException>()));
     });
 
     test('fee가 UTXO amount 대비 너무 크면 SplitInsufficientAmountException', () async {
       final utxo = createUtxo(50000);
       final builder = createBuilder(utxo, feeRate: 1000.0);
 
-      expect(() => builder.buildEqualSplit(splitCount: 2), throwsA(isA<SplitInsufficientAmountException>()));
+      expect(() => builder.buildEqualAmountSplit(splitCount: 2), throwsA(isA<SplitInsufficientAmountException>()));
     });
   });
 
@@ -335,7 +339,7 @@ void main() {
       final utxo = createUtxo(100000000); // 1 BTC
       final builder = createBuilder(utxo, feeRate: 1.0);
 
-      final result = await builder.buildCustomSplit(amountCountMap: {10000000: 5, 5000000: 9});
+      final result = await builder.buildCustomAmountSplit(amountCountMap: {10000000: 5, 5000000: 9});
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -352,7 +356,7 @@ void main() {
       final utxo = createUtxo(100000000); // 1 BTC
       final builder = createBuilder(utxo, feeRate: 1.0);
 
-      final result = await builder.buildCustomSplit(amountCountMap: {300000: 332});
+      final result = await builder.buildCustomAmountSplit(amountCountMap: {300000: 332});
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -370,7 +374,7 @@ void main() {
       final utxo = createUtxo(100000000); // 1 BTC
       final builder = createBuilder(utxo, feeRate: 12.5);
 
-      final result = await builder.buildCustomSplit(amountCountMap: {300000: 332});
+      final result = await builder.buildCustomAmountSplit(amountCountMap: {300000: 332});
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -389,7 +393,7 @@ void main() {
       final builder = createBuilder(utxo, feeRate: 1.0);
 
       expect(
-        () => builder.buildCustomSplit(amountCountMap: {10000000: 5, 5000000: 10}),
+        () => builder.buildCustomAmountSplit(amountCountMap: {10000000: 5, 5000000: 10}),
         throwsA(isA<SplitInsufficientAmountException>()),
       );
     });
@@ -399,7 +403,7 @@ void main() {
       final builder = createBuilder(utxo, feeRate: 1.0);
 
       expect(
-        () => builder.buildCustomSplit(amountCountMap: {50000000: 1, 49999828: 1}),
+        () => builder.buildCustomAmountSplit(amountCountMap: {50000000: 1, 49999828: 1}),
         throwsA(isA<SplitOutputDustException>()),
       );
     });
@@ -409,7 +413,7 @@ void main() {
       final builder = createBuilder(utxo, feeRate: 10000000);
 
       try {
-        await builder.buildCustomSplit(amountCountMap: {5000000: 20});
+        await builder.buildCustomAmountSplit(amountCountMap: {5000000: 20});
         fail('SplitInsufficientAmountException should be thrown');
       } on SplitInsufficientAmountException catch (e) {
         expect(e.estimatedFee, isNotNull);
@@ -422,7 +426,7 @@ void main() {
       final utxo = createUtxo(100000);
       final builder = createBuilder(utxo);
 
-      final result = await builder.buildEqualSplit(splitCount: 3);
+      final result = await builder.buildEqualAmountSplit(splitCount: 3);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -435,7 +439,7 @@ void main() {
       final utxo = createUtxo(100000);
       final builder = createBuilder(utxo, feeRate: 3.5);
 
-      final result = await builder.buildEqualSplit(splitCount: 3);
+      final result = await builder.buildEqualAmountSplit(splitCount: 3);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -450,7 +454,7 @@ void main() {
       final utxo = createUtxo(1000000);
       final builder = createBuilder(utxo, feeRate: 100.0);
 
-      final result = await builder.buildEqualSplit(splitCount: 2);
+      final result = await builder.buildEqualAmountSplit(splitCount: 2);
 
       expect(result.isSuccess, isTrue);
       expectSuccessfulTransaction(result);
@@ -483,13 +487,13 @@ void main() {
         if (maxCount < 2) {
           // 분할 불가능한 경우 - 2분할도 실패해야 함
           expect(
-            () => builder.buildEqualSplit(splitCount: 2),
+            () => builder.buildEqualAmountSplit(splitCount: 2),
             throwsA(anyOf(isA<SplitOutputDustException>(), isA<SplitInsufficientAmountException>())),
           );
           return;
         }
 
-        final result = await builder.buildEqualSplit(splitCount: maxCount);
+        final result = await builder.buildEqualAmountSplit(splitCount: maxCount);
 
         expect(result.isSuccess, isTrue, reason: 'getMaxEqualSplitCount=$maxCount, buildEqualSplit 실패');
         expectSuccessfulTransaction(result);

--- a/test/core/transaction/singlesig_utxo_split_builder_test.dart
+++ b/test/core/transaction/singlesig_utxo_split_builder_test.dart
@@ -44,7 +44,7 @@ void main() {
     print('estimatedFee: ${result.estimatedFee}');
   }
 
-  setUp(() async {
+  setUpAll(() async {
     realmManager = await setupTestRealmManager();
     final realmWalletBase = RealmWalletBase(
       wallet.id,
@@ -100,8 +100,7 @@ void main() {
     });
   });
 
-  tearDown(() {
-    realmManager.reset();
+  tearDownAll(() {
     realmManager.dispose();
   });
 

--- a/test/core/transaction/singlesig_utxo_split_builder_test.dart
+++ b/test/core/transaction/singlesig_utxo_split_builder_test.dart
@@ -277,6 +277,22 @@ void main() {
       expect(counts, orderedEquals([...counts]..sort()));
     });
 
+    test('추천 count로 균등 분할하면 output amount가 대응 nice amount 근사값이 된다', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo);
+
+      final counts = await builder.getNiceSplitCounts();
+
+      expect(counts, [2, 5, 10, 20, 50]);
+      await expectEqualSplitAmountsNearNiceAmounts(builder, {
+        2: 50000000,
+        5: 20000000,
+        10: 10000000,
+        20: 5000000,
+        50: 2000000,
+      });
+    });
+
     test('utxo.amount가 50000일 때 가능한 nice split count만 반환한다', () async {
       final utxo = createUtxo(50000);
       final builder = createBuilder(utxo);
@@ -285,6 +301,16 @@ void main() {
 
       expect(counts, [3, 5]);
       expect(counts, orderedEquals([...counts]..sort()));
+    });
+
+    test('utxo.amount가 50000일 때 추천 count로 균등 분할하면 output amount가 대응 nice amount 근사값이 된다', () async {
+      final utxo = createUtxo(50000);
+      final builder = createBuilder(utxo);
+
+      final counts = await builder.getNiceSplitCounts();
+
+      expect(counts, [3, 5]);
+      await expectEqualSplitAmountsNearNiceAmounts(builder, {3: 20000, 5: 10000});
     });
 
     test('같은 feeRate에서는 캐시된 동일 인스턴스를 반환하고 feeRate 변경 후에는 새로 계산한다', () async {

--- a/test/core/transaction/singlesig_utxo_split_builder_test.dart
+++ b/test/core/transaction/singlesig_utxo_split_builder_test.dart
@@ -1,0 +1,365 @@
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/core/exceptions/utxo_split/utxo_split_exception.dart';
+import 'package:coconut_wallet/core/transaction/utxo_split_builder.dart';
+import 'package:coconut_wallet/enums/wallet_enums.dart';
+import 'package:coconut_wallet/model/utxo/utxo_state.dart';
+import 'package:coconut_wallet/model/wallet/singlesig_wallet_list_item.dart';
+import 'package:coconut_wallet/model/wallet/wallet_address.dart';
+import 'package:coconut_wallet/repository/realm/address_repository.dart';
+import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
+import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'utxo_split_test_helper.dart';
+import '../../mock/wallet_mock.dart';
+import '../../repository/realm/test_realm_manager.dart';
+
+void main() {
+  NetworkType.setNetworkType(NetworkType.regtest);
+
+  late TestRealmManager realmManager;
+  late AddressRepository addressRepository;
+  final SinglesigWalletListItem wallet = WalletMock.createSingleSigWalletItem();
+  const int walletId = 1;
+
+  UtxoState createUtxo(int amount) => UtxoState(
+    transactionHash: 'd77dc64d3eb3454e9c65e5e36989af0eef349d824593dfe2a086fb9dadf7dfc4',
+    index: 0,
+    amount: amount,
+    blockHeight: 100,
+    to: 'bcrt1qh22yl57ys0vaaln9nfp4zczj2fshjnl6gnsh66',
+    derivationPath: "m/84'/1'/0'/0/0",
+    timestamp: DateTime.now(),
+  );
+
+  UtxoSplitBuilder createBuilder(UtxoState utxo, {double feeRate = 1.0}) =>
+      UtxoSplitBuilder(utxo: utxo, feeRate: feeRate, walletListItemBase: wallet, addressRepository: addressRepository);
+
+  void printSplitOutputs(UtxoSplitResult result, String label) {
+    print('--- $label ---');
+    for (final entry in result.splitAmountMap.entries) {
+      print('${entry.key} x ${entry.value}');
+    }
+  }
+
+  setUp(() async {
+    realmManager = await setupTestRealmManager();
+    final realmWalletBase = RealmWalletBase(
+      wallet.id,
+      wallet.colorIndex,
+      wallet.iconIndex,
+      wallet.descriptor,
+      wallet.name,
+      WalletType.singleSignature.name,
+    );
+    addressRepository = AddressRepository(realmManager);
+
+    realmManager.realm.write(() {
+      realmManager.realm.add(realmWalletBase);
+    });
+
+    // generatedReceiveIndex, generatedChangeIndex 업데이트
+    realmManager.realm.write(() {
+      final savedWallet = realmManager.realm.find<RealmWalletBase>(wallet.id)!;
+      savedWallet.generatedReceiveIndex = 49;
+      savedWallet.generatedChangeIndex = 19;
+    });
+
+    // receive 주소 50개, change 주소 20개 생성
+    final List<WalletAddress> addresses = [];
+    for (int i = 0; i < 50; i++) {
+      final address = wallet.walletBase.getAddress(i, isChange: false);
+      final derivationPath = "${wallet.walletBase.derivationPath}/0/$i";
+      addresses.add(WalletAddress(address, derivationPath, i, false, false, 0, 0, 0));
+    }
+    for (int i = 0; i < 20; i++) {
+      final address = wallet.walletBase.getAddress(i, isChange: true);
+      final derivationPath = "${wallet.walletBase.derivationPath}/1/$i";
+      addresses.add(WalletAddress(address, derivationPath, i, true, false, 0, 0, 0));
+    }
+
+    realmManager.realm.write(() {
+      realmManager.realm.addAll<RealmWalletAddress>([
+        ...addresses.map(
+          (addr) => RealmWalletAddress(
+            getWalletAddressId(walletId, addr.index, addr.address),
+            walletId,
+            addr.address,
+            addr.index,
+            addr.isChange,
+            addr.derivationPath,
+            false,
+            0,
+            0,
+            0,
+          ),
+        ),
+      ]);
+    });
+  });
+
+  tearDown(() {
+    realmManager.reset();
+    realmManager.dispose();
+  });
+
+  group('균등 나누기 (Equal Split)', () {
+    test('기본 균등 분할 - 나머지가 있는 경우', () async {
+      // P2WPKH: 1 input, 5 outputs → vSize 약 203 → fee = 203 sats (feeRate 1.0)
+      // 100000 - 203 = 99797 → 99797 / 5 = 19959 remainder 2
+      // splitAmountMap: {19959: 3, 19960: 2}
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildEqualSplit(splitCount: 5);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+
+      // splitAmountMap의 총 개수가 5인지 확인
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
+      expect(totalCount, 5);
+
+      // 금액 합 + fee = utxo amount 검증
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+
+      // feeRatio 검증 (소숫점 2자리)
+      expect(result.feeRatio, isA<double>());
+      expect(result.feeRatio.toString().split('.').last.length, lessThanOrEqualTo(2));
+
+      print(result.toString());
+    });
+
+    test('나머지 없이 딱 떨어지는 경우', () async {
+      // fee를 빼고 splitCount로 나누어 떨어지는 금액을 찾아야 함
+      // 1 input, 2 outputs → vSize 약 135 → fee = 135 sats (feeRate 1.0)
+      // 100000 - 135 = 99865 / 2 = 49932.5 → 이건 안 맞으니까
+      // 100270 - 135 = 100135 / 5 = 20027 remainder 0
+      final utxo = createUtxo(100270);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildEqualSplit(splitCount: 5);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      // 딱 떨어지면 splitAmountMap에 1개 항목
+      // (나머지가 0이면 {baseAmount: splitCount}가 되어 1개 key)
+      // 나머지가 있으면 2개 key
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
+      expect(totalCount, 5);
+    });
+
+    test('dust 발생 시 SplitOutputDustException', () async {
+      // 최소 허용 금액에서 많이 쪼개려 하면 dust 발생
+      final utxo = createUtxo(20000);
+      final builder = createBuilder(utxo);
+
+      expect(() => builder.buildEqualSplit(splitCount: 200), throwsA(isA<SplitOutputDustException>()));
+    });
+
+    test('fee가 UTXO amount 대비 너무 크면 SplitInsufficientAmountException', () async {
+      final utxo = createUtxo(20000);
+      final builder = createBuilder(utxo, feeRate: 1000.0);
+
+      expect(() => builder.buildEqualSplit(splitCount: 2), throwsA(isA<SplitInsufficientAmountException>()));
+    });
+  });
+
+  group('일정 금액으로 나누기 (Fixed Amount Split)', () {
+    test('기본 성공 케이스 - 1BTC UTXO, 1000000 sats per output', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildFixedAmountSplit(amountPerOutput: 1000000);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap.containsKey(1000000), isTrue);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, '1BTC UTXO, 1000000 sats per output');
+    });
+
+    test('dust 금액 → SplitOutputDustException', () async {
+      // amountPerOutput(100) <= dustLimit(546)
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      expect(() => builder.buildFixedAmountSplit(amountPerOutput: 100), throwsA(isA<SplitOutputDustException>()));
+    });
+
+    test('기본 성공 케이스 - 100000 sats UTXO, 5000 sats per output', () async {
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildFixedAmountSplit(amountPerOutput: 5000);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap.containsKey(5000), isTrue);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, '100000 sats UTXO, 5000 sats per output');
+    });
+
+    test('amountPerOutput이 너무 커서 fee 포함 불가 → SplitInsufficientAmountException', () async {
+      // firstLeft = 100000 - 10 - 110 - 99990 = -110 ≤ dustLimit(546) + feePerOutput(31)
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      expect(
+        () => builder.buildFixedAmountSplit(amountPerOutput: 99990),
+        throwsA(isA<SplitInsufficientAmountException>()),
+      );
+    });
+
+    test('feeRate가 너무 높아서 fee 포함 불가 → SplitInsufficientAmountException', () async {
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo, feeRate: 100000);
+
+      expect(
+        () => builder.buildFixedAmountSplit(amountPerOutput: 5000),
+        throwsA(isA<SplitInsufficientAmountException>()),
+      );
+    });
+  });
+
+  group('직접 나누기 (Custom Split)', () {
+    test('1BTC를 0.1 x 5, 0.05 x 9로 나누기', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 1.0);
+
+      final result = await builder.buildCustomSplit(amountCountMap: {10000000: 5, 5000000: 9});
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap[10000000], 5);
+      expect(result.splitAmountMap[5000000], 9);
+      expect(result.splitAmountMap.keys.length, 3);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, 'CustomSplit: 1BTC UTXO, 0.1 x 5, 0.05 x 9 and extra');
+    });
+
+    test('1BTC를 0.1 x 5, 0.05 x 10로 나누려 하면 SplitInsufficientAmountException', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 1.0);
+
+      expect(
+        () => builder.buildCustomSplit(amountCountMap: {10000000: 5, 5000000: 10}),
+        throwsA(isA<SplitInsufficientAmountException>()),
+      );
+    });
+
+    test('1BTC를 0.5 x 1, 0.49999828 x 1로 나누려 하면 SplitOutputDustException', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 1.0);
+
+      expect(
+        () => builder.buildCustomSplit(amountCountMap: {50000000: 1, 49999828: 1}),
+        throwsA(isA<SplitOutputDustException>()),
+      );
+    });
+
+    test('feeRate 10000000에서 0.1BTC를 0.05 x 20으로 나누려 하면 SplitInsufficientAmountException이고 estimatedFee가 있다', () async {
+      final utxo = createUtxo(10000000); // 0.1 BTC
+      final builder = createBuilder(utxo, feeRate: 10000000);
+
+      try {
+        await builder.buildCustomSplit(amountCountMap: {5000000: 20});
+        fail('SplitInsufficientAmountException should be thrown');
+      } on SplitInsufficientAmountException catch (e) {
+        expect(e.estimatedFee, isNotNull);
+      }
+    });
+  });
+
+  group('수수료 계산', () {
+    test('estimatedFee 검증', () async {
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildEqualSplit(splitCount: 3);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      // 실제 fee는 TransactionBuilder가 계산하므로 양수이고 utxo amount 미만인지 검증
+      expect(result.estimatedFee, greaterThan(0));
+      expect(result.estimatedFee, lessThan(utxo.amount));
+    });
+
+    test('feeRatio 소숫점 2자리 검증', () async {
+      final utxo = createUtxo(100000);
+      final builder = createBuilder(utxo, feeRate: 3.5);
+
+      final result = await builder.buildEqualSplit(splitCount: 3);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      // feeRatio가 소숫점 2자리 이내인지 검증
+      final ratioStr = result.feeRatio.toString();
+      if (ratioStr.contains('.')) {
+        expect(ratioStr.split('.').last.length, lessThanOrEqualTo(2));
+      }
+    });
+
+    test('높은 fee rate에서도 정상 동작', () async {
+      final utxo = createUtxo(1000000);
+      final builder = createBuilder(utxo, feeRate: 100.0);
+
+      final result = await builder.buildEqualSplit(splitCount: 2);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.estimatedFee, greaterThan(0));
+    });
+  });
+
+  group('getMaxEqualSplitCount로 buildEqualSplit 성공 검증', () {
+    final testCases = [
+      //(amount, feeRate, description)
+      (20000, 1.0, '최소 허용 금액'),
+      (30000, 1.0, '소액 UTXO'),
+      (50000, 1.0, '5만 sats'),
+      (100000, 1.0, '10만 sats'),
+      (1000000, 1.0, '100만 sats'),
+      (10000000, 1.0, '0.1 BTC'),
+      // (100000000, 1.0, '1 BTC'), // 173010개: 너무 많아서 10분으로도 부족함
+      (100000, 5.0, '높은 feeRate'),
+      (100000, 50.0, '매우 높은 feeRate'),
+      (10000000, 100.0, '높은 금액 + 높은 feeRate'), // estimatedFee: 8498810.0 8498975
+    ];
+
+    for (final (amount, feeRate, description) in testCases) {
+      test('$description (amount: $amount, feeRate: $feeRate)', () async {
+        final utxo = createUtxo(amount);
+        final builder = createBuilder(utxo, feeRate: feeRate);
+        final maxCount = await builder.getMaxEqualSplitCount();
+
+        print('--> maxCount: $maxCount');
+        if (maxCount < 2) {
+          // 분할 불가능한 경우 - 2분할도 실패해야 함
+          expect(
+            () => builder.buildEqualSplit(splitCount: 2),
+            throwsA(anyOf(isA<SplitOutputDustException>(), isA<SplitInsufficientAmountException>())),
+          );
+          return;
+        }
+
+        final result = await builder.buildEqualSplit(splitCount: maxCount);
+
+        expect(result.isSuccess, isTrue, reason: 'getMaxEqualSplitCount=$maxCount, buildEqualSplit 실패');
+        expectSuccessfulTransaction(result);
+
+        // 금액 합 + fee = utxo amount
+        final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+        expect(totalAmount + result.estimatedFee, utxo.amount);
+      }, timeout: const Timeout(Duration(minutes: 10)));
+    }
+  });
+}

--- a/test/core/transaction/singlesig_utxo_split_builder_test.dart
+++ b/test/core/transaction/singlesig_utxo_split_builder_test.dart
@@ -265,6 +265,45 @@ void main() {
     });
   });
 
+  group('Nice Split Counts', () {
+    test('성공 가능한 nice amount 기준 count를 오름차순으로 최대 5개 반환한다', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo);
+
+      final counts = await builder.getNiceSplitCounts();
+
+      expect(counts, [2, 5, 10, 20, 50]);
+      expect(counts.length, lessThanOrEqualTo(5));
+      expect(counts, orderedEquals([...counts]..sort()));
+    });
+
+    test('utxo.amount가 50000일 때 가능한 nice split count만 반환한다', () async {
+      final utxo = createUtxo(50000);
+      final builder = createBuilder(utxo);
+
+      final counts = await builder.getNiceSplitCounts();
+
+      expect(counts, [3, 5]);
+      expect(counts, orderedEquals([...counts]..sort()));
+    });
+
+    test('같은 feeRate에서는 캐시된 동일 인스턴스를 반환하고 feeRate 변경 후에는 새로 계산한다', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo, feeRate: 1.0);
+
+      final first = await builder.getNiceSplitCounts();
+      final cached = await builder.getNiceSplitCounts();
+      expect(cached, same(first));
+
+      builder.feeRate = 50.0;
+
+      final afterFeeChange = await builder.getNiceSplitCounts();
+
+      expect(afterFeeChange, [2, 5, 10, 20, 50]);
+      expect(afterFeeChange, isNot(same(first)));
+    });
+  });
+
   group('직접 나누기 (Custom Split)', () {
     test('1BTC를 0.1 x 5, 0.05 x 9로 나누기', () async {
       final utxo = createUtxo(100000000); // 1 BTC

--- a/test/core/transaction/singlesig_utxo_split_builder_test.dart
+++ b/test/core/transaction/singlesig_utxo_split_builder_test.dart
@@ -40,6 +40,8 @@ void main() {
     for (final entry in result.splitAmountMap.entries) {
       print('${entry.key} x ${entry.value}');
     }
+
+    print('estimatedFee: ${result.estimatedFee}');
   }
 
   setUp(() async {
@@ -61,13 +63,13 @@ void main() {
     // generatedReceiveIndex, generatedChangeIndex 업데이트
     realmManager.realm.write(() {
       final savedWallet = realmManager.realm.find<RealmWalletBase>(wallet.id)!;
-      savedWallet.generatedReceiveIndex = 49;
+      savedWallet.generatedReceiveIndex = 399;
       savedWallet.generatedChangeIndex = 19;
     });
 
-    // receive 주소 50개, change 주소 20개 생성
+    // receive 주소 400개, change 주소 20개 생성
     final List<WalletAddress> addresses = [];
-    for (int i = 0; i < 50; i++) {
+    for (int i = 0; i < 400; i++) {
       final address = wallet.walletBase.getAddress(i, isChange: false);
       final derivationPath = "${wallet.walletBase.derivationPath}/0/$i";
       addresses.add(WalletAddress(address, derivationPath, i, false, false, 0, 0, 0));
@@ -107,7 +109,7 @@ void main() {
     test('기본 균등 분할 - 나머지가 있는 경우', () async {
       // P2WPKH: 1 input, 5 outputs → vSize 약 203 → fee = 203 sats (feeRate 1.0)
       // 100000 - 203 = 99797 → 99797 / 5 = 19959 remainder 2
-      // splitAmountMap: {19959: 3, 19960: 2}
+      // splitAmountMap: {19959: 3, 19960: 2} 203/ 5 = 40 r 3
       final utxo = createUtxo(100000);
       final builder = createBuilder(utxo);
 
@@ -127,8 +129,7 @@ void main() {
       // feeRatio 검증 (소숫점 2자리)
       expect(result.feeRatio, isA<double>());
       expect(result.feeRatio.toString().split('.').last.length, lessThanOrEqualTo(2));
-
-      print(result.toString());
+      printSplitOutputs(result, '기본 균등 분할');
     });
 
     test('나머지 없이 딱 떨어지는 경우', () async {
@@ -149,18 +150,19 @@ void main() {
 
       final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
       expect(totalCount, 5);
+      printSplitOutputs(result, '균등분할: 나머지 없이 딱 떨어지는 경우');
     });
 
     test('dust 발생 시 SplitOutputDustException', () async {
       // 최소 허용 금액에서 많이 쪼개려 하면 dust 발생
-      final utxo = createUtxo(20000);
+      final utxo = createUtxo(50000);
       final builder = createBuilder(utxo);
 
       expect(() => builder.buildEqualSplit(splitCount: 200), throwsA(isA<SplitOutputDustException>()));
     });
 
     test('fee가 UTXO amount 대비 너무 크면 SplitInsufficientAmountException', () async {
-      final utxo = createUtxo(20000);
+      final utxo = createUtxo(50000);
       final builder = createBuilder(utxo, feeRate: 1000.0);
 
       expect(() => builder.buildEqualSplit(splitCount: 2), throwsA(isA<SplitInsufficientAmountException>()));
@@ -206,6 +208,42 @@ void main() {
       printSplitOutputs(result, '100000 sats UTXO, 5000 sats per output');
     });
 
+    test('1BTC UTXO를 300000 sats씩 나누기 - outputCount varInt threshold 초과', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo);
+
+      final result = await builder.buildFixedAmountSplit(amountPerOutput: 300000);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap.containsKey(300000), isTrue);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
+      expect(totalCount, greaterThanOrEqualTo(253));
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, '1BTC UTXO, 300000 sats per output');
+    });
+
+    test('1BTC UTXO를 300000 sats씩 나누기 - feeRate 12.5, outputCount varInt threshold 초과', () async {
+      final utxo = createUtxo(100000000);
+      final builder = createBuilder(utxo, feeRate: 12.5);
+
+      final result = await builder.buildFixedAmountSplit(amountPerOutput: 300000);
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap.containsKey(300000), isTrue);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
+      expect(totalCount, greaterThanOrEqualTo(253));
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, '1BTC UTXO, 300000 sats per output, feeRate 12.5');
+    });
+
     test('amountPerOutput이 너무 커서 fee 포함 불가 → SplitInsufficientAmountException', () async {
       // firstLeft = 100000 - 10 - 110 - 99990 = -110 ≤ dustLimit(546) + feePerOutput(31)
       final utxo = createUtxo(100000);
@@ -244,6 +282,42 @@ void main() {
       final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
       expect(totalAmount + result.estimatedFee, utxo.amount);
       printSplitOutputs(result, 'CustomSplit: 1BTC UTXO, 0.1 x 5, 0.05 x 9 and extra');
+    });
+
+    test('1BTC를 300000 sats 332개로 나누기', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 1.0);
+
+      final result = await builder.buildCustomSplit(amountCountMap: {300000: 332});
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap[300000], 332);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, count) => sum + count);
+      expect(totalCount, 333);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, 'CustomSplit: 1BTC UTXO, 300000 sats x 332 and extra');
+    });
+
+    test('1BTC를 300000 sats 332개로 나누기, feeRate 12.5', () async {
+      final utxo = createUtxo(100000000); // 1 BTC
+      final builder = createBuilder(utxo, feeRate: 12.5);
+
+      final result = await builder.buildCustomSplit(amountCountMap: {300000: 332});
+
+      expect(result.isSuccess, isTrue);
+      expectSuccessfulTransaction(result);
+      expect(result.splitAmountMap[300000], 332);
+
+      final totalCount = result.splitAmountMap.values.fold<int>(0, (sum, count) => sum + count);
+      expect(totalCount, 333);
+
+      final totalAmount = result.splitAmountMap.entries.fold<int>(0, (sum, entry) => sum + entry.key * entry.value);
+      expect(totalAmount + result.estimatedFee, utxo.amount);
+      printSplitOutputs(result, 'CustomSplit: 1BTC UTXO, 300000 sats x 332, feeRate 12.5 and extra');
     });
 
     test('1BTC를 0.1 x 5, 0.05 x 10로 나누려 하면 SplitInsufficientAmountException', () async {
@@ -323,16 +397,14 @@ void main() {
   group('getMaxEqualSplitCount로 buildEqualSplit 성공 검증', () {
     final testCases = [
       //(amount, feeRate, description)
-      (20000, 1.0, '최소 허용 금액'),
-      (30000, 1.0, '소액 UTXO'),
-      (50000, 1.0, '5만 sats'),
+      (50000, 1.0, '최소 허용 금액'),
       (100000, 1.0, '10만 sats'),
       (1000000, 1.0, '100만 sats'),
       (10000000, 1.0, '0.1 BTC'),
-      // (100000000, 1.0, '1 BTC'), // 173010개: 너무 많아서 10분으로도 부족함
       (100000, 5.0, '높은 feeRate'),
       (100000, 50.0, '매우 높은 feeRate'),
       (10000000, 100.0, '높은 금액 + 높은 feeRate'), // estimatedFee: 8498810.0 8498975
+      // (100000000, 1.0, '1 BTC'), // output 173010개: 너무 많아서 10분으로도 부족함
     ];
 
     for (final (amount, feeRate, description) in testCases) {

--- a/test/core/transaction/singlesig_utxo_split_builder_test.dart
+++ b/test/core/transaction/singlesig_utxo_split_builder_test.dart
@@ -461,7 +461,9 @@ void main() {
   group('getMaxEqualSplitCount로 buildEqualSplit 성공 검증', () {
     final testCases = [
       //(amount, feeRate, description)
-      (50000, 1.0, '최소 허용 금액'),
+      (20000, 1.0, '최소 허용 금액 (20000)'),
+      (30000, 1.0, '소액 UTXO'),
+      (50000, 1.0, '5만 sats'),
       (100000, 1.0, '10만 sats'),
       (1000000, 1.0, '100만 sats'),
       (10000000, 1.0, '0.1 BTC'),

--- a/test/core/transaction/utxo_split_test_helper.dart
+++ b/test/core/transaction/utxo_split_test_helper.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
-import 'package:coconut_wallet/core/transaction/utxo_split_builder.dart';
+import 'package:coconut_wallet/core/transaction/utxo_split_transaction_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void expectSuccessfulTransaction(UtxoSplitResult result, {int? expectedOutputCount}) {
@@ -19,12 +19,12 @@ void expectSuccessfulTransaction(UtxoSplitResult result, {int? expectedOutputCou
 }
 
 Future<void> expectEqualSplitAmountsNearNiceAmounts(
-  UtxoSplitBuilder builder,
+  UtxoSplitTransactionBuilder builder,
   Map<int, int> expectedNiceAmountByCount, {
   int tolerance = 10000,
 }) async {
   for (final entry in expectedNiceAmountByCount.entries) {
-    final result = await builder.buildEqualSplit(splitCount: entry.key);
+    final result = await builder.buildEqualAmountSplit(splitCount: entry.key);
 
     expectSuccessfulTransaction(result, expectedOutputCount: entry.key);
     expect(result.splitAmountMap.keys, everyElement(inInclusiveRange(entry.value - tolerance, entry.value)));

--- a/test/core/transaction/utxo_split_test_helper.dart
+++ b/test/core/transaction/utxo_split_test_helper.dart
@@ -17,3 +17,16 @@ void expectSuccessfulTransaction(UtxoSplitResult result, {int? expectedOutputCou
     expect(output.amount, greaterThan(dustLimit));
   }
 }
+
+Future<void> expectEqualSplitAmountsNearNiceAmounts(
+  UtxoSplitBuilder builder,
+  Map<int, int> expectedNiceAmountByCount, {
+  int tolerance = 10000,
+}) async {
+  for (final entry in expectedNiceAmountByCount.entries) {
+    final result = await builder.buildEqualSplit(splitCount: entry.key);
+
+    expectSuccessfulTransaction(result, expectedOutputCount: entry.key);
+    expect(result.splitAmountMap.keys, everyElement(inInclusiveRange(entry.value - tolerance, entry.value)));
+  }
+}

--- a/test/core/transaction/utxo_split_test_helper.dart
+++ b/test/core/transaction/utxo_split_test_helper.dart
@@ -1,0 +1,19 @@
+import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
+import 'package:coconut_wallet/core/transaction/utxo_split_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void expectSuccessfulTransaction(UtxoSplitResult result, {int? expectedOutputCount}) {
+  expect(result.isSuccess, isTrue);
+  expect(result.transaction, isNotNull);
+  expect(result.transaction!.inputs.length, 1);
+
+  final splitMapOutputCount = result.splitAmountMap.values.fold<int>(0, (sum, c) => sum + c);
+  expect(result.transaction!.outputs.length, splitMapOutputCount);
+  if (expectedOutputCount != null) {
+    expect(result.transaction!.outputs.length, expectedOutputCount);
+  }
+
+  for (final output in result.transaction!.outputs) {
+    expect(output.amount, greaterThan(dustLimit));
+  }
+}


### PR DESCRIPTION
# 구현 사항 요약
Builder 생성 후 변경할 수 있는 것은 feeRate 뿐입니다.

사용하는 쪽에서 필요에 따라 
* getMaxEqualSplitCount: 최대 분할 가능 개수 반환
* buildEqualSplit: 균등 나누기
* buildFixedAmountSplit: 고정값 나누기
* buildCustomSplit: 직접 나누기
* getNiceSplitCounts: niceAmounts로 나눠지게 하는 나누기 값 최대 5개 반환
* set feeRate
호출해서 사용합니다.

## 테스트 코드
1. singlesig_utxo_split_builder_test.dart
2. multisig_utxo_split_builder_test.dart
두 파일의 테스트케이스들은 조건이 모두 같습니다. 