### PR TITLE
test(regtest): add hosted wallet broadcast E2E

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -4,7 +4,7 @@
 
 ## 테스트 실행 환경
 
-- 실제 모바일 기기가 연결되어 있어야 합니다.
+- 실제 모바일 기기 또는 Android 에뮬레이터가 연결되어 있어야 합니다.
 - Regtest flavor를 사용합니다.
 
 ## 테스트 실행 방법
@@ -13,6 +13,12 @@
 
 ```bash
 flutter test integration_test/<test_file>.dart --flavor regtest
+```
+
+FVM으로 Flutter 버전을 고정한 환경에서는 다음처럼 실행할 수 있습니다:
+
+```bash
+fvm flutter test integration_test/<test_file>.dart --flavor regtest -d <device_id>
 ```
 
 ## 디버깅을 하고 싶을 때
@@ -48,6 +54,10 @@ Flutter Test를 클릭해주고, Test File 경로를 지정합니다. Additional
 
 2. `realm_migration_test.dart`
    - 스키마 버전, 월렛 여부에 따른 Realm 마이그레이션 테스트
+
+3. `hosted_regtest_e2e_test.dart`
+   - Hosted regtest 환경에서 faucet fund, UTXO sync, PSBT 생성, Vault 서명, Wallet broadcast, transaction 조회까지 검증하는 E2E smoke 테스트
+   - seed, private key, raw PSBT, signed transaction 원문은 출력하지 않고 실패 시 공개 txid 수준의 정보만 남깁니다.
 
 ## 주의사항
 

