### PR TITLE
[660] 월렛 트랜잭션 메모 한/영 입력오류

### DIFF
--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -705,7 +705,6 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> with 
                   );
                 }
               },
-              formatInput: (s) => s.trim(),
             );
           },
           child: Text(


### PR DESCRIPTION
## 변경사항
월렛 트랜잭션 메모 - 한글 입력시 영문 자판으로 전환되는 현상 해결
- 불필요한 trim() 제거
   - 문자 매입력시 trim()으로 인해 TextEditingValue를 새로 만들고 selection도 다시 설정함.
   - 한글 IME는 조합 중인 상태에 민감해서, 이런 식으로 입력값을 매번 덮어쓰면 조합이 끊기고 키보드가 영문으로 튀는 증상이 생길 수 있음.
   
   #660 