### PR TITLE
enhance(dustLimit): AddressType별 DustThreshold 적용, 기존 dustLimit 제거

### DIFF
--- a/lib/constants/bitcoin_network_rules.dart
+++ b/lib/constants/bitcoin_network_rules.dart
@@ -1,1 +1,0 @@
-const int dustLimit = 546;

--- a/lib/constants/dust_constants.dart
+++ b/lib/constants/dust_constants.dart
@@ -8,11 +8,27 @@ class DustThresholds {
   static const int p2sh = 888;
   static const int p2wpkhInP2sh = 273;
 
-  static Map<AddressType, int> thresholds = {
+  static final Map<AddressType, int> thresholds = {
     AddressType.p2wpkh: p2wpkh,
     AddressType.p2wsh: p2wsh,
     AddressType.p2pkh: p2pkh,
     AddressType.p2sh: p2sh,
     AddressType.p2wpkhInP2sh: p2wpkhInP2sh,
   };
+
+  static int getByAddressType(AddressType addressType) {
+    if (addressType.isTaproot) {
+      return taproot;
+    }
+
+    final threshold = thresholds[addressType];
+    if (threshold == null) {
+      throw Exception('Unsupported Address Type: $addressType');
+    }
+    return threshold;
+  }
+}
+
+extension AddressTypeDustThresholdX on AddressType {
+  int get dustThreshold => DustThresholds.getByAddressType(this);
 }

--- a/lib/core/transaction/fee_bumping/cpfp_builder.dart
+++ b/lib/core/transaction/fee_bumping/cpfp_builder.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:coconut_lib/coconut_lib.dart';
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
+import 'package:coconut_wallet/constants/dust_constants.dart';
 import 'package:coconut_wallet/core/exceptions/cpfp_creation/cpfp_creation_exception.dart';
 import 'package:coconut_wallet/core/exceptions/transaction_creation/transaction_creation_exception.dart';
 import 'package:coconut_wallet/core/transaction/fee_bumping/cpfp_preparer.dart';
@@ -56,6 +56,7 @@ class CpfpBuildResult {
 
 class CpfpBuilder {
   final WalletListItemBase walletListItemBase;
+  int get _dustThreshold => walletListItemBase.walletType.addressType.dustThreshold;
 
   /// child tx의 단일 output 주소 (sweep 대상)
   final WalletAddress nextReceiveAddress;
@@ -232,7 +233,7 @@ class CpfpBuilder {
     }
     final recalculatedFeeRate = _calculateMinimumChildFeeRate(estimatedVSize);
     final inputSum = inputs.fold<int>(0, (cur, utxo) => cur + utxo.amount);
-    final deficitAmount = txBuildResult.estimatedFee - (inputSum - dustLimit);
+    final deficitAmount = txBuildResult.estimatedFee - (inputSum - _dustThreshold);
 
     return CpfpBuildResult(
       addedInputs: addedUtxo,

--- a/lib/core/transaction/fee_bumping/rbf_builder.dart
+++ b/lib/core/transaction/fee_bumping/rbf_builder.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_lib/coconut_lib.dart';
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
+import 'package:coconut_wallet/constants/dust_constants.dart';
 import 'package:coconut_wallet/core/transaction/fee_bumping/rbf_preparer.dart';
 import 'package:coconut_wallet/extensions/transaction_extension.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
@@ -69,6 +69,7 @@ class RbfBuilder {
 
   final WalletListItemBase walletListItemBase;
   final WalletAddress nextChangeAddress;
+  int get _dustThreshold => walletListItemBase.walletType.addressType.dustThreshold;
 
   late final TransactionRecord _pendingTx;
   late final List<UtxoState> _inputUtxos;
@@ -185,7 +186,7 @@ class RbfBuilder {
 
   /// selfOutput의 amount를 줄이거나 제거하여 deficitAmount를 줄이는 함수.
   ///
-  /// - 부분 차감: selfOutput.amount - deficit > dustLimit → amount만 줄임 (vSize 변화 없음)
+  /// - 부분 차감: selfOutput.amount - deficit > dust threshold → amount만 줄임 (vSize 변화 없음)
   /// - 전체 제거: 위 조건 불만족 → output 전체 제거.
   ///   deficit -= (selfOutput.amount + ceil(outputBytes * feeRate))
   ///   output이 제거되면 vSize가 줄어들고, 그 절약된 fee도 deficit 감소에 기여함.
@@ -201,7 +202,7 @@ class RbfBuilder {
     int index = selfOutputs!.length - 1;
     for (; index >= 0; index--) {
       final selfOutput = selfOutputs![index];
-      if (selfOutput.amount - leftDeficit >= dustLimit) {
+      if (selfOutput.amount - leftDeficit > _dustThreshold) {
         final (:result, :recipients) = _trySelfOutputReductionSweep(newRecipients, selfOutput, feeRate);
         if (result != null) {
           return (result: result, newRecipients: recipients!, remainingDeficit: 0, vSizeReduced: vSizeReduced);
@@ -209,11 +210,11 @@ class RbfBuilder {
       }
       // recipients에 selfOutput 1개만 남은 경우
       if (newRecipients.length == 1) {
-        if (selfOutput.amount <= dustLimit + 1) {
+        if (selfOutput.amount <= _dustThreshold + 1) {
           // 0 ~ 547
           break;
         } else {
-          const int lastSelfOutputAmount = dustLimit + 1;
+          final int lastSelfOutputAmount = _dustThreshold + 1;
           newRecipients[selfOutput.address] = lastSelfOutputAmount;
           leftDeficit -= (selfOutput.amount - lastSelfOutputAmount);
         }
@@ -381,7 +382,7 @@ class RbfBuilder {
     );
     // coconut_lib change output의 dust 기준에 걸려 수수료로 전환된 경우
     if (foundChangeOutput == null) return null;
-    return foundChangeOutput.amount <= dustLimit;
+    return foundChangeOutput.amount <= _dustThreshold;
   }
 
   /// 트랜잭션 생성 시도 시 항상 맨 처음 호출된다고 가정

--- a/lib/core/transaction/transaction_builder.dart
+++ b/lib/core/transaction/transaction_builder.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_lib/coconut_lib.dart';
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
+import 'package:coconut_wallet/constants/dust_constants.dart';
 import 'package:coconut_wallet/core/transaction/utxo_selector.dart';
 import 'package:coconut_wallet/extensions/transaction_extension.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
@@ -81,6 +81,7 @@ class TransactionBuilder {
   Transaction? _transaction;
   int? _estimatedFeeByFeeEstimator; // 처음엔 추정된 값으로 초기화됨
   int? _subtractedFeeFromAmount; // 최종 생성된 tx.estimateFee()와 실제로 사용되는 fee가 다를 때 설정됨
+  int get _dustThreshold => walletListItemBase.walletType.addressType.dustThreshold;
 
   TransactionBuilder({
     required this.availableUtxos,
@@ -244,7 +245,7 @@ class TransactionBuilder {
           feeRate,
           walletListItemBase.walletBase,
         );
-        if (tx.outputs.first.amount <= dustLimit) {
+        if (tx.outputs.first.amount <= _dustThreshold) {
           throw SendAmountTooLowException(
             estimatedFee: tx.estimateFee(
               feeRate,
@@ -270,7 +271,7 @@ class TransactionBuilder {
 
     int initialFee = _estimatedFeeByFeeEstimator!;
     int sendAmount = maxUsedAmount - initialFee;
-    if (sendAmount <= dustLimit) {
+    if (sendAmount <= _dustThreshold) {
       throw SendAmountTooLowException(estimatedFee: _estimatedFeeByFeeEstimator!);
     }
 
@@ -312,7 +313,7 @@ class TransactionBuilder {
 
           initialFee = realEstimatedFee;
           sendAmount = maxUsedAmount - realEstimatedFee;
-          if (sendAmount <= dustLimit) {
+          if (sendAmount <= _dustThreshold) {
             /// estimatedFee + sendAmount < maxUsedAmount이더라도 반환
             return tx;
           }
@@ -329,7 +330,7 @@ class TransactionBuilder {
         if (estimatedFee != null) {
           initialFee = estimatedFee;
           sendAmount = maxUsedAmount - initialFee;
-          if (sendAmount <= dustLimit) {
+          if (sendAmount <= _dustThreshold) {
             throw SendAmountTooLowException(estimatedFee: initialFee);
           }
           continue;
@@ -364,7 +365,7 @@ class TransactionBuilder {
           feeRate,
           walletListItemBase.walletBase,
         );
-        if (tx.outputs.last.amount <= dustLimit) {
+        if (tx.outputs.last.amount <= _dustThreshold) {
           throw SendAmountTooLowException(
             estimatedFee: tx.estimateFee(
               feeRate,
@@ -389,7 +390,7 @@ class TransactionBuilder {
     final lastRecipient = recipients.entries.last;
     int initialFee = _estimatedFeeByFeeEstimator!;
     int finalLastSendAmount = lastRecipient.value - initialFee;
-    if (finalLastSendAmount <= dustLimit) {
+    if (finalLastSendAmount <= _dustThreshold) {
       throw SendAmountTooLowException(estimatedFee: _estimatedFeeByFeeEstimator!);
     }
 
@@ -431,7 +432,7 @@ class TransactionBuilder {
 
           initialFee = realEstimatedFee;
           finalLastSendAmount = lastRecipient.value - initialFee;
-          if (finalLastSendAmount <= dustLimit) {
+          if (finalLastSendAmount <= _dustThreshold) {
             return tx;
           }
           updatedRecipients[recipients.entries.last.key] = finalLastSendAmount;
@@ -449,7 +450,7 @@ class TransactionBuilder {
         if (estimatedFee != null) {
           initialFee = estimatedFee;
           finalLastSendAmount = lastRecipient.value - initialFee;
-          if (finalLastSendAmount <= dustLimit) {
+          if (finalLastSendAmount <= _dustThreshold) {
             throw SendAmountTooLowException(estimatedFee: initialFee);
           }
           updatedRecipients[recipients.entries.last.key] = finalLastSendAmount;

--- a/lib/core/transaction/utxo_selector.dart
+++ b/lib/core/transaction/utxo_selector.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_lib/coconut_lib.dart';
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
+import 'package:coconut_wallet/constants/dust_constants.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/core/exceptions/transaction_creation/transaction_creation_exception.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
@@ -91,7 +91,7 @@ class UtxoSelector {
     }
 
     // 보내는 금액에서 제외하는 경우, amount 충분한지 확인
-    if (isFeeSubtractedFromAmount && paymentMap.entries.last.value - estimatedFee <= dustLimit) {
+    if (isFeeSubtractedFromAmount && paymentMap.entries.last.value - estimatedFee <= addressType.dustThreshold) {
       throw SendAmountTooLowException(
         message: 'Last output amount is too small to cover fee.',
         estimatedFee: estimatedFee,

--- a/lib/model/utxo/utxo_bucket.dart
+++ b/lib/model/utxo/utxo_bucket.dart
@@ -1,4 +1,3 @@
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 
 class UtxoBucket {
@@ -10,19 +9,21 @@ class UtxoBucket {
 }
 
 /// UTXO 금액 구간 정의 (그래프, 모달 등 공통 사용)
-const utxoBucketRanges = [
-  (label: 'whale', min: 1_000_000_000, max: 2_100_000_000_000_000),
-  (label: 'whole', min: 100_000_000, max: 999_999_999),
-  (label: 'huge', min: 10_000_000, max: 99_999_999),
-  (label: 'large', min: 1_000_001, max: 9_999_999),
-  (label: 'meduim', min: 100_001, max: 1_000_000),
-  (label: 'small', min: 10_001, max: 100_000),
-  (label: 'tiny', min: dustLimit + 1, max: 10_000),
-  (label: 'dust', min: 0, max: dustLimit),
-];
+List<({String label, int min, int max})> getUtxoBucketRanges({required int dustThreshold}) {
+  return [
+    (label: 'whale', min: 1_000_000_000, max: 2_100_000_000_000_000),
+    (label: 'whole', min: 100_000_000, max: 999_999_999),
+    (label: 'huge', min: 10_000_000, max: 99_999_999),
+    (label: 'large', min: 1_000_001, max: 9_999_999),
+    (label: 'meduim', min: 100_001, max: 1_000_000),
+    (label: 'small', min: 10_001, max: 100_000),
+    (label: 'tiny', min: dustThreshold + 1, max: 10_000),
+    (label: 'dust', min: 0, max: dustThreshold),
+  ];
+}
 
-List<UtxoBucket> bucketize(List<UtxoState> utxos) {
-  return utxoBucketRanges
+List<UtxoBucket> bucketize(List<UtxoState> utxos, {required int dustThreshold}) {
+  return getUtxoBucketRanges(dustThreshold: dustThreshold)
       .map((r) {
         final list =
             utxos.where((u) => u.amount >= r.min && u.amount <= r.max).toList()..sort((a, b) {

--- a/lib/providers/view_model/send/refactor/send_view_model.dart
+++ b/lib/providers/view_model/send/refactor/send_view_model.dart
@@ -1,5 +1,5 @@
 import 'package:coconut_lib/coconut_lib.dart';
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
+import 'package:coconut_wallet/constants/dust_constants.dart';
 import 'package:coconut_wallet/core/transaction/transaction_builder.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/enums/transaction_enums.dart';
@@ -70,13 +70,13 @@ enum AmountError {
   bool get isError => this != AmountError.none;
   bool get isNotError => this == AmountError.none;
 
-  String getMessage(BitcoinUnit currentUnit) {
+  String getMessage(BitcoinUnit currentUnit, {required int dustThreshold}) {
     switch (this) {
       case AmountError.insufficientBalance:
         return t.errors.insufficient_balance;
       case AmountError.minimumAmount:
         return t.alert.error_send.minimum_amount(
-          amount: currentUnit.displayBitcoinAmount(dustLimit + 1, withUnit: true),
+          amount: currentUnit.displayBitcoinAmount(dustThreshold + 1, withUnit: true),
         );
       case AmountError.none:
         return "";
@@ -197,6 +197,8 @@ class SendViewModel extends ChangeNotifier {
 
   bool get isNetworkOn => _isNetworkOn == true;
   num get _dustLimitDenominator => (_currentUnit.isBasedOnSatoshi ? 1 : 1e8);
+  int get _dustThreshold =>
+      _selectedWalletItem != null ? _selectedWalletItem!.walletType.addressType.dustThreshold : DustThresholds.p2wsh;
   bool get isAmountDisabled => _isMaxMode && _currentIndex == lastIndex;
   bool get isEstimatedFeeGreaterThanBalance => balance < (_estimatedFee ?? 0);
   bool get hasValidRecipient => validRecipientList.isNotEmpty;
@@ -617,7 +619,7 @@ class SendViewModel extends ChangeNotifier {
     int estimatedFeeInSats = _estimatedFee ?? 0;
     int maxBalanceInSats = balance - _currentUnit.toSatoshi(amountSumExceptLast) - estimatedFeeInSats;
     _recipientList[lastIndex].amount =
-        maxBalanceInSats > dustLimit
+        maxBalanceInSats > _dustThreshold
             ? (_currentUnit.isBasedOnSatoshi
                     ? maxBalanceInSats
                     : BalanceFormatUtil.formatSatoshiToReadableBitcoin(maxBalanceInSats).replaceAll(' ', ''))
@@ -695,11 +697,11 @@ class SendViewModel extends ChangeNotifier {
     String message = "";
     // [전체] 충분하지 않은 Balance 입력 > [수신자] dust 보다 적은 금액을 입력 > [마지막 수신자] 전송 금액 - 예상 수수료가 dustLimit보다 크지 않음 > [수신자] 주소에 에러가 있는 경우 > 최소값보다 낮은 수수료 입력
     if (_isAmountSumExceedsBalance.isError) {
-      message = _isAmountSumExceedsBalance.getMessage(currentUnit);
+      message = _isAmountSumExceedsBalance.getMessage(currentUnit, dustThreshold: _dustThreshold);
     } else if (_recipientList.any((r) => r.minimumAmountError.isError)) {
-      message = AmountError.minimumAmount.getMessage(currentUnit);
+      message = AmountError.minimumAmount.getMessage(currentUnit, dustThreshold: _dustThreshold);
     } else if (_isLastAmountInsufficient.isError) {
-      message = _isLastAmountInsufficient.getMessage(currentUnit);
+      message = _isLastAmountInsufficient.getMessage(currentUnit, dustThreshold: _dustThreshold);
     } else if (_recipientList.any((r) => r.addressError.isError)) {
       int addressErrorIndex = _recipientList.indexWhere((r) => r.addressError.isError);
       if (addressErrorIndex != -1) {
@@ -934,7 +936,7 @@ class SendViewModel extends ChangeNotifier {
     assert(recipientIndex != -1);
     final recipient = recipientList[recipientIndex];
     if (recipient.amount.isNotEmpty && double.parse(recipient.amount) > 0) {
-      if (double.parse(recipient.amount) <= dustLimit / _dustLimitDenominator) {
+      if (double.parse(recipient.amount) <= _dustThreshold / _dustLimitDenominator) {
         recipient.minimumAmountError = AmountError.minimumAmount;
       } else {
         recipient.minimumAmountError = AmountError.none;
@@ -957,7 +959,7 @@ class SendViewModel extends ChangeNotifier {
     if (_recipientList[lastIndex].amount.isNotEmpty) {
       double amount = double.parse(_recipientList[lastIndex].amount);
       int estimatedFeeInSats = _estimatedFee ?? 0;
-      bool isAmountInsufficientForFee = _currentUnit.toSatoshi(amount) - estimatedFeeInSats <= dustLimit;
+      bool isAmountInsufficientForFee = _currentUnit.toSatoshi(amount) - estimatedFeeInSats <= _dustThreshold;
 
       _isLastAmountInsufficient = isAmountInsufficientForFee ? AmountError.insufficientBalance : AmountError.none;
       Logger.log("_insufficientBalanceErrorOfLastRecipient: $_isLastAmountInsufficient");

--- a/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
@@ -1,5 +1,3 @@
-import 'package:coconut_lib/coconut_lib.dart';
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
 import 'package:coconut_wallet/core/exceptions/cpfp_creation/cpfp_creation_exception.dart';
 import 'package:coconut_wallet/core/exceptions/rbf_creation/rbf_creation_exception.dart';
 import 'package:coconut_wallet/core/transaction/fee_bumping/cpfp_builder.dart';
@@ -474,10 +472,6 @@ class FeeBumpingViewModel extends ChangeNotifier {
   void setIsNetworkOn(bool? isNetworkOn) {
     _isNetworkOn = isNetworkOn;
     notifyListeners();
-  }
-
-  bool makeDust(List<Utxo> utxoList, double outputSum, double requiredFee) {
-    return utxoList.fold(0, (sum, utxo) => sum + utxo.amount) - outputSum - requiredFee < dustLimit;
   }
 
   // 노드 프로바이더에서 추천 수수료 조회

--- a/lib/screens/wallet_detail/utxo_overview/utxo_bucket_card_row.dart
+++ b/lib/screens/wallet_detail/utxo_overview/utxo_bucket_card_row.dart
@@ -1,5 +1,4 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/model/utxo/utxo_bucket.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
@@ -16,6 +15,7 @@ class UtxoBucketCardRow extends StatelessWidget {
   final UtxoBucket bucket;
   final int index;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final ValueListenable<int> activeIndexListenable;
   final ValueListenable<({int bucket, int card})?>? restoredStateListenable;
   final bool isSelectionMode;
@@ -31,6 +31,7 @@ class UtxoBucketCardRow extends StatelessWidget {
     required this.bucket,
     required this.index,
     required this.currentUnit,
+    required this.dustThreshold,
     required this.activeIndexListenable,
     this.restoredStateListenable,
     required this.isSelectionMode,
@@ -68,6 +69,7 @@ class UtxoBucketCardRow extends StatelessWidget {
               return _CoinStack(
                 utxos: bucket.utxos,
                 currentUnit: currentUnit,
+                dustThreshold: dustThreshold,
                 isExpanded: isExpanded,
                 isSelectionMode: isSelectionMode,
                 selectedUtxoIds: selectedUtxoIds,
@@ -88,6 +90,7 @@ class UtxoBucketCardRow extends StatelessWidget {
         return _CoinStack(
           utxos: bucket.utxos,
           currentUnit: currentUnit,
+          dustThreshold: dustThreshold,
           isExpanded: active == index,
           isSelectionMode: isSelectionMode,
           selectedUtxoIds: selectedUtxoIds,
@@ -111,7 +114,13 @@ class UtxoBucketCardRow extends StatelessWidget {
           const SizedBox(height: 8),
           ValueListenableBuilder<int>(
             valueListenable: activeIndexListenable,
-            builder: (_, active, __) => _Summary(bucket: bucket, currentUnit: currentUnit, isActive: active == index),
+            builder:
+                (_, active, __) => _Summary(
+                  bucket: bucket,
+                  currentUnit: currentUnit,
+                  dustThreshold: dustThreshold,
+                  isActive: active == index,
+                ),
           ),
           const SizedBox(height: 8),
           Expanded(child: _buildCoinStack()),
@@ -125,9 +134,15 @@ class UtxoBucketCardRow extends StatelessWidget {
 class _Summary extends StatelessWidget {
   final UtxoBucket bucket;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final bool isActive;
 
-  const _Summary({required this.bucket, required this.currentUnit, required this.isActive});
+  const _Summary({
+    required this.bucket,
+    required this.currentUnit,
+    required this.dustThreshold,
+    required this.isActive,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -137,7 +152,7 @@ class _Summary extends StatelessWidget {
     return Align(
       alignment: Alignment.center,
       child: Text(
-        '${bucket.utxos.length} coins • ${formatUtxoAmountForDisplay(totalSats, currentUnit, forceSats: isDustBucket)}',
+        '${bucket.utxos.length} coins • ${formatUtxoAmountForDisplay(totalSats, currentUnit, dustThreshold: dustThreshold, forceSats: isDustBucket)}',
         style: CoconutTypography.body2_14_NumberBold.setColor(textColor),
       ),
     );
@@ -147,6 +162,7 @@ class _Summary extends StatelessWidget {
 class _CoinStack extends StatefulWidget {
   final List<UtxoState> utxos;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final bool isExpanded;
   final bool isSelectionMode;
   final Set<String> selectedUtxoIds;
@@ -159,6 +175,7 @@ class _CoinStack extends StatefulWidget {
   const _CoinStack({
     required this.utxos,
     required this.currentUnit,
+    required this.dustThreshold,
     required this.isExpanded,
     required this.isSelectionMode,
     required this.selectedUtxoIds,
@@ -319,6 +336,7 @@ class _CoinStackState extends State<_CoinStack> {
                           isSelected: widget.selectedUtxoIds.contains(widget.utxos[i].utxoId),
                           isSelectionMode: widget.isSelectionMode,
                           currentUnit: widget.currentUnit,
+                          dustThreshold: widget.dustThreshold,
                           isAddressReused: widget.reusedAddresses.contains(widget.utxos[i].to),
                           isSuspiciousDust: widget.suspiciousUtxoIds.contains(widget.utxos[i].utxoId),
                           onTap: () => widget.onTap(widget.utxos[i]),
@@ -344,6 +362,7 @@ class UtxoCoinCard extends StatefulWidget {
   final bool isSelected;
   final bool isSelectionMode;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final bool isAddressReused;
   final bool isSuspiciousDust;
   final VoidCallback onTap;
@@ -358,6 +377,7 @@ class UtxoCoinCard extends StatefulWidget {
     this.isSelected = false,
     this.isSelectionMode = false,
     required this.currentUnit,
+    required this.dustThreshold,
     this.isAddressReused = false,
     this.isSuspiciousDust = false,
     required this.onTap,
@@ -373,7 +393,8 @@ class UtxoCoinCard extends StatefulWidget {
     bool isFocused,
     Color iconColor,
     UtxoState utxo,
-    BitcoinUnit currentUnit, {
+    BitcoinUnit currentUnit,
+    int dustThreshold, {
     bool isSuspiciousDust = false,
   }) {
     return Stack(
@@ -400,7 +421,12 @@ class UtxoCoinCard extends StatefulWidget {
               FittedBox(
                 fit: BoxFit.scaleDown,
                 child: Text(
-                  formatUtxoBalanceForTooltip(utxo.amount, currentUnit, isDustBucket: utxo.amount <= dustLimit),
+                  formatUtxoBalanceForTooltip(
+                    utxo.amount,
+                    currentUnit,
+                    dustThreshold: dustThreshold,
+                    isDustBucket: utxo.amount <= dustThreshold,
+                  ),
                   textAlign: TextAlign.center,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
@@ -441,7 +467,7 @@ class _UtxoCoinCardState extends State<UtxoCoinCard> {
     final cardWidth = isBill ? widget.size * 1.35 : widget.size;
     final cardHeight = isBill ? widget.size * 0.85 : widget.size;
     final tierTheme = context.watch<PreferenceProvider>().utxoTierTheme;
-    final bucketCol = tierTheme.colorForSats(widget.utxo.amount);
+    final bucketCol = tierTheme.colorForSats(widget.utxo.amount, dustThreshold: widget.dustThreshold);
     final bgColor = widget.isFocused ? bucketCol : Color.lerp(const Color(0xFF1A1A1A), bucketCol, 0.68)!;
     final iconColor = bgColor;
     final shadowBlur = widget.isFocused ? 16.0 : 6.0;
@@ -497,6 +523,7 @@ class _UtxoCoinCardState extends State<UtxoCoinCard> {
                               iconColor,
                               widget.utxo,
                               widget.currentUnit,
+                              widget.dustThreshold,
                               isSuspiciousDust: widget.isSuspiciousDust,
                             ),
                             // coin 테두리
@@ -524,6 +551,7 @@ class _UtxoCoinCardState extends State<UtxoCoinCard> {
                               iconColor,
                               widget.utxo,
                               widget.currentUnit,
+                              widget.dustThreshold,
                               isSuspiciousDust: widget.isSuspiciousDust,
                             ),
                             Positioned.fill(

--- a/lib/screens/wallet_detail/utxo_overview/utxo_filter_bar.dart
+++ b/lib/screens/wallet_detail/utxo_overview/utxo_filter_bar.dart
@@ -9,12 +9,14 @@ class _SelectionSummaryBar extends StatelessWidget {
   final int selectedCount;
   final int selectedTotalSats;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final VoidCallback onCancel;
 
   const _SelectionSummaryBar({
     required this.selectedCount,
     required this.selectedTotalSats,
     required this.currentUnit,
+    required this.dustThreshold,
     required this.onCancel,
   });
 
@@ -38,7 +40,7 @@ class _SelectionSummaryBar extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               Text(
-                '$selectedCount coins • ${formatUtxoAmountForDisplay(selectedTotalSats, currentUnit)}',
+                '$selectedCount coins • ${formatUtxoAmountForDisplay(selectedTotalSats, currentUnit, dustThreshold: dustThreshold)}',
                 style: CoconutTypography.body1_16_NumberBold.setColor(CoconutColors.white),
                 textScaler: const TextScaler.linear(1.0),
               ),
@@ -60,6 +62,7 @@ class UtxoAmountStickyFilterBarDelegate extends SliverPersistentHeaderDelegate {
   final int selectedCount;
   final int selectedTotalSats;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final int viewModeIndex;
   final int lockFilterIndex;
   final bool isSelectionMode;
@@ -72,6 +75,7 @@ class UtxoAmountStickyFilterBarDelegate extends SliverPersistentHeaderDelegate {
     required this.selectedCount,
     required this.selectedTotalSats,
     required this.currentUnit,
+    required this.dustThreshold,
     required this.viewModeIndex,
     required this.lockFilterIndex,
     required this.isSelectionMode,
@@ -97,6 +101,7 @@ class UtxoAmountStickyFilterBarDelegate extends SliverPersistentHeaderDelegate {
           selectedCount: selectedCount,
           selectedTotalSats: selectedTotalSats,
           currentUnit: currentUnit,
+          dustThreshold: dustThreshold,
           viewModeIndex: viewModeIndex,
           lockFilterIndex: lockFilterIndex,
           isSelectionMode: isSelectionMode,
@@ -114,6 +119,7 @@ class UtxoAmountStickyFilterBarDelegate extends SliverPersistentHeaderDelegate {
       selectedCount != oldDelegate.selectedCount ||
       selectedTotalSats != oldDelegate.selectedTotalSats ||
       currentUnit != oldDelegate.currentUnit ||
+      dustThreshold != oldDelegate.dustThreshold ||
       viewModeIndex != oldDelegate.viewModeIndex ||
       lockFilterIndex != oldDelegate.lockFilterIndex ||
       isSelectionMode != oldDelegate.isSelectionMode;
@@ -125,6 +131,7 @@ class _StickyFilterBar extends StatelessWidget {
   final int selectedCount;
   final int selectedTotalSats;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final int viewModeIndex;
   final int lockFilterIndex;
   final bool isSelectionMode;
@@ -136,6 +143,7 @@ class _StickyFilterBar extends StatelessWidget {
     required this.selectedCount,
     required this.selectedTotalSats,
     required this.currentUnit,
+    required this.dustThreshold,
     required this.viewModeIndex,
     required this.lockFilterIndex,
     required this.isSelectionMode,
@@ -198,6 +206,7 @@ class _StickyFilterBar extends StatelessWidget {
                 selectedCount: selectedCount,
                 selectedTotalSats: selectedTotalSats,
                 currentUnit: currentUnit,
+                dustThreshold: dustThreshold,
                 onCancel: onExitSelectionMode,
               ),
             ),
@@ -354,6 +363,7 @@ class UtxoTagSelectionBarDelegate extends SliverPersistentHeaderDelegate {
   final int selectedCount;
   final int selectedTotalSats;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final bool isSelectionMode;
   final VoidCallback onExitSelectionMode;
 
@@ -362,6 +372,7 @@ class UtxoTagSelectionBarDelegate extends SliverPersistentHeaderDelegate {
     required this.selectedCount,
     required this.selectedTotalSats,
     required this.currentUnit,
+    required this.dustThreshold,
     required this.isSelectionMode,
     required this.onExitSelectionMode,
   });
@@ -387,6 +398,7 @@ class UtxoTagSelectionBarDelegate extends SliverPersistentHeaderDelegate {
                     selectedCount: selectedCount,
                     selectedTotalSats: selectedTotalSats,
                     currentUnit: currentUnit,
+                    dustThreshold: dustThreshold,
                     onCancel: onExitSelectionMode,
                   ),
                 )
@@ -401,5 +413,6 @@ class UtxoTagSelectionBarDelegate extends SliverPersistentHeaderDelegate {
       selectedCount != oldDelegate.selectedCount ||
       selectedTotalSats != oldDelegate.selectedTotalSats ||
       currentUnit != oldDelegate.currentUnit ||
+      dustThreshold != oldDelegate.dustThreshold ||
       isSelectionMode != oldDelegate.isSelectionMode;
 }

--- a/lib/screens/wallet_detail/utxo_overview/utxo_summary_chart.dart
+++ b/lib/screens/wallet_detail/utxo_overview/utxo_summary_chart.dart
@@ -1,5 +1,4 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/extensions/int_extensions.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
@@ -24,6 +23,7 @@ class UtxoSummaryChart extends StatelessWidget {
   final int lockedCount;
   final int lockedSats;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final VoidCallback? onBalanceTap;
   final VoidCallback? onThemeSettingTap;
   final bool hasReusedAddresses;
@@ -38,6 +38,7 @@ class UtxoSummaryChart extends StatelessWidget {
     required this.lockedCount,
     required this.lockedSats,
     required this.currentUnit,
+    required this.dustThreshold,
     this.onBalanceTap,
     this.onThemeSettingTap,
     this.hasReusedAddresses = false,
@@ -66,6 +67,7 @@ class UtxoSummaryChart extends StatelessWidget {
               coinCount: coinCount,
               totalSats: totalSats,
               currentUnit: currentUnit,
+              dustThreshold: dustThreshold,
               onBalanceTap: onBalanceTap,
             ),
             const SizedBox(height: 12),
@@ -76,7 +78,7 @@ class UtxoSummaryChart extends StatelessWidget {
                     label: t.utxo_detail_screen.utxo_unlocked,
                     count: availableCount,
                     sats: availableSats,
-                    formatBalance: (s) => formatUtxoAmountForDisplay(s, currentUnit),
+                    formatBalance: (s) => formatUtxoAmountForDisplay(s, currentUnit, dustThreshold: dustThreshold),
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -85,7 +87,7 @@ class UtxoSummaryChart extends StatelessWidget {
                     label: t.utxo_detail_screen.utxo_locked,
                     count: lockedCount,
                     sats: lockedSats,
-                    formatBalance: (s) => formatUtxoAmountForDisplay(s, currentUnit),
+                    formatBalance: (s) => formatUtxoAmountForDisplay(s, currentUnit, dustThreshold: dustThreshold),
                   ),
                 ),
               ],
@@ -95,6 +97,7 @@ class UtxoSummaryChart extends StatelessWidget {
               buckets: buckets,
               tierTheme: tierTheme,
               currentUnit: currentUnit,
+              dustThreshold: dustThreshold,
               onThemeSettingTap: onThemeSettingTap,
             ),
             if (hasReusedAddresses) ...[
@@ -175,9 +178,16 @@ class _BarChart extends StatefulWidget {
   final List<UtxoBucket> buckets;
   final UtxoTierTheme tierTheme;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final VoidCallback? onThemeSettingTap;
 
-  const _BarChart({required this.buckets, required this.tierTheme, required this.currentUnit, this.onThemeSettingTap});
+  const _BarChart({
+    required this.buckets,
+    required this.tierTheme,
+    required this.currentUnit,
+    required this.dustThreshold,
+    this.onThemeSettingTap,
+  });
 
   @override
   State<_BarChart> createState() => _BarChartState();
@@ -247,16 +257,16 @@ class _BarChartState extends State<_BarChart> {
                     ],
                   ),
                   const SizedBox(height: 16),
-                  ...utxoBucketRanges.map((r) {
-                    final isDustRange = r.max <= dustLimit;
+                  ...getUtxoBucketRanges(dustThreshold: widget.dustThreshold).map((r) {
+                    final isDustRange = r.max <= widget.dustThreshold;
                     final isWhale = r.label == 'whale';
                     final rangeStr =
                         isWhale
                             ? '≥ 10 ${t.btc}'
                             : (isDustRange
                                 ? '${r.min.toThousandsSeparatedString()} ~ ${r.max.toThousandsSeparatedString()} ${t.sats}'
-                                : '${formatUtxoAmountForDisplay(r.min, BitcoinUnit.btc)} ~ ${formatUtxoAmountForDisplay(r.max, BitcoinUnit.btc)}');
-                    final color = tierTheme.colorForSats(r.max);
+                                : '${formatUtxoAmountForDisplay(r.min, BitcoinUnit.btc, dustThreshold: widget.dustThreshold)} ~ ${formatUtxoAmountForDisplay(r.max, BitcoinUnit.btc, dustThreshold: widget.dustThreshold)}');
+                    final color = tierTheme.colorForSats(r.max, dustThreshold: widget.dustThreshold);
                     return Padding(
                       padding: const EdgeInsets.only(bottom: 8),
                       child: Row(
@@ -319,11 +329,11 @@ class _BarChartState extends State<_BarChart> {
                 widget.buckets.asMap().entries.map((entry) {
                   final index = entry.key;
                   final bucket = entry.value;
-                  final count = bucket.utxos.length;
+                  final count = bucket.utxos.length.toDouble();
                   final heightRatio = count / maxCountClamped;
                   final barHeight = _barMaxHeight * heightRatio;
                   final isTapped = _tappedBucketIndex == index;
-                  var color = widget.tierTheme.colorForSats(bucket.maxSats);
+                  var color = widget.tierTheme.colorForSats(bucket.maxSats, dustThreshold: widget.dustThreshold);
                   if (!isTapped) {
                     color = Color.lerp(color, const Color(0xFF1D1D1D), _overlayOpacity)!;
                   }
@@ -438,6 +448,7 @@ class _BarChartState extends State<_BarChart> {
                                 final balance = formatUtxoBalanceForTooltip(
                                   bucket.utxos.fold<int>(0, (s, u) => s + u.amount),
                                   widget.currentUnit,
+                                  dustThreshold: widget.dustThreshold,
                                   isDustBucket: bucket.label == 'dust',
                                 );
                                 return OverflowBox(

--- a/lib/screens/wallet_detail/utxo_overview/utxo_tag_chart.dart
+++ b/lib/screens/wallet_detail/utxo_overview/utxo_tag_chart.dart
@@ -36,6 +36,7 @@ class UtxoTagChart extends StatelessWidget {
   final List<UtxoState> utxoList;
   final List<UtxoTag> utxoTagList;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final VoidCallback? onBalanceTap;
 
   const UtxoTagChart({
@@ -43,6 +44,7 @@ class UtxoTagChart extends StatelessWidget {
     required this.utxoList,
     required this.utxoTagList,
     required this.currentUnit,
+    required this.dustThreshold,
     this.onBalanceTap,
   });
 
@@ -160,6 +162,7 @@ class UtxoTagChart extends StatelessWidget {
               coinCount: coinCount,
               totalSats: totalSats,
               currentUnit: currentUnit,
+              dustThreshold: dustThreshold,
               onBalanceTap: onBalanceTap,
             ),
             const SizedBox(height: 12),
@@ -376,7 +379,7 @@ class _DonutChartState extends State<_DonutChart> {
     }
 
     const padding = 12.0;
-    final stackW = _size + padding * 2;
+    const stackW = _size + padding * 2;
 
     return SizedBox(
       width: stackW,
@@ -618,6 +621,7 @@ class UtxoTagGridSection extends StatefulWidget {
   final List<UtxoState> utxoList;
   final List<UtxoTag> utxoTagList;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final Set<String> selectedUtxoIds;
   final Set<String> reusedAddresses;
   final Set<String> suspiciousUtxoIds;
@@ -630,6 +634,7 @@ class UtxoTagGridSection extends StatefulWidget {
     required this.utxoList,
     required this.utxoTagList,
     required this.currentUnit,
+    required this.dustThreshold,
     required this.selectedUtxoIds,
     required this.reusedAddresses,
     required this.suspiciousUtxoIds,
@@ -904,6 +909,7 @@ class _UtxoTagGridSectionState extends State<UtxoTagGridSection> {
                                                           isSelected: isSelected,
                                                           isSelectionMode: widget.isSelectionMode,
                                                           currentUnit: widget.currentUnit,
+                                                          dustThreshold: widget.dustThreshold,
                                                           isAddressReused: widget.reusedAddresses.contains(utxo.to),
                                                           isSuspiciousDust: widget.suspiciousUtxoIds.contains(
                                                             utxo.utxoId,
@@ -943,6 +949,7 @@ class _UtxoTagGridSectionState extends State<UtxoTagGridSection> {
                                           isSelected: isSelected,
                                           isSelectionMode: widget.isSelectionMode,
                                           currentUnit: widget.currentUnit,
+                                          dustThreshold: widget.dustThreshold,
                                           isAddressReused: widget.reusedAddresses.contains(utxo.to),
                                           isSuspiciousDust: widget.suspiciousUtxoIds.contains(utxo.utxoId),
                                           onTap: () => widget.onUtxoTap(utxo),

--- a/lib/screens/wallet_detail/utxo_overview/utxo_total_balance_header.dart
+++ b/lib/screens/wallet_detail/utxo_overview/utxo_total_balance_header.dart
@@ -8,6 +8,7 @@ class UtxoTotalBalanceHeader extends StatelessWidget {
   final int coinCount;
   final int totalSats;
   final BitcoinUnit currentUnit;
+  final int dustThreshold;
   final VoidCallback? onBalanceTap;
 
   const UtxoTotalBalanceHeader({
@@ -15,6 +16,7 @@ class UtxoTotalBalanceHeader extends StatelessWidget {
     required this.coinCount,
     required this.totalSats,
     required this.currentUnit,
+    required this.dustThreshold,
     this.onBalanceTap,
   });
 
@@ -29,7 +31,7 @@ class UtxoTotalBalanceHeader extends StatelessWidget {
           onTap: onBalanceTap,
           behavior: HitTestBehavior.opaque,
           child: Text(
-            '$coinCount coins • ${formatUtxoAmountForDisplay(totalSats, currentUnit)}',
+            '$coinCount coins • ${formatUtxoAmountForDisplay(totalSats, currentUnit, dustThreshold: dustThreshold)}',
             style: CoconutTypography.heading4_18_NumberBold.setColor(CoconutColors.white),
           ),
         ),

--- a/lib/screens/wallet_detail/utxo_overview_screen.dart
+++ b/lib/screens/wallet_detail/utxo_overview_screen.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_wallet/constants/dust_constants.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/utxo/utxo_bucket.dart';
@@ -47,6 +48,8 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
 
   final GlobalKey _appBarKey = GlobalKey();
   final GlobalKey _scrollRailKey = GlobalKey();
+
+  int get _dustThreshold => viewModel.walletType.addressType.dustThreshold;
 
   bool _isByAmount = true;
   int _lockFilterIndex = 0; // 0: 사용 가능, 1: 사용 잠김
@@ -97,7 +100,7 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
   }
 
   void _refreshBucketsFromViewModel() {
-    _buckets = bucketize(viewModel.utxoList);
+    _buckets = bucketize(viewModel.utxoList, dustThreshold: _dustThreshold);
     final preserving = _restoreUtxoId != null;
     _updateFilteredBuckets(preserveUiState: preserving);
     _restoreStateAfterReturn();
@@ -168,7 +171,7 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
       context.read<NodeProvider>().getWalletStateStream(widget.id),
     );
 
-    _buckets = bucketize(viewModel.utxoList);
+    _buckets = bucketize(viewModel.utxoList, dustThreshold: _dustThreshold);
     _updateFilteredBuckets();
 
     viewModel.addListener(_onViewModelChanged);
@@ -307,6 +310,7 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
                     .where((u) => u.status == UtxoStatus.locked)
                     .fold<int>(0, (s, u) => s + u.amount),
                 currentUnit: _currentUnit,
+                dustThreshold: _dustThreshold,
                 onBalanceTap: _toggleUnit,
                 onThemeSettingTap: () {
                   CommonBottomSheets.showCustomHeightBottomSheet(
@@ -325,6 +329,7 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
                 selectedCount: _selectedUtxoIds.length,
                 selectedTotalSats: _selectedTotalSats,
                 currentUnit: _currentUnit,
+                dustThreshold: _dustThreshold,
                 viewModeIndex: _viewModeIndex,
                 lockFilterIndex: _lockFilterIndex,
                 isSelectionMode: _isSelectionMode,
@@ -360,6 +365,7 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
                         bucket: bucket,
                         index: index,
                         currentUnit: _currentUnit,
+                        dustThreshold: _dustThreshold,
                         activeIndexListenable: _activeIndex,
                         restoredStateListenable: _restoredStateListenable,
                         isSelectionMode: _isSelectionMode,
@@ -441,6 +447,7 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
             utxoList: viewModel.utxoList,
             utxoTagList: utxoTagList,
             currentUnit: _currentUnit,
+            dustThreshold: _dustThreshold,
             onBalanceTap: _toggleUnit,
           ),
         ),
@@ -451,6 +458,7 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
             selectedCount: _selectedUtxoIds.length,
             selectedTotalSats: _selectedTotalSats,
             currentUnit: _currentUnit,
+            dustThreshold: _dustThreshold,
             isSelectionMode: _isSelectionMode,
             onExitSelectionMode: () {
               _exitSelectionMode();
@@ -463,6 +471,7 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
             utxoList: viewModel.utxoList,
             utxoTagList: utxoTagList,
             currentUnit: _currentUnit,
+            dustThreshold: _dustThreshold,
             selectedUtxoIds: _selectedUtxoIds,
             reusedAddresses: _reusedAddresses,
             suspiciousUtxoIds: _suspiciousUtxoIds,
@@ -804,6 +813,7 @@ class _UtxoOverviewScreenState extends State<UtxoOverviewScreen> {
                   isSelected: isSelected,
                   isSelectionMode: _isSelectionMode,
                   currentUnit: currentUnit,
+                  dustThreshold: _dustThreshold,
                   isAddressReused: _reusedAddresses.contains(utxo.to),
                   isSuspiciousDust: _suspiciousUtxoIds.contains(utxo.utxoId),
                   onTap: () {

--- a/lib/screens/wallet_detail/wallet_info_screen.dart
+++ b/lib/screens/wallet_detail/wallet_info_screen.dart
@@ -406,10 +406,7 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
       placeholderColor: CoconutColors.gray700,
       activeColor: CoconutColors.white,
       cursorColor: CoconutColors.white,
-      suffix: Text(
-        BitcoinUnit.btc.symbol,
-        style: CoconutTypography.body2_14_Bold,
-      ),
+      suffix: Text(BitcoinUnit.btc.symbol, style: CoconutTypography.body2_14_Bold),
       onComplete: (text) {
         final btc = double.tryParse(text.replaceAll(',', ''));
         if (btc == null || btc <= 0) {

--- a/lib/utils/transaction_util.dart
+++ b/lib/utils/transaction_util.dart
@@ -1,12 +1,11 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/constants/dust_constants.dart';
 import 'package:coconut_wallet/enums/network_enums.dart';
 import 'package:coconut_wallet/enums/transaction_enums.dart';
-import 'package:coconut_wallet/extensions/transaction_extension.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/transaction_record.dart';
-import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/preferences/preference_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -123,7 +122,7 @@ class TransactionUtil {
   ) {
     int baseVbyte = 72; // 0 input, 2 output
     int vBytePerInput = 0;
-    int dust = _getDustThreshold(addressType);
+    int dust = addressType.dustThreshold;
     if (addressType.isSegwit) {
       vBytePerInput = 68; //segwit discount
     } else {
@@ -166,22 +165,6 @@ class TransactionUtil {
     }
 
     return selectedUtxos;
-  }
-
-  static int _getDustThreshold(AddressType addressType) {
-    if (addressType == AddressType.p2wpkh) {
-      return 294;
-    } else if (addressType == AddressType.p2wsh || addressType.isTaproot) {
-      return 330;
-    } else if (addressType == AddressType.p2pkh) {
-      return 546;
-    } else if (addressType == AddressType.p2sh) {
-      return 888;
-    } else if (addressType == AddressType.p2wpkhInP2sh) {
-      return 273;
-    } else {
-      throw Exception('Unsupported Address Type');
-    }
   }
 
   /// 코인베이스 트랜잭션 여부를 확인합니다.

--- a/lib/utils/utxo_amount_format_util.dart
+++ b/lib/utils/utxo_amount_format_util.dart
@@ -1,22 +1,26 @@
-import 'package:coconut_wallet/constants/bitcoin_network_rules.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/extensions/int_extensions.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 
 /// 지정 단위에 따라 금액 표시. dust(≤546, 0 제외)는 항상 sats로 표기.
-String formatUtxoAmountForDisplay(int sats, BitcoinUnit unit, {bool forceSats = false}) {
+String formatUtxoAmountForDisplay(int sats, BitcoinUnit unit, {required int dustThreshold, bool forceSats = false}) {
   if (sats == 0) {
     return unit.displayBitcoinAmount(sats, withUnit: true);
   }
-  if (forceSats || sats <= dustLimit) {
+  if (forceSats || sats <= dustThreshold) {
     return '${sats.toThousandsSeparatedString()} ${t.sats}';
   }
   return unit.displayBitcoinAmount(sats, withUnit: true);
 }
 
 /// 차트 툴팁용: 단위 생략, dust만 sats 표기.
-String formatUtxoBalanceForTooltip(int sats, BitcoinUnit unit, {bool isDustBucket = false}) {
-  if (isDustBucket || sats <= dustLimit) {
+String formatUtxoBalanceForTooltip(
+  int sats,
+  BitcoinUnit unit, {
+  required int dustThreshold,
+  bool isDustBucket = false,
+}) {
+  if (isDustBucket || sats <= dustThreshold) {
     return '${sats.toThousandsSeparatedString()} ${t.sats}';
   }
   return unit.displayBitcoinAmount(sats, withUnit: false);

--- a/lib/utils/utxo_tier_theme.dart
+++ b/lib/utils/utxo_tier_theme.dart
@@ -52,13 +52,13 @@ class UtxoTierTheme {
   TierSwatch swatch(UtxoTier tier) => TierSwatch(bg: bg(tier), fg: fg(tier));
 
   /// sats 금액에 해당하는 배경색
-  Color colorForSats(int sats) => bg(tierOfSats(sats));
+  Color colorForSats(int sats, {required int dustThreshold}) => bg(tierOfSats(sats, dustThreshold: dustThreshold));
 }
 
-// ---- sats -> tier (네 구간 반영, tiny는 547~10,000로 공백 커버) ----
-UtxoTier tierOfSats(int sats) {
-  if (sats <= 546) return UtxoTier.dust;
-  if (sats <= 10_000) return UtxoTier.tiny; // 547~10,000
+// ---- sats -> tier (네 구간 반영, tiny는 dustThreshold~10,000로 공백 커버) ----
+UtxoTier tierOfSats(int sats, {required int dustThreshold}) {
+  if (sats <= dustThreshold) return UtxoTier.dust;
+  if (sats <= 10_000) return UtxoTier.tiny; // dustThreshold+1~10,000
   if (sats <= 100_000) return UtxoTier.small;
   if (sats <= 1_000_000) return UtxoTier.medium;
   if (sats <= 9_999_999) return UtxoTier.large;

--- a/test/core/transaction/rbf_builder/singlesig_rbf_builder_test.dart
+++ b/test/core/transaction/rbf_builder/singlesig_rbf_builder_test.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/constants/dust_constants.dart';
 import 'package:coconut_wallet/core/exceptions/rbf_creation/rbf_creation_exception.dart';
 import 'package:coconut_wallet/core/transaction/fee_bumping/rbf_builder.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
@@ -255,7 +256,7 @@ void main() {
     test('selfOutput 1 / change insufficient / selfOutput partial reduction → getBaselineTransaction 성공', () async {
       // 원본 tx: 1-in/2-out (selfOutput + change), vSize=141
       // additionalFee = 141, changeOutput(100) < 141 → deficitAmount = 41
-      // selfOutput(99759) - 41 = 99718 > dustLimit(546) → partial reduction
+      // selfOutput(99759) - 41 = 99718 > dustLimit(294) → partial reduction
       // sweep tx 생성 후 실제 vSize=109.75로 작아짐
       // RBF 최소 조건: fee >= 141 + 109.75 = 250.75
       // requiredFeeRate = ceil(251/109.75) = 2.29으로 재빌드
@@ -290,16 +291,16 @@ void main() {
       () async {
         // 원본 tx: 1-in/3-out (external + selfOutput + change), vSize=172
         // additionalFee = 172, changeOutput(100) < 172 → deficitAmount = 72
-        // selfOutput(500) - 72 = 428 ≤ dustLimit(546) → full removal
+        // selfOutput(366) - 72 = 294 ≤ dustLimit(294) → full removal
         // leftDeficit = 72 - (500 + ceil(31*1.0)=31) = -459 → 0
         // vSizeReduced = 31, newTxVSize = 172 - 31 = 141
         // newRecipients = {external: 1000} (selfOutput 제거됨)
         // build at _calculateMinimumFeeRate(141) = 2.0:
-        //   tx: external(1000) + change(1741-1000-282=459), fee=282, 실제 vSize=140.75
+        //   tx: external(1000) + change(1638-1000-282=356), fee=282, 실제 vSize=140.75
         //   getFeeRate = ceilFeeRate(282/140.75) = 2.01
         final (pendingTx, rbfBuilder) = creator.createRbfBuilder(
-          inputAmounts: [1772],
-          recipients: [Tuple(false, 1000), Tuple(true, 500)],
+          inputAmounts: [1638],
+          recipients: [Tuple(false, 1000), Tuple(true, 366)],
           changeAmount: 100,
           fee: 172,
           vSize: 172,
@@ -791,7 +792,7 @@ void main() {
       // 원본 tx: 1-in/2-out (external + selfOutput), changeAmount=0, vSize=141
       // changeOutput 없으므로 보수적 vSize 추정: newTxVSize = 141 + 31*1.0 = 172
       // additionalFee = ceil(172 * 1.0) = 172, deficitAmount = 172
-      // selfOutput(98859) - 172 = 98687 > dustLimit(546) → partial reduction
+      // selfOutput(98859) - 172 = 98687 > dustLimit(294) → partial reduction
       // newRecipients = {ext: 1000, self: 98687}, deficit = 0
       // build at _calculateMinimumFeeRate(172) = ceilFeeRate(313/172) = 1.82:
       //   tx: ext(1000) + self(98687), change=0 → 드롭
@@ -841,7 +842,7 @@ void main() {
       // 원본 tx: 1-in/3-out (external + selfOutput1 + selfOutput2), changeAmount=0, vSize=172
       // changeOutput 없으므로 보수적 vSize 추정: newTxVSize = 172 + 31*1.0 = 203
       // additionalFee = ceil(203 * 1.0) = 203, deficitAmount = 203
-      // selfOutput2(5000) - 203 = 4797 > dustLimit(546) → partial reduction
+      // selfOutput2(5000) - 203 = 4797 > dustLimit(294) → partial reduction
       // newRecipients = {ext: 1000, self1: 10000, self2: 4797}, deficit = 0
       // sweep tx 생성 후 실제 vSize 확인하여 RBF 최소 조건 만족하도록 재빌드
       final (pendingTx, rbfBuilder) = creator.createRbfBuilder(
@@ -925,7 +926,7 @@ void main() {
     test('Ex 1, Self 2 / change NotEnough / use 1 enough selfOutput', () async {
       // 원본 tx: 1-in/4-out (external + selfOutput1 + selfOutput2 + change), vSize=203
       // changeAmount=100 < additionalFee=203 → deficitAmount = 103
-      // selfOutput2(900) - 103 = 797 > dustLimit(546) → partial reduction
+      // selfOutput2(900) - 103 = 797 > dustLimit(294) → partial reduction
       // newRecipients = {ext: 13000, self1: 2000, self2: 797}, deficit = 0
       // sweep tx 생성 후 실제 vSize 확인하여 RBF 최소 조건 만족하도록 재빌드
       final (pendingTx, rbfBuilder) = creator.createRbfBuilder(
@@ -1019,15 +1020,14 @@ void main() {
       expectRbfMinimumCondition(buildResult, pendingTx);
     });
 
-    test('Ex 1, Self 2 / change enough but left under dustlimit / sweep', () async {
+    test('Ex 1, Self 2 / change enough but left under dustlimit / left changed used as fee', () async {
       // 원본 tx: 1-in/4-out (external + selfOutput1 + selfOutput2 + change), vSize=210
-      // changeAmount= 1979
-      // first changeAmount = 1979 - 1652 = 328, 328 < 547
-      // selfOutput2의 amount를 (5000 - 2000)으로 만든 후 Sweep으로 트랜잭션 생성, 3000 - 1374 = 1626
+      // changeAmount= 1934
+      // FeeRate 8.0일 때, first changeAmount = 1879 - 1602 = 277, 277 < 294 -> 남은 잔돈은 수수료로 사용됨
       final (pendingTx, rbfBuilder) = creator.createRbfBuilder(
-        inputAmounts: [5000],
+        inputAmounts: [4900],
         recipients: [Tuple(true, 1000), Tuple(false, 1000), Tuple(true, 1000)],
-        changeAmount: 1979,
+        changeAmount: 1879,
         fee: 21,
         vSize: 210,
       );
@@ -1044,7 +1044,7 @@ void main() {
       final RbfBuildResult buildResult = rbfBuilder.build(newFeeRate: 8);
 
       expect(buildResult.isSuccess, isTrue);
-      expect(buildResult.estimatedFee, equals(1374));
+      expect(buildResult.estimatedFee, equals(1900));
       expect(buildResult.transaction, isNotNull);
       expect(buildResult.exception, isNull);
       expect(buildResult.isSelfOutputsUsed, isFalse);
@@ -1058,11 +1058,8 @@ void main() {
       expect(tx.outputs.any((o) => o.getAddress() == creator.externalWalletAddressList[1] && o.amount == 1000), isTrue);
       // SelfOutput1은 그대로 유지
       expect(tx.outputs.any((o) => o.getAddress() == creator.receiveAddressList[1] && o.amount == 1000), isTrue);
-      // SelfOutput2는 늘어남
-      final selfOutput2InTx = tx.outputs.where((o) => o.getAddress() == creator.receiveAddressList[2]).toList();
-      expect(selfOutput2InTx.length, 1);
-      expect(selfOutput2InTx.first.amount, greaterThan(1000));
-      expect(selfOutput2InTx.first.amount, 1626);
+      // SelfOutput2도 그대로 유지
+      expect(tx.outputs.any((o) => o.getAddress() == creator.receiveAddressList[2] && o.amount == 1000), isTrue);
       // Change output은 드롭됨
       expect(tx.outputs.any((o) => o.getAddress() == creator.changeAddressList[0]), isFalse);
 
@@ -1230,7 +1227,7 @@ void main() {
       // 1-in/2-out (selfOutput1 + selfOutput2), no change, vSize=172
       // newTxVSize = 172 + 31*1.0 = 203 (conservative for no change)
       // deficitAmount = 203
-      // selfOutput2(1800) - 203 = 1597 > dustLimit(546) → selfOutput2만 partial reduction (sweep)
+      // selfOutput2(1800) - 203 = 1597 > dustLimit(294) → selfOutput2만 partial reduction (sweep)
       final (pendingTx, rbfBuilder) = creator.createRbfBuilder(
         inputAmounts: [12000],
         recipients: [Tuple(true, 10000), Tuple(true, 1800)],
@@ -1469,14 +1466,14 @@ void main() {
     test('Self1 / no change / use 1 enough additionalUtxo', () async {
       // 1-in/1-out (self1=700), no change, fee=141, vSize=141
       // newTxVSize = 172 (conservative), deficitAmount = 172
-      // self1(700): 700-172=528 < dustLimit → dustLimit 브랜치, set to 547, leftDeficit=19
-      // additionalUtxo(1000)로 sweep: self1 = inputSum(841) + 1000 - fee
+      // self1(700): 404-172=294 <= dustLimit → dustLimit 브랜치, set to 295, leftDeficit=1
+      // additionalUtxo(1000)로 sweep: self1 = inputSum(514) + 1000 - fee
       final (pendingTx, rbfBuilder) = creator.createRbfBuilder(
-        inputAmounts: [841],
-        recipients: [Tuple(true, 700)],
+        inputAmounts: [514],
+        recipients: [Tuple(true, 404)],
         changeAmount: 0,
-        fee: 141,
-        vSize: 141,
+        fee: 110,
+        vSize: 110,
         additionalSpendable: [1000],
       );
 
@@ -1505,7 +1502,7 @@ void main() {
       final tx = buildResult.transaction!;
       final selfOutput1InTx = tx.outputs.where((o) => o.getAddress() == creator.receiveAddressList[1]).toList();
       expect(selfOutput1InTx.length, 1);
-      expect(selfOutput1InTx.first.amount, greaterThan(546));
+      expect(selfOutput1InTx.first.amount, greaterThan(DustThresholds.p2wpkh));
 
       expectRbfMinimumCondition(buildResult, pendingTx);
     });
@@ -1554,7 +1551,7 @@ void main() {
       // self1은 sweep되어 있음
       final selfOutput1InTx = tx.outputs.where((o) => o.getAddress() == creator.receiveAddressList[1]).toList();
       expect(selfOutput1InTx.length, 1);
-      expect(selfOutput1InTx.first.amount, greaterThan(546));
+      expect(selfOutput1InTx.first.amount, greaterThan(DustThresholds.p2wpkh));
 
       expectRbfMinimumCondition(buildResult, pendingTx);
     });
@@ -1667,11 +1664,11 @@ void main() {
       // 1-in/2-out (self1=575, change=84), fee=341, vSize=141
       // newTxVSize = 141 (changeOutput exists)
       // additionalFee=141, change(84) < 141 → deficit=57
-      // self1(575): 575-57=518 < dustLimit → set to 547, leftDeficit=57-(575-547)=29
+      // self1(575): 350-57=293 < dustLimit → set to 294, leftDeficit=57-(350-294)=1
       // additionalUtxo(1000)로 sweep: self1 = inputSum(1000) + 1000 - fee
       final (pendingTx, rbfBuilder) = creator.createRbfBuilder(
         inputAmounts: [1000],
-        recipients: [Tuple(true, 575)],
+        recipients: [Tuple(true, 350)],
         changeAmount: 84,
         fee: 341,
         vSize: 141,
@@ -1705,7 +1702,7 @@ void main() {
       // self1은 sweep, change는 드롭
       final selfOutput1InTx = tx.outputs.where((o) => o.getAddress() == creator.receiveAddressList[1]).toList();
       expect(selfOutput1InTx.length, 1);
-      expect(selfOutput1InTx.first.amount, greaterThan(546));
+      expect(selfOutput1InTx.first.amount, greaterThan(DustThresholds.p2wpkh));
       expect(tx.outputs.any((o) => o.getAddress() == creator.changeAddressList[0]), isFalse);
 
       expectRbfMinimumCondition(buildResult, pendingTx);
@@ -1754,7 +1751,7 @@ void main() {
       // self1은 sweep되어 있음
       final selfOutput1InTx = tx.outputs.where((o) => o.getAddress() == creator.receiveAddressList[1]).toList();
       expect(selfOutput1InTx.length, 1);
-      expect(selfOutput1InTx.first.amount, greaterThan(546));
+      expect(selfOutput1InTx.first.amount, greaterThan(DustThresholds.p2wpkh));
 
       expectRbfMinimumCondition(buildResult, pendingTx);
     });


### PR DESCRIPTION
## 영향받는 곳 
1. 보내기 화면 
보내는 금액 DustThreshold 
ㄴ 싱글시그지갑: 294sats
ㄴ 멀티시그지갑: 330sats
- 보내는 금액 입력 시 Threshold 이하일 때 경고문구와 UI
- 모두보내기: 마지막 보내는금액이 Threshold 이하일 때 경고문구와 UI

2. utxo overview screen
tiny 기준이 Threshold + 1 ~ 0.0001 BTC로 변경됨 (기존에는 0.0000 0547 BTC ~ 0.0001 BTC로 고정이었음)

3. '나누기'
(640 브랜치를 머지한 후 테스트 가능합니다)