### PR TITLE
fix: stabilize electrum startup reconnect flow

### DIFF
--- a/lib/app_guard.dart
+++ b/lib/app_guard.dart
@@ -118,16 +118,34 @@ class _AppGuardState extends State<AppGuard> {
 
   /// NodeProvider 재연결
   void _handleNodeProviderReconnect() {
-    // 1. 이미 초기화되어 있고 연결이 정상인 경우 재연결하지 않음
-    if (_nodeProvider.isInitialized &&
-        !_nodeProvider.hasConnectionError &&
-        _nodeProvider.state.nodeSyncState != NodeSyncState.failed) {
+    // 1. 초기화가 진행 중이면 reconnect 무시
+    if (_nodeProvider.isInitializing) {
+      Logger.log('AppGuard: NodeProvider is initializing, skipping reconnect');
+      return;
+    }
+
+    // 2. 초기화 미완료 시 initialize 호출
+    if (!_nodeProvider.isInitialized) {
+      Logger.log('AppGuard: NodeProvider is not initialized yet, initializing instead of reconnect');
+      _nodeProvider.initialize();
+      return;
+    }
+
+    // 3. 초기 동기화(init/syncing) 중 reconnect 보류
+    final nodeSyncState = _nodeProvider.state.nodeSyncState;
+    if (nodeSyncState == NodeSyncState.init || nodeSyncState == NodeSyncState.syncing) {
+      Logger.log('AppGuard: NodeProvider is syncing, skipping reconnect');
+      return;
+    }
+
+    // 4. 이미 초기화되어 있고 연결이 정상인 경우 reconnect 무시
+    if (_nodeProvider.isInitialized && !_nodeProvider.hasConnectionError && nodeSyncState != NodeSyncState.failed) {
       Logger.log('AppGuard: Connection is healthy, skipping reconnect');
       return;
     }
 
-    // 2. 연결 에러가 있거나 ping이 실패한 경우 재연결
-    if (_nodeProvider.hasConnectionError || _nodeProvider.state.nodeSyncState == NodeSyncState.failed) {
+    // 5. 연결 에러가 있거나 ping이 실패한 경우 재연결
+    if (_nodeProvider.hasConnectionError || nodeSyncState == NodeSyncState.failed) {
       Logger.log('AppGuard: Connection issues detected, attempting reconnect');
       _nodeProvider.reconnect();
     }
@@ -135,6 +153,12 @@ class _AppGuardState extends State<AppGuard> {
 
   /// NodeProvider 연결 해제
   void _handleNodeProviderDisconnect() {
+    // 초기화 중/미초기화 상태에서 연결 해제 시도 시 연결 해제 무시
+    if (_nodeProvider.isInitializing || !_nodeProvider.isInitialized) {
+      Logger.log('AppGuard: NodeProvider is not ready for disconnect, skipping closeConnection');
+      return;
+    }
+
     // 1. 네트워크가 끊어진 경우 연결 해제
     if (!_connectivityProvider.isInternetOn) {
       Logger.log('AppGuard: Network disconnected, closing connection');

--- a/lib/providers/view_model/home/wallet_home_view_model.dart
+++ b/lib/providers/view_model/home/wallet_home_view_model.dart
@@ -254,7 +254,10 @@ class WalletHomeViewModel extends ChangeNotifier {
       return NetworkStatus.offline;
     }
 
-    if (_nodeSyncState == NodeSyncState.completed || _nodeProvider.isInitializing) {
+    if (_nodeSyncState == NodeSyncState.completed ||
+        _nodeSyncState == NodeSyncState.init ||
+        _nodeSyncState == NodeSyncState.syncing ||
+        _nodeProvider.isInitializing) {
       return NetworkStatus.online;
     }
 


### PR DESCRIPTION
## 증상
초기 구동 시 NodeProvider 초기화/동기화 중 AppGuard가 reconnect를 호출해 일렉트럼 연결이 해제되면서 홈 화면에 '일렉트럼 연결 오류' 상태가 나타나는 현상 

## 조치
- 초기 구동시 reconnect 호출 방지
- init/syncing 단계의 일시적 연결 에러를 홈 화면에 노출하지 않음.

## 테스트
- 월렛 초기 구동시 reconnect 및 wallet sync 오류 로그가 보이지 않아야 합니다.
- 네트워크 상태 변경 시, reconnect가 정상 호출됩니다.  