### PR TITLE
fix(send): fix fragmented BBQR rendering and minor send flow UI updates

### DIFF
--- a/lib/providers/view_model/send/unsigned_transaction_view_model.dart
+++ b/lib/providers/view_model/send/unsigned_transaction_view_model.dart
@@ -26,12 +26,14 @@ class UnsignedTransactionQrViewModel extends ChangeNotifier {
   void initializeBbqr(String psbtBase64, WalletImportSource walletImportSource) {
     _isBbqrType = walletImportSource == WalletImportSource.coldCard;
 
-    if (walletImportSource == WalletImportSource.coldCard) {
-      _bbqrParts = BbQrEncoder().encodeBase64(psbtBase64);
-      if (_isBbqrType) {
-        startBbqrTimer();
-      }
+    if (!_isBbqrType) {
+      notifyListeners();
+      return;
     }
+
+    _bbqrParts = BbQrEncoder().encodeBase64(psbtBase64);
+    startBbqrTimer();
+
     notifyListeners();
   }
 

--- a/lib/screens/send/refactor/send_screen.dart
+++ b/lib/screens/send/refactor/send_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
+import 'package:coconut_wallet/extensions/int_extensions.dart';
 import 'package:coconut_wallet/extensions/string_extensions.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
@@ -947,7 +948,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
                           fit: BoxFit.scaleDown,
                           alignment: Alignment.centerRight,
                           child: Text(
-                            "${_viewModel.estimatedFeeInSats ?? '-'} sats",
+                            "${_viewModel.estimatedFeeInSats?.toThousandsSeparatedString() ?? '-'} sats",
                             style: CoconutTypography.body2_14_NumberBold.setColor(
                               _viewModel.isEstimatedFeeGreaterThanBalance ? CoconutColors.hotPink : CoconutColors.white,
                             ),
@@ -1205,21 +1206,22 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
           padding: const EdgeInsets.only(top: 40, left: 16, right: 16),
           child: Column(
             children: [
-              Selector<SendViewModel, Tuple7<BitcoinUnit, String, bool, bool, bool, bool, int?>>(
+              Selector<SendViewModel, Tuple7<String, bool, bool, BitcoinUnit, bool, bool, int?>>(
                 selector:
                     (_, viewModel) => Tuple7(
-                      viewModel.currentUnit,
                       viewModel.recipientList[index].amount,
-                      viewModel.isMaxMode,
-                      viewModel.isTotalSendAmountExceedsBalance,
                       viewModel.isLastAmountInsufficient,
                       viewModel.recipientList[index].minimumAmountError.isError,
+                      // 이하 리빌드를 위한 값들
+                      viewModel.currentUnit,
+                      viewModel.isMaxMode,
+                      viewModel.isTotalSendAmountExceedsBalance,
                       viewModel.estimatedFeeInSats,
                     ),
                 builder: (context, data, child) {
-                  String amountText = data.item2;
-                  final isMinimumAmount = data.item6;
-                  final hasInsufficientBalanceErrorOfLastRecipient = data.item5 && index == _viewModel.lastIndex;
+                  String amountText = data.item1;
+                  final hasInsufficientBalanceErrorOfLastRecipient = data.item2 && index == _viewModel.lastIndex;
+                  final isMinimumAmount = data.item3;
 
                   Color amountTextColor;
                   if (_viewModel.isTotalSendAmountExceedsBalance ||

--- a/lib/screens/send/unsigned_transaction_qr_screen.dart
+++ b/lib/screens/send/unsigned_transaction_qr_screen.dart
@@ -73,6 +73,10 @@ class _UnsignedTransactionQrScreenState extends State<UnsignedTransactionQrScree
                                   child: _buildToolTip(),
                                 ),
                                 AdaptiveQrImage(
+                                  key:
+                                      viewModel.isBbqrType && viewModel.hasBbqrParts
+                                          ? ValueKey('bbqr-${viewModel.currentBbqrIndex}')
+                                          : const ValueKey('ur'),
                                   qrData:
                                       viewModel.isBbqrType && viewModel.hasBbqrParts
                                           ? viewModel.bbqrParts[viewModel.currentBbqrIndex]

--- a/lib/utils/bb_qr/bb_qr_encoder.dart
+++ b/lib/utils/bb_qr/bb_qr_encoder.dart
@@ -8,7 +8,7 @@ class BbQrEncoder {
   final String encodingTypeInstance;
   final String dataTypeInstance;
 
-  BbQrEncoder({this.maxChunkSize = 800, String encodingType = 'Z', String dataType = 'P'})
+  BbQrEncoder({this.maxChunkSize = 700, String encodingType = 'Z', String dataType = 'P'})
     : encodingTypeInstance = encodingType,
       dataTypeInstance = dataType;
 

--- a/lib/widgets/custom_loading_overlay.dart
+++ b/lib/widgets/custom_loading_overlay.dart
@@ -10,7 +10,7 @@ class CustomLoadingOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LoaderOverlay(
-      overlayColor: CoconutColors.black.withOpacity(0.5),
+      overlayColor: CoconutColors.black.withValues(alpha: 0.5),
       overlayWidgetBuilder: (_) {
         return const Stack(
           children: [


### PR DESCRIPTION
### 증상
- psbt가 큰 경우, bbqr fragment를 정상적으로 보여주지 못함.

### 원인
- bbqr chunk 사이즈가 qr view 라이브러리의 maximum 사이즈 초과하는 문제
- unsigned_psbt 화면에서 타이머가 동작해도 fragmented bbqr을 제대로 렌더링하지 못하는 문제

### 조치 
- bbqr chunk 사이즈를 줄임
- qr 위젯 리렌더링을 위해 인덱스 기반 키 적용

### 테스트
- 콜드카드로 watch-only 추가
- 입력이 10개 이상 포함된 트랜잭션을 생성하여 fragmented bbqr이 출력되는지 확인합니다.
- utxo 합치기 / send 플로우에서 모두 정상 동작해야 합니다.