--- a/integration_test/hosted_regtest_e2e_test.dart
+++ b/integration_test/hosted_regtest_e2e_test.dart
@@ -1,0 +1,254 @@
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/core/transaction/transaction_builder.dart';
+import 'package:coconut_wallet/enums/network_enums.dart';
+import 'package:coconut_wallet/enums/wallet_enums.dart';
+import 'package:coconut_wallet/model/utxo/utxo_state.dart';
+import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
+import 'package:coconut_wallet/model/wallet/watch_only_wallet.dart';
+import 'package:coconut_wallet/providers/node_provider/node_provider.dart';
+import 'package:coconut_wallet/providers/wallet_provider.dart';
+import 'package:coconut_wallet/repository/realm/realm_manager.dart';
+import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
+import 'package:coconut_wallet/repository/secure_storage/secure_storage_repository.dart';
+import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
+import 'package:coconut_wallet/screens/home/wallet_home_screen.dart';
+import 'package:coconut_wallet/services/faucet_service.dart';
+import 'package:coconut_wallet/services/model/error/default_error_response.dart';
+import 'package:coconut_wallet/services/model/request/faucet_request.dart';
+import 'package:coconut_wallet/services/model/response/faucet_response.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:provider/provider.dart';
+
+import 'integration_test_utils.dart';
+import 'package:coconut_wallet/main.dart' as app;
+
+const int _minimumSendSats = 10000;
+const double _feeRate = 1.0;
+
+/// Hosted NonceLab regtest end-to-end smoke test.
+///
+/// This test intentionally does not print seed material, raw PSBTs, signed
+/// transactions, or private keys. It only records public txids on failure.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late RealmManager realmManager;
+
+  setUp(() async {
+    realmManager = RealmManager();
+    realmManager.reset();
+
+    final prefs = SharedPrefsRepository();
+    await prefs.init();
+    await prefs.clearSharedPref();
+    await SecureStorageRepository().deleteAll();
+    await skipTutorial(true);
+  });
+
+  tearDown(() async {
+    realmManager.realm.close();
+  });
+
+  testWidgets('fund, sign, and broadcast via hosted regtest', (tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    final walletHomeScreen = find.byType(WalletHomeScreen);
+    await waitForWidget(
+      tester,
+      walletHomeScreen,
+      timeoutMessage: 'WalletHomeScreen not found after 60 seconds',
+    );
+
+    final context = tester.element(walletHomeScreen);
+    final walletProvider = Provider.of<WalletProvider>(context, listen: false);
+    final nodeProvider = Provider.of<NodeProvider>(context, listen: false);
+    final utxoRepository = Provider.of<UtxoRepository>(context, listen: false);
+
+    await _waitForNodeReady(nodeProvider);
+
+    final fundingVault = SingleSignatureVault.random(
+      addressType: AddressType.p2wpkh,
+    );
+    final recipientVault = SingleSignatureVault.random(
+      addressType: AddressType.p2wpkh,
+    );
+
+    final addResult = await walletProvider.syncFromCoconutVault(
+      WatchOnlyWallet(
+        'hosted regtest e2e',
+        0,
+        0,
+        fundingVault.descriptor,
+        null,
+        null,
+        WalletImportSource.coconutVault.name,
+      ),
+    );
+
+    expect(addResult.result, WalletSyncResult.newWalletAdded);
+    expect(addResult.walletId, isNotNull);
+
+    final walletId = addResult.walletId!;
+    final wallet = walletProvider.getWalletById(walletId);
+    final receiveAddress = walletProvider.getReceiveAddress(walletId).address;
+
+    final subscribeResult = await nodeProvider.subscribeWallet(wallet);
+    expect(
+      subscribeResult.isSuccess,
+      true,
+      reason: 'wallet subscription failed',
+    );
+
+    final faucet = Faucet();
+    final faucetStatus = await faucet.getStatus();
+    expect(faucetStatus.totalBalance, greaterThan(0));
+
+    final faucetAmountBtc = _selectFaucetAmount(
+      faucetStatus.minLimit,
+      faucetStatus.maxLimit,
+    );
+    final faucetResponse = await faucet.getTestCoin(
+      FaucetRequest(address: receiveAddress, amount: faucetAmountBtc),
+    );
+
+    if (faucetResponse is DefaultErrorResponse) {
+      fail('faucet rejected request: ${faucetResponse.message}');
+    }
+    expect(faucetResponse, isA<FaucetResponse>());
+    final fundingTxHash = (faucetResponse as FaucetResponse).txHash;
+    expect(fundingTxHash, isNotEmpty);
+    printOnFailure('funding txid: $fundingTxHash');
+
+    final fundedUtxos = await _waitForFundedUtxos(
+      nodeProvider: nodeProvider,
+      utxoRepository: utxoRepository,
+      walletId: walletId,
+      wallet: wallet,
+    );
+
+    final totalInputSats = fundedUtxos.fold<int>(
+      0,
+      (sum, utxo) => sum + utxo.amount,
+    );
+    expect(totalInputSats, greaterThan(_minimumSendSats));
+
+    final sendAmountSats = _selectSendAmount(totalInputSats);
+    final changeDerivationPath = '${fundingVault.derivationPath}/1/0';
+    final transactionBuildResult =
+        TransactionBuilder(
+          availableUtxos: fundedUtxos,
+          recipients: {recipientVault.getAddress(0): sendAmountSats},
+          feeRate: _feeRate,
+          changeDerivationPath: changeDerivationPath,
+          walletListItemBase: wallet,
+          isFeeSubtractedFromAmount: false,
+          isUtxoFixed: true,
+        ).build();
+
+    expect(
+      transactionBuildResult.isSuccess,
+      true,
+      reason: transactionBuildResult.exception?.toString(),
+    );
+
+    final unsignedPsbt = Psbt.fromTransaction(
+      transactionBuildResult.transaction!,
+      wallet.walletBase,
+    );
+    final signedPsbt = fundingVault.addSignatureToPsbt(
+      unsignedPsbt.serialize(),
+    );
+    final signedTransaction = Psbt.parse(
+      signedPsbt,
+    ).getSignedTransaction(wallet.walletType.addressType);
+
+    final broadcastResult = await nodeProvider.broadcast(signedTransaction);
+    expect(
+      broadcastResult.isSuccess,
+      true,
+      reason: broadcastResult.isFailure ? broadcastResult.error.message : null,
+    );
+    printOnFailure('broadcast txid: ${broadcastResult.value}');
+
+    final broadcastedTx = await nodeProvider.getTransaction(
+      broadcastResult.value,
+    );
+    expect(
+      broadcastedTx.isSuccess,
+      true,
+      reason: broadcastedTx.isFailure ? broadcastedTx.error.message : null,
+    );
+  });
+}
+
+Future<void> _waitForNodeReady(NodeProvider nodeProvider) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 60));
+  Object? lastError;
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      await nodeProvider.initialize();
+      final blockResult = await nodeProvider.getLatestBlock();
+      if (blockResult.isSuccess && blockResult.value.height > 0) {
+        return;
+      }
+      if (blockResult.isFailure) {
+        lastError = blockResult.error.message;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await Future<void>.delayed(const Duration(seconds: 2));
+  }
+
+  fail('node did not become ready within 60 seconds: $lastError');
+}
+
+Future<List<UtxoState>> _waitForFundedUtxos({
+  required NodeProvider nodeProvider,
+  required UtxoRepository utxoRepository,
+  required int walletId,
+  required WalletListItemBase wallet,
+}) async {
+  final deadline = DateTime.now().add(const Duration(minutes: 3));
+
+  while (DateTime.now().isBefore(deadline)) {
+    await nodeProvider.subscribeWallet(wallet);
+    final walletState = nodeProvider.state.registeredWallets[walletId];
+    final utxos =
+        utxoRepository
+            .getUtxoStateList(walletId)
+            .where(
+              (utxo) =>
+                  utxo.amount > 0 &&
+                  utxo.status != UtxoStatus.outgoing &&
+                  utxo.status != UtxoStatus.locked,
+            )
+            .toList();
+
+    if (utxos.isNotEmpty && walletState?.utxo == WalletSyncState.completed) {
+      return utxos;
+    }
+
+    await Future<void>.delayed(const Duration(seconds: 5));
+  }
+
+  fail('no funded hosted-regtest UTXO appeared within 3 minutes');
+}
+
+double _selectFaucetAmount(double minLimit, double maxLimit) {
+  final lowerBound = minLimit > 0 ? minLimit : 0.001;
+  final upperBound = maxLimit > 0 ? maxLimit : lowerBound;
+  final desired = lowerBound < 0.001 ? 0.001 : lowerBound;
+  return desired > upperBound ? upperBound : desired;
+}
+
+int _selectSendAmount(int totalInputSats) {
+  final half = totalInputSats ~/ 2;
+  if (half > _minimumSendSats) {
+    return half;
+  }
+  return _minimumSendSats;
+}

--- a/lib/providers/node_provider/node_provider.dart
+++ b/lib/providers/node_provider/node_provider.dart
@@ -44,14 +44,18 @@ class NodeProvider extends ChangeNotifier {
   bool _isPendingInitialization = false;
   bool _hasConnectionError = false;
   bool _isServerChanging = false;
+  bool _isDisposed = false;
 
   final _syncStateController = StreamController<NodeSyncState>.broadcast();
-  final _walletStateController = StreamController<Map<int, WalletUpdateInfo>>.broadcast();
+  final _walletStateController =
+      StreamController<Map<int, WalletUpdateInfo>>.broadcast();
   final _currentBlockController = StreamController<BlockTimestamp?>.broadcast();
 
-  final ValueNotifier<BlockTimestamp?> _currentBlockNotifier = ValueNotifier<BlockTimestamp?>(null);
+  final ValueNotifier<BlockTimestamp?> _currentBlockNotifier =
+      ValueNotifier<BlockTimestamp?>(null);
   Timer? _blockUpdateTimer;
-  ValueNotifier<BlockTimestamp?> get currentBlockNotifier => _currentBlockNotifier;
+  ValueNotifier<BlockTimestamp?> get currentBlockNotifier =>
+      _currentBlockNotifier;
 
   /// 전체 동기화 상태를 구독할 수 있는 스트림
   Stream<NodeSyncState> get syncStateStream {
@@ -86,7 +90,9 @@ class NodeProvider extends ChangeNotifier {
     return Stream.multi((controller) {
       controller.add(_currentBlockNotifier.value);
 
-      final subscription = _currentBlockController.stream.listen(controller.add);
+      final subscription = _currentBlockController.stream.listen(
+        controller.add,
+      );
       controller.onCancel = () => subscription.cancel();
     });
   }
@@ -144,7 +150,8 @@ class NodeProvider extends ChangeNotifier {
     _blockUpdateTimer = null;
   }
 
-  NodeProviderState get state => _stateManager?.state ?? NodeProviderState.initial();
+  NodeProviderState get state =>
+      _stateManager?.state ?? NodeProviderState.initial();
   bool get isInitialized => _initCompleter?.isCompleted ?? false;
   String get host => _electrumServer.host;
   int get port => _electrumServer.port;
@@ -163,7 +170,9 @@ class NodeProvider extends ChangeNotifier {
     this._analyticsService, {
     IsolateManager? isolateManager,
   }) : _isolateManager = isolateManager ?? IsolateManager() {
-    Logger.log('NodeProvider: initialized with $host:$port, ssl=$ssl, networkType=$_networkType');
+    Logger.log(
+      'NodeProvider: initialized with $host:$port, ssl=$ssl, networkType=$_networkType',
+    );
 
     _connectivityProvider.addListener(_onConnectivityChanged);
     _walletLoadStateNotifier.addListener(_onWalletLoadStateChanged);
@@ -172,10 +181,16 @@ class NodeProvider extends ChangeNotifier {
     _checkInitialNetworkState();
   }
 
+  void _notifyListenersIfActive() {
+    if (!_isDisposed) {
+      notifyListeners();
+    }
+  }
+
   void _setConnectionError(bool value) {
     if (_hasConnectionError != value) {
       _hasConnectionError = value;
-      notifyListeners();
+      _notifyListenersIfActive();
     }
   }
 
@@ -260,10 +275,14 @@ class NodeProvider extends ChangeNotifier {
         // 새로운 지갑 발견
         subscribeWallet(wallet).then((result) {
           if (result.isFailure) {
-            Logger.error('NodeProvider: [${wallet.name}] 지갑 구독 실패: ${result.error}');
+            Logger.error(
+              'NodeProvider: [${wallet.name}] 지갑 구독 실패: ${result.error}',
+            );
             _stateManager?.setNodeSyncStateToFailed();
           } else {
-            _analyticsService?.logEvent(eventName: AnalyticsEventNames.walletAddSyncCompleted);
+            _analyticsService?.logEvent(
+              eventName: AnalyticsEventNames.walletAddSyncCompleted,
+            );
           }
         });
       }
@@ -273,7 +292,7 @@ class NodeProvider extends ChangeNotifier {
   void _createStateManager() {
     _stateManager = NodeStateManager(
       () {
-        return notifyListeners();
+        return _notifyListenersIfActive();
       },
       _syncStateController,
       _walletStateController,
@@ -284,7 +303,9 @@ class NodeProvider extends ChangeNotifier {
   void _createNewCompleter() {
     if (_initCompleter != null && !_initCompleter!.isCompleted) {
       try {
-        _initCompleter!.completeError(Exception('NodeProvider: Previous initialization was cancelled'));
+        _initCompleter!.completeError(
+          Exception('NodeProvider: Previous initialization was cancelled'),
+        );
       } catch (e) {
         // 이미 완료된 경우 무시
       }
@@ -359,7 +380,7 @@ class NodeProvider extends ChangeNotifier {
       rethrow;
     } finally {
       _isInitializing = false;
-      notifyListeners();
+      _notifyListenersIfActive();
     }
   }
 
@@ -385,7 +406,8 @@ class NodeProvider extends ChangeNotifier {
   }
 
   Future<Result<bool>> subscribeWallets() async {
-    if (_walletLoadStateNotifier.value != WalletLoadState.loadCompleted || _connectivityProvider.isInternetOff) {
+    if (_walletLoadStateNotifier.value != WalletLoadState.loadCompleted ||
+        _connectivityProvider.isInternetOff) {
       return Result.success(false);
     }
     final walletItems = _walletItemListNotifier.value;
@@ -409,7 +431,9 @@ class NodeProvider extends ChangeNotifier {
   Future<Result<String>> broadcast(Transaction signedTx) async {
     final result = await _isolateManager.broadcast(signedTx);
     if (result.isFailure) {
-      Logger.error('NodeProvider.broadcast: failed code=${result.error.code} message=${result.error.message}');
+      Logger.error(
+        'NodeProvider.broadcast: failed code=${result.error.code} message=${result.error.message}',
+      );
       FileLogger.logBroadcast('NodeProvider failure code=${result.error.code}');
     }
     return result;
@@ -441,9 +465,15 @@ class NodeProvider extends ChangeNotifier {
     Duration? timeout,
   }) async {
     Logger.log('NodeProvider: getTransactionRecord called (txHash: $txHash)');
-    final result = await _isolateManager.getTransactionRecord(walletItem, txHash, timeout: timeout);
+    final result = await _isolateManager.getTransactionRecord(
+      walletItem,
+      txHash,
+      timeout: timeout,
+    );
     if (result.isFailure) {
-      Logger.error('NodeProvider.getTransactionRecord failed (txHash: $txHash) - error: ${result.error}');
+      Logger.error(
+        'NodeProvider.getTransactionRecord failed (txHash: $txHash) - error: ${result.error}',
+      );
     }
     return result;
   }
@@ -474,29 +504,39 @@ class NodeProvider extends ChangeNotifier {
       final walletLoadState = _walletLoadStateNotifier.value;
       final walletItems = _walletItemListNotifier.value;
 
-      if (walletLoadState == WalletLoadState.loadCompleted && walletItems.isNotEmpty) {
-        Logger.log('NodeProvider: Wallet Loaded & Wallet Items is Not Empty, start subscribing');
+      if (walletLoadState == WalletLoadState.loadCompleted &&
+          walletItems.isNotEmpty) {
+        Logger.log(
+          'NodeProvider: Wallet Loaded & Wallet Items is Not Empty, start subscribing',
+        );
         final result = await subscribeWallets();
-        notifyListeners();
+        _notifyListenersIfActive();
 
         if (result.isSuccess) {
           Logger.log('NodeProvider: Reconnect completed successfully');
           _setConnectionError(false);
           _restartBlockUpdates();
         } else {
-          Logger.error('NodeProvider: subscribeWallets failed: ${result.error}');
+          Logger.error(
+            'NodeProvider: subscribeWallets failed: ${result.error}',
+          );
           _stateManager?.setNodeSyncStateToFailed();
           _setConnectionError(true);
         }
-      } else if (walletLoadState == WalletLoadState.loadCompleted && walletItems.isEmpty) {
-        Logger.log('NodeProvider: Wallet Loaded & Wallet Items is Empty, set state to completed');
+      } else if (walletLoadState == WalletLoadState.loadCompleted &&
+          walletItems.isEmpty) {
+        Logger.log(
+          'NodeProvider: Wallet Loaded & Wallet Items is Empty, set state to completed',
+        );
         _stateManager?.setNodeSyncStateToCompleted();
         _setConnectionError(false);
-        notifyListeners();
+        _notifyListenersIfActive();
       } else {
-        Logger.log('NodeProvider: Wallet Loading, reset flag for auto-subscription');
+        Logger.log(
+          'NodeProvider: Wallet Loading, reset flag for auto-subscription',
+        );
         _isFirstInitialization = true;
-        notifyListeners();
+        _notifyListenersIfActive();
       }
     } catch (e) {
       Logger.error('NodeProvider: Reconnect failed: $e');
@@ -543,7 +583,7 @@ class NodeProvider extends ChangeNotifier {
       _initCompleter = null;
       _stateManager = null;
 
-      notifyListeners();
+      _notifyListenersIfActive();
       Logger.log('NodeProvider: Connection closed successfully');
     } catch (e) {
       Logger.error('NodeProvider: 연결 종료 중 오류 발생: $e');
@@ -552,17 +592,23 @@ class NodeProvider extends ChangeNotifier {
     }
   }
 
-  Future<Result<bool>> checkServerConnection(ElectrumServer electrumServer) async {
+  Future<Result<bool>> checkServerConnection(
+    ElectrumServer electrumServer,
+  ) async {
     final electrumService = ElectrumService();
 
     try {
       await _establishSocketConnection(electrumService, electrumServer);
       await _verifyProtocolCommunication(electrumService);
 
-      Logger.log('NodeProvider: 서버 연결 테스트 성공 - ${electrumServer.host}:${electrumServer.port}');
+      Logger.log(
+        'NodeProvider: 서버 연결 테스트 성공 - ${electrumServer.host}:${electrumServer.port}',
+      );
       return Result.success(true);
     } catch (e) {
-      Logger.error('NodeProvider: 서버 연결 확인 실패 - ${electrumServer.host}:${electrumServer.port}: $e');
+      Logger.error(
+        'NodeProvider: 서버 연결 확인 실패 - ${electrumServer.host}:${electrumServer.port}: $e',
+      );
       await electrumService.close();
       return Result.failure(ErrorCodes.networkError);
     } finally {
@@ -570,11 +616,17 @@ class NodeProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> _establishSocketConnection(ElectrumService service, ElectrumServer server) async {
+  Future<void> _establishSocketConnection(
+    ElectrumService service,
+    ElectrumServer server,
+  ) async {
     final isOnionHost = server.host.trim().toLowerCase().endsWith('.onion');
-    final connectionTimeout = isOnionHost ? kIsolateInitTimeoutForOnion : kIsolateInitTimeout;
+    final connectionTimeout =
+        isOnionHost ? kIsolateInitTimeoutForOnion : kIsolateInitTimeout;
 
-    await service.connect(server.host, server.port, ssl: server.ssl).timeout(connectionTimeout);
+    await service
+        .connect(server.host, server.port, ssl: server.ssl)
+        .timeout(connectionTimeout);
 
     if (service.connectionStatus != SocketConnectionStatus.connected) {
       throw Exception('Socket connection failed');
@@ -599,17 +651,17 @@ class NodeProvider extends ChangeNotifier {
         if (result.isFailure) {
           Logger.error('NodeProvider: 서버 변경 실패: ${result.error}');
           _stateManager?.setNodeSyncStateToFailed();
-          notifyListeners();
+          _notifyListenersIfActive();
         }
       });
 
       Logger.log('NodeProvider: 서버 변경 성공');
-      notifyListeners();
+      _notifyListenersIfActive();
       return Result.success(true);
     } catch (e) {
       Logger.error('NodeProvider: 서버 변경 중 초기화 실패: $e');
       _stateManager?.setNodeSyncStateToFailed();
-      notifyListeners();
+      _notifyListenersIfActive();
       return Result.failure(ErrorCodes.networkError);
     } finally {
       _isServerChanging = false;
@@ -618,6 +670,7 @@ class NodeProvider extends ChangeNotifier {
 
   @override
   void dispose() {
+    _isDisposed = true;
     _connectivityProvider.removeListener(_onConnectivityChanged);
     _walletLoadStateNotifier.removeListener(_onWalletLoadStateChanged);
     _walletItemListNotifier.removeListener(_onWalletItemListChanged);
@@ -628,6 +681,7 @@ class NodeProvider extends ChangeNotifier {
     _syncStateController.close();
     _walletStateController.close();
     _currentBlockController.close();
+    _currentBlockNotifier.dispose();
 
     super.dispose();
   }


### PR DESCRIPTION
Adds a hosted regtest emulator E2E smoke test for wallet import, faucet funding, UTXO sync, PSBT signing, broadcast, and transaction lookup. Also makes NodeProvider teardown safe after dispose. Verified with fvm dart analyze on changed Dart files and fvm flutter test integration_test/hosted_regtest_e2e_test.dart --flavor regtest -d emulator-5554.