### PR TITLE
[684] 월렛 - 지역별 소수점 표기 문제

### DIFF
--- a/lib/extensions/int_extensions.dart
+++ b/lib/extensions/int_extensions.dart
@@ -1,8 +1,9 @@
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:intl/intl.dart';
 
 extension IntFormatting on int {
-  String toThousandsSeparatedString() {
-    final formatter = NumberFormat('#,###');
+  String toThousandsSeparatedString({String? localeName}) {
+    final formatter = NumberFormat.decimalPattern(localeName ?? getNumberFormatLocaleName());
     return formatter.format(this);
   }
 }

--- a/lib/extensions/string_extensions.dart
+++ b/lib/extensions/string_extensions.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_wallet/extensions/int_extensions.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:intl/intl.dart';
 
 extension StringCheck on String {
@@ -7,12 +8,14 @@ extension StringCheck on String {
 }
 
 extension StringFormatting on String {
-  String toThousandsSeparatedString() {
+  String toThousandsSeparatedString({String? localeName}) {
     // String을 숫자로 변환할 수 없는 경우 원래 문자열 반환
     final number = num.tryParse(this);
     if (number == null) return this;
 
     try {
+      final effectiveLocale = localeName ?? getNumberFormatLocaleName();
+
       // 소수점이 있는지 확인
       if (contains('.')) {
         List<String> parts = split('.');
@@ -24,11 +27,11 @@ extension StringFormatting on String {
           decimalPart = "${decimalPart.substring(0, 4)} ${decimalPart.substring(4)}";
         }
 
-        final formatter = NumberFormat('#,###');
+        final formatter = NumberFormat.decimalPattern(effectiveLocale);
         String formattedInt = formatter.format(int.parse(integerPart));
-        return '$formattedInt.$decimalPart';
+        return '$formattedInt${formatter.symbols.DECIMAL_SEP}$decimalPart';
       } else {
-        return int.parse(this).toThousandsSeparatedString();
+        return int.parse(this).toThousandsSeparatedString(localeName: effectiveLocale);
       }
     } catch (e) {
       return this;

--- a/lib/providers/view_model/home/wallet_home_edit_view_model.dart
+++ b/lib/providers/view_model/home/wallet_home_edit_view_model.dart
@@ -16,7 +16,7 @@ class WalletHomeEditViewModel extends ChangeNotifier {
 
   late int minimumSatoshi;
   final int maximumAmount = 21000000;
-  final int maxInputLength = 17; // 21000000.00000000
+  final int maxInputLength = 19; // 21,000,000.00000000
 
   Map<int, dynamic> _fakeBalanceMap = {};
   int? _fakeBalanceTotalAmount;
@@ -45,7 +45,9 @@ class WalletHomeEditViewModel extends ChangeNotifier {
 
     _fakeBalanceTotalBtc =
         _preferenceProvider.fakeBalanceTotalAmount != null
-            ? UnitUtil.convertSatoshiToBitcoin(_preferenceProvider.fakeBalanceTotalAmount!)
+            ? UnitUtil.convertSatoshiToBitcoin(
+              _preferenceProvider.fakeBalanceTotalAmount!,
+            )
             : null;
 
     if (_fakeBalanceTotalBtc != null) {
@@ -63,8 +65,10 @@ class WalletHomeEditViewModel extends ChangeNotifier {
     _tempHomeFeatures =
         _preferenceProvider.homeFeatures
             .map(
-              (feature) =>
-                  HomeFeature(homeFeatureTypeString: feature.homeFeatureTypeString, isEnabled: feature.isEnabled),
+              (feature) => HomeFeature(
+                homeFeatureTypeString: feature.homeFeatureTypeString,
+                isEnabled: feature.isEnabled,
+              ),
             )
             .toList();
     _tempIsBalanceHidden = isBalanceHidden;
@@ -192,7 +196,9 @@ class WalletHomeEditViewModel extends ChangeNotifier {
   }
 
   void toggleTempHomeFeatureEnabled(String homeFeatureTypeString) {
-    final index = _tempHomeFeatures.indexWhere((element) => element.homeFeatureTypeString == homeFeatureTypeString);
+    final index = _tempHomeFeatures.indexWhere(
+      (element) => element.homeFeatureTypeString == homeFeatureTypeString,
+    );
     if (index != -1) {
       final feature = _tempHomeFeatures[index];
       _tempHomeFeatures[index] = HomeFeature(
@@ -239,7 +245,9 @@ class WalletHomeEditViewModel extends ChangeNotifier {
         debugPrint('[Wallet $i]Fake Balance: ${fakeBalanceMap[i]} BTC');
       }
       await _preferenceProvider.setFakeBalanceMap(fakeBalanceMap);
-      await _preferenceProvider.toggleFakeBalanceActivation(_tempIsFakeBalanceActive);
+      await _preferenceProvider.toggleFakeBalanceActivation(
+        _tempIsFakeBalanceActive,
+      );
       return;
     }
 
@@ -251,7 +259,10 @@ class WalletHomeEditViewModel extends ChangeNotifier {
     final random = Random();
     // 1. 각 지갑에 최소 1사토시 할당
     // 2. 남은 사토시를 랜덤 가중치로 분배
-    final List<int> weights = List.generate(walletCount, (_) => random.nextInt(100) + 1); // 1~100
+    final List<int> weights = List.generate(
+      walletCount,
+      (_) => random.nextInt(100) + 1,
+    ); // 1~100
     final int weightSum = weights.reduce((a, b) => a + b);
     final int remainingSats = (fakeSats - walletCount);
     final List<int> splits = [];
@@ -268,7 +279,9 @@ class WalletHomeEditViewModel extends ChangeNotifier {
     final Map<int, dynamic> fakeBalanceMap = {};
 
     if (_preferenceProvider.isFakeBalanceActive != _tempIsFakeBalanceActive) {
-      await _preferenceProvider.toggleFakeBalanceActivation(_tempIsFakeBalanceActive);
+      await _preferenceProvider.toggleFakeBalanceActivation(
+        _tempIsFakeBalanceActive,
+      );
     }
 
     await _preferenceProvider.setFakeBalanceTotalAmount(fakeSats);

--- a/lib/providers/view_model/home/wallet_list_view_model.dart
+++ b/lib/providers/view_model/home/wallet_list_view_model.dart
@@ -33,6 +33,7 @@ class WalletListViewModel extends ChangeNotifier {
   late PreferenceProvider _preferenceProvider;
   late bool? _isNetworkOn;
   Map<int, AnimatedBalanceData> _walletBalance = {};
+  late List<WalletListItemBase> _walletItemListSnapshot;
 
   bool _isFirstLoaded = false;
   NodeSyncState _nodeSyncState = NodeSyncState.syncing;
@@ -80,6 +81,7 @@ class WalletListViewModel extends ChangeNotifier {
     _visibleFiats = _preferenceProvider.walletListVisibleFiats;
     _syncNodeStateStream = _nodeProvider.syncStateStream;
     _syncNodeStateSubscription = _syncNodeStateStream.listen(_handleNodeSyncState);
+    _walletItemListSnapshot = List<WalletListItemBase>.from(_walletProvider.walletItemList);
     _walletBalance = _walletProvider.fetchWalletBalanceMap().map(
       (key, balance) => MapEntry(key, AnimatedBalanceData(balance.total, balance.total)),
     );
@@ -153,9 +155,12 @@ class WalletListViewModel extends ChangeNotifier {
   }
 
   void onPreferenceProviderUpdated() {
+    var didChange = false;
+
     /// 지갑 순서 변경 체크
     if (!const ListEquality().equals(_walletOrder, _preferenceProvider.walletOrder)) {
       _walletOrder = _preferenceProvider.walletOrder;
+      didChange = true;
     }
 
     /// 총 잔액에서 제외할 지갑 목록 변경 체크
@@ -164,14 +169,18 @@ class WalletListViewModel extends ChangeNotifier {
       _preferenceProvider.excludedFromTotalBalanceWalletIds.toSet(),
     )) {
       _excludedFromTotalBalanceWalletIds = _preferenceProvider.excludedFromTotalBalanceWalletIds;
+      didChange = true;
     }
 
     /// 보여지는 통화 목록 변경 체크
     if (!const ListEquality().equals(_visibleFiats, _preferenceProvider.walletListVisibleFiats)) {
       _visibleFiats = _preferenceProvider.walletListVisibleFiats;
+      didChange = true;
     }
 
-    notifyListeners();
+    if (didChange) {
+      notifyListeners();
+    }
   }
 
   Future<void> updateWalletBalances() async {
@@ -188,8 +197,12 @@ class WalletListViewModel extends ChangeNotifier {
   }
 
   void onWalletProviderUpdated(WalletProvider walletProvider) {
+    final didProviderChange = !identical(_walletProvider, walletProvider);
     _walletProvider = walletProvider;
-    notifyListeners();
+
+    if (_updateWalletItemListSnapshot() || didProviderChange) {
+      notifyListeners();
+    }
   }
 
   void onNodeProviderUpdated() {
@@ -352,6 +365,10 @@ class WalletListViewModel extends ChangeNotifier {
   }
 
   void setVisibleFiats(List<FiatCode> fiats) {
+    if (const ListEquality().equals(_visibleFiats, fiats)) {
+      return;
+    }
+
     _preferenceProvider.setWalletListVisibleFiats(fiats);
     _visibleFiats = _preferenceProvider.walletListVisibleFiats;
     notifyListeners();
@@ -363,8 +380,36 @@ class WalletListViewModel extends ChangeNotifier {
   }
 
   void setWalletListFiatHidden(bool isHidden) {
+    if (_preferenceProvider.isWalletListFiatHidden == isHidden) {
+      return;
+    }
+
     _preferenceProvider.setWalletListFiatHidden(isHidden);
     notifyListeners();
+  }
+
+  bool _updateWalletItemListSnapshot() {
+    final walletItemList = _walletProvider.walletItemList;
+    if (_isSameWalletItemList(_walletItemListSnapshot, walletItemList)) {
+      return false;
+    }
+
+    _walletItemListSnapshot = List<WalletListItemBase>.from(walletItemList);
+    return true;
+  }
+
+  bool _isSameWalletItemList(List<WalletListItemBase> previous, List<WalletListItemBase> current) {
+    if (previous.length != current.length) {
+      return false;
+    }
+
+    for (var i = 0; i < previous.length; i++) {
+      if (previous[i].toString() != current[i].toString()) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   @override

--- a/lib/providers/view_model/send/refactor/send_view_model.dart
+++ b/lib/providers/view_model/send/refactor/send_view_model.dart
@@ -594,7 +594,10 @@ class SendViewModel extends ChangeNotifier with FeeRateMixin {
         maxBalanceInSats > _dustThreshold
             ? (_currentUnit.isBasedOnSatoshi
                     ? maxBalanceInSats
-                    : BalanceFormatUtil.formatSatoshiToReadableBitcoin(maxBalanceInSats).replaceAll(' ', ''))
+                    : BalanceFormatUtil.formatSatoshiToReadableBitcoin(
+                      maxBalanceInSats,
+                      localeName: 'en_US',
+                    ).replaceAll(' ', ''))
                 .toString()
             : "0";
 
@@ -798,6 +801,7 @@ class SendViewModel extends ChangeNotifier with FeeRateMixin {
 
   void onKeyTap(String newInput) {
     if (_currentIndex == _recipientList.length) return;
+    if (newInput == ',') newInput = '.';
     if (_currentUnit.isBasedOnSatoshi && newInput == '.') return;
 
     final recipient = _recipientList[_currentIndex];

--- a/lib/providers/view_model/utility/p2p_calculator_view_model.dart
+++ b/lib/providers/view_model/utility/p2p_calculator_view_model.dart
@@ -207,15 +207,15 @@ class P2PCalculatorViewModel extends ChangeNotifier {
     if (_inputAssetType == InputAssetType.fiat) {
       switch (_fiatCode) {
         case FiatCode.KRW:
-          return '50,000';
+          return 50000.toThousandsSeparatedString();
         case FiatCode.USD:
           return '50';
         case FiatCode.JPY:
-          return '5,000';
+          return 5000.toThousandsSeparatedString();
       }
     } else {
       if (_currentUnit.isBasedOnSatoshi) {
-        return '50,000';
+        return 50000.toThousandsSeparatedString();
       } else {
         return '0.0005';
       }

--- a/lib/providers/view_model/utility/p2p_calculator_view_model.dart
+++ b/lib/providers/view_model/utility/p2p_calculator_view_model.dart
@@ -8,6 +8,7 @@ import 'package:coconut_wallet/providers/price_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/utils/fiat_util.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/vibration_util.dart';
 import 'package:dio/dio.dart';
@@ -217,7 +218,7 @@ class P2PCalculatorViewModel extends ChangeNotifier {
       if (_currentUnit.isBasedOnSatoshi) {
         return 50000.toThousandsSeparatedString();
       } else {
-        return '0.0005';
+        return formatBtc(50000);
       }
     }
   }
@@ -257,7 +258,10 @@ class P2PCalculatorViewModel extends ChangeNotifier {
 
   String formatBtc(int sats) {
     var result = BalanceFormatUtil.formatSatoshiToReadableBitcoin(sats);
-    if (result.endsWith('.')) result = result.substring(0, result.length - 1);
+    final decimalSeparator = getNumberDecimalSeparator();
+    if (result.endsWith(decimalSeparator)) {
+      result = result.substring(0, result.length - decimalSeparator.length);
+    }
     return result;
   }
 

--- a/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/fee_bumping_view_model.dart
@@ -23,6 +23,8 @@ import 'package:coconut_wallet/repository/realm/wallet_preferences_repository.da
 import 'package:coconut_wallet/screens/wallet_detail/transaction_fee_bumping_screen.dart';
 import 'package:coconut_wallet/services/fee_service.dart';
 import 'package:coconut_wallet/services/model/response/recommended_fee.dart';
+import 'package:coconut_wallet/extensions/int_extensions.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/wallet_util.dart';
 import 'package:flutter/foundation.dart';
@@ -517,7 +519,7 @@ class FeeBumpingViewModel extends ChangeNotifier {
       newTxSize: _formatNumber(baseline.estimatedVSize),
       recommendedFeeRate: _formatNumber(_feeInfos[2].satsPerVb!),
       originalTxSize: _formatNumber(_pendingTx.vSize),
-      originalFee: _pendingTx.fee,
+      originalFee: _pendingTx.fee.toThousandsSeparatedString(),
       totalRequiredFee: _formatNumber(totalRequiredFee),
       newTxFee: _formatNumber(requiredNewTxFee),
       newTxFeeRate: _formatNumber(baseline.minimumFeeRate),
@@ -526,6 +528,12 @@ class FeeBumpingViewModel extends ChangeNotifier {
   }
 
   String _formatNumber(double value) {
-    return value % 1 == 0 ? value.toInt().toString() : value.toStringAsFixed(2);
+    if (value % 1 == 0) {
+      return value.toInt().toThousandsSeparatedString();
+    }
+
+    final parts = value.toStringAsFixed(2).split('.');
+    final integerPart = int.parse(parts[0]).toThousandsSeparatedString();
+    return '$integerPart${getNumberDecimalSeparator()}${parts[1]}';
   }
 }

--- a/lib/providers/view_model/wallet_detail/utxo_merge/utxo_merge_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_merge/utxo_merge_view_model.dart
@@ -18,6 +18,7 @@ import 'package:coconut_wallet/utils/bitcoin/transaction_util.dart';
 import 'package:coconut_wallet/extensions/int_extensions.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/utils/fee_rate_mixin.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:coconut_wallet/model/wallet/wallet_address.dart';
@@ -459,7 +460,7 @@ class UtxoMergeViewModel extends ChangeNotifier with FeeRateMixin {
   int candidateUtxoCountForCustomAmountText(String text, {required bool isLessThan}) {
     if (text.trim().isEmpty) return 0;
 
-    final btcAmount = double.tryParse(text.trim());
+    final btcAmount = double.tryParse(normalizeDecimalNumberTextForParsing(text.trim()));
     if (btcAmount == null || btcAmount == 0) return 0;
 
     final satsThreshold = UnitUtil.convertBitcoinToSatoshi(btcAmount);
@@ -708,7 +709,9 @@ class UtxoMergeViewModel extends ChangeNotifier with FeeRateMixin {
       return null;
     }
     try {
-      return UnitUtil.convertBitcoinToSatoshi(double.parse(_customAmountRangeText!.trim()));
+      return UnitUtil.convertBitcoinToSatoshi(
+        double.parse(normalizeDecimalNumberTextForParsing(_customAmountRangeText!.trim())),
+      );
     } catch (_) {
       return null;
     }

--- a/lib/providers/view_model/wallet_detail/utxo_merge/utxo_merge_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_merge/utxo_merge_view_model.dart
@@ -429,7 +429,7 @@ class UtxoMergeViewModel extends ChangeNotifier with FeeRateMixin {
   }
 
   void removeTrailingDotInFeeRate() {
-    feeRateController.text = removeTrailingDotInFeeRateText(feeRateController.text);
+    feeRateController.text = removeTrailingDotInFeeRateText(feeRateInput);
   }
 
   void setFeeRateFromRecommendation(double sats) {
@@ -439,7 +439,7 @@ class UtxoMergeViewModel extends ChangeNotifier with FeeRateMixin {
 
   Future<bool> refreshRecommendedFees() async {
     return fetchRecommendedFees(
-      currentFeeRateText: feeRateController.text,
+      currentFeeRateText: feeRateInput,
       onDefaultFeeRateSet: (text) => feeRateController.text = text,
     );
   }
@@ -479,7 +479,7 @@ class UtxoMergeViewModel extends ChangeNotifier with FeeRateMixin {
     );
   }
 
-  String get feeRateInput => feeRateController.text.trim();
+  String get feeRateInput => normalizeDecimalNumberTextForParsing(feeRateController.text.trim());
 
   bool get canPrepareMergeTransaction {
     return _currentStep == UtxoMergeStep.selectReceiveAddress &&

--- a/lib/providers/view_model/wallet_detail/utxo_split/utxo_split_view_model.dart
+++ b/lib/providers/view_model/wallet_detail/utxo_split/utxo_split_view_model.dart
@@ -12,6 +12,7 @@ import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/preferences/preference_provider.dart';
 import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/utils/fee_rate_mixin.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/utils/logger.dart';
@@ -356,7 +357,7 @@ class UtxoSplitViewModel extends ChangeNotifier with FeeRateMixin {
   }
 
   double get feeRate {
-    final feeRateText = feeRateController.text;
+    final feeRateText = normalizeDecimalNumberTextForParsing(feeRateController.text);
     return double.tryParse(feeRateText) ?? 0.0;
   }
 
@@ -501,7 +502,7 @@ class UtxoSplitViewModel extends ChangeNotifier with FeeRateMixin {
   // --- Network ---
   Future<bool> refreshRecommendedFees() async {
     return await fetchRecommendedFees(
-      currentFeeRateText: feeRateController.text,
+      currentFeeRateText: normalizeDecimalNumberTextForParsing(feeRateController.text),
       onDefaultFeeRateSet: (text) {
         feeRateController.text = text;
         _splitBuilder.feeRate = double.parse(text);
@@ -814,7 +815,9 @@ class UtxoSplitViewModel extends ChangeNotifier with FeeRateMixin {
   }
 
   void removeTrailingDotInFeeRate() {
-    feeRateController.text = removeTrailingDotInFeeRateText(feeRateController.text);
+    feeRateController.text = removeTrailingDotInFeeRateText(
+      normalizeDecimalNumberTextForParsing(feeRateController.text),
+    );
   }
 
   void restoreFeeRateIfZero() {

--- a/lib/screens/common/bip21_amount_bottom_sheet.dart
+++ b/lib/screens/common/bip21_amount_bottom_sheet.dart
@@ -3,6 +3,7 @@ import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/screens/common/single_text_field_bottom_sheet.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/text_field_filter_util.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -22,9 +23,11 @@ class Bip21AmountBottomSheet {
     required BitcoinUnit currentUnit,
     required int? initialAmountSats,
   }) {
+    final localeName = getNumberFormatLocaleName();
     final initialText = BalanceFormatUtil.formatSatsToBip21InputText(
       currentUnit: currentUnit,
       initialAmountSats: initialAmountSats,
+      localeName: localeName,
     );
 
     return SingleTextFieldBottomSheet.showWithResult<Bip21AmountBottomSheetResult>(
@@ -37,8 +40,8 @@ class Bip21AmountBottomSheet {
       collapsedHeight: 240,
       textInputFormatters:
           currentUnit.isBtcUnit
-              ? [FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')), const BtcAmountInputFormatter()]
-              : [FilteringTextInputFormatter.digitsOnly, const SatoshiAmountInputFormatter()],
+              ? [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')), BtcAmountInputFormatter(localeName: localeName)]
+              : [FilteringTextInputFormatter.digitsOnly, SatoshiAmountInputFormatter(localeName: localeName)],
       completeEnabledWhen: (current, original) => current != original,
       focusOnlyWhenOriginalNotEmpty: false,
       prefix:
@@ -53,7 +56,11 @@ class Bip21AmountBottomSheet {
               ? Text(currentUnit.symbol, style: CoconutTypography.body2_14_Bold)
               : null,
       resultBuilder: (currentText, originalText) {
-        final sats = BalanceFormatUtil.parseBip21AmountTextToSats(currentUnit: currentUnit, inputText: currentText);
+        final sats = BalanceFormatUtil.parseBip21AmountTextToSats(
+          currentUnit: currentUnit,
+          inputText: currentText,
+          localeName: localeName,
+        );
         return Bip21AmountBottomSheetResult(didEdit: currentText != originalText, amountInSats: sats);
       },
     );

--- a/lib/screens/home/wallet_home_edit_screen.dart
+++ b/lib/screens/home/wallet_home_edit_screen.dart
@@ -7,7 +7,7 @@ import 'package:coconut_wallet/providers/preferences/preference_provider.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_home_edit_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
-import 'package:coconut_wallet/utils/logger.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/text_field_filter_util.dart';
 import 'package:coconut_wallet/widgets/button/fixed_bottom_button.dart';
 import 'package:coconut_wallet/widgets/button/shrink_animation_button.dart';
@@ -31,7 +31,8 @@ class WalletHomeEditScreen extends StatefulWidget {
   State<WalletHomeEditScreen> createState() => _WalletHomeEditScreenState();
 }
 
-class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with TickerProviderStateMixin {
+class _WalletHomeEditScreenState extends State<WalletHomeEditScreen>
+    with TickerProviderStateMixin {
   final TextEditingController _textEditingController = TextEditingController();
   late WalletHomeEditViewModel _viewModel;
   late final ScrollController _scrollController;
@@ -50,7 +51,9 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // 하단 버튼 사이즈 계산
       if (fixedBottomButtonKey.currentContext != null) {
-        final fixedBottomButtonRenderBox = fixedBottomButtonKey.currentContext?.findRenderObject() as RenderBox;
+        final fixedBottomButtonRenderBox =
+            fixedBottomButtonKey.currentContext?.findRenderObject()
+                as RenderBox;
         setState(() {
           _fixedBottomButtonSize = fixedBottomButtonRenderBox.size;
         });
@@ -62,12 +65,15 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
           _textEditingController.text = '0';
         } else if (_viewModel.tempFakeBalanceTotalBtc! % 1 == 0) {
           // 정수일 때
-          _textEditingController.text = _viewModel.tempFakeBalanceTotalBtc.toString().split('.')[0];
+          _textEditingController.text =
+              _viewModel.tempFakeBalanceTotalBtc.toString().split('.')[0];
         } else {
           // 아주 작은 소수일 때 e-8로 표시되는 경우가 있음 -> toStringAsFixed(8)로 8자리까지 표시 후 뒤에 0이 있으면 제거
-          _textEditingController.text = _viewModel.tempFakeBalanceTotalBtc!
-              .toStringAsFixed(8)
-              .replaceFirst(RegExp(r'\.?0+$'), '');
+          _textEditingController.text = _formatBtcTextForDisplay(
+            _viewModel.tempFakeBalanceTotalBtc!
+                .toStringAsFixed(8)
+                .replaceFirst(RegExp(r'\.?0+$'), ''),
+          );
         }
       }
 
@@ -90,7 +96,9 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
         _debounceTimer = Timer(const Duration(milliseconds: 300), () {
           if (!mounted) return;
 
-          final text = _textEditingController.text.replaceAll(',', '');
+          final text = normalizeDecimalNumberTextForParsing(
+            _textEditingController.text,
+          );
           final input = text.isEmpty ? null : double.tryParse(text);
           final error =
               (input != null && input > _viewModel.maximumAmount)
@@ -121,13 +129,20 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
   }
 
   WalletHomeEditViewModel _createViewModel() {
-    _viewModel = WalletHomeEditViewModel(context.read<WalletProvider>(), context.read<PreferenceProvider>());
+    _viewModel = WalletHomeEditViewModel(
+      context.read<WalletProvider>(),
+      context.read<PreferenceProvider>(),
+    );
     return _viewModel;
   }
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProxyProvider2<WalletProvider, PreferenceProvider, WalletHomeEditViewModel>(
+    return ChangeNotifierProxyProvider2<
+      WalletProvider,
+      PreferenceProvider,
+      WalletHomeEditViewModel
+    >(
       create: (context) => _createViewModel(),
       update: (context, walletProvider, preferenceProvider, previous) {
         previous ??= _createViewModel();
@@ -152,7 +167,8 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                     return CoconutPopup(
                       languageCode: context.read<PreferenceProvider>().language,
                       title: t.wallet_list.edit.finish,
-                      description: t.wallet_list.edit.unsaved_changes_confirm_exit,
+                      description:
+                          t.wallet_list.edit.unsaved_changes_confirm_exit,
                       leftButtonText: t.cancel,
                       rightButtonText: t.confirm,
                       onTapRight: () {
@@ -188,34 +204,62 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                         children: [
                           CoconutLayout.spacing_100h,
                           Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 30),
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 20,
+                              vertical: 30,
+                            ),
                             child: SizedBox(
                               width: MediaQuery.sizeOf(context).width / 3 * 2,
                               child: FittedBox(
                                 fit: BoxFit.scaleDown,
                                 alignment: Alignment.centerLeft,
-                                child: Text(t.wallet_home_screen.edit.title, style: CoconutTypography.heading3_21_Bold),
+                                child: Text(
+                                  t.wallet_home_screen.edit.title,
+                                  style: CoconutTypography.heading3_21_Bold,
+                                ),
                               ),
                             ),
                           ),
-                          const Divider(height: 1, color: CoconutColors.gray700),
-                          if (context.read<WalletProvider>().walletItemList.isNotEmpty) ...[
+                          const Divider(
+                            height: 1,
+                            color: CoconutColors.gray700,
+                          ),
+                          if (context
+                              .read<WalletProvider>()
+                              .walletItemList
+                              .isNotEmpty) ...[
                             Consumer<WalletHomeEditViewModel>(
                               builder: (context, viewModel, child) {
                                 return Column(
                                   children: [
                                     SingleButton(
                                       isVerticalSubtitle: true,
-                                      title: t.wallet_home_screen.edit.hide_balance,
-                                      subtitle: t.wallet_home_screen.edit.hide_balance_on_home,
-                                      subtitleStyle: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
-                                      customPadding: const EdgeInsets.fromLTRB(20, 16, 20, 10),
+                                      title:
+                                          t
+                                              .wallet_home_screen
+                                              .edit
+                                              .hide_balance,
+                                      subtitle:
+                                          t
+                                              .wallet_home_screen
+                                              .edit
+                                              .hide_balance_on_home,
+                                      subtitleStyle: CoconutTypography.body3_12
+                                          .setColor(CoconutColors.gray400),
+                                      customPadding: const EdgeInsets.fromLTRB(
+                                        20,
+                                        16,
+                                        20,
+                                        10,
+                                      ),
                                       onPressed: () async {
                                         if (_textFieldFocusNode.hasFocus) {
                                           FocusScope.of(context).unfocus();
                                           return;
                                         }
-                                        viewModel.setTempIsBalanceHidden(!viewModel.tempIsBalanceHidden);
+                                        viewModel.setTempIsBalanceHidden(
+                                          !viewModel.tempIsBalanceHidden,
+                                        );
                                       },
                                       backgroundColor: CoconutColors.black,
                                       rightElement: CoconutSwitch(
@@ -225,23 +269,43 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                         trackColor: CoconutColors.gray600,
                                         thumbColor: CoconutColors.gray800,
                                         onChanged: (value) {
-                                          viewModel.setTempIsBalanceHidden(value);
+                                          viewModel.setTempIsBalanceHidden(
+                                            value,
+                                          );
                                         },
                                       ),
                                     ),
                                     SingleButton(
                                       isVerticalSubtitle: true,
-                                      title: t.wallet_home_screen.edit.fake_balance.fake_balance_display,
-                                      subtitle: t.wallet_home_screen.edit.fake_balance.fake_balance_input_description,
-                                      subtitleStyle: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
-                                      customPadding: const EdgeInsets.fromLTRB(20, 10, 20, 10),
+                                      title:
+                                          t
+                                              .wallet_home_screen
+                                              .edit
+                                              .fake_balance
+                                              .fake_balance_display,
+                                      subtitle:
+                                          t
+                                              .wallet_home_screen
+                                              .edit
+                                              .fake_balance
+                                              .fake_balance_input_description,
+                                      subtitleStyle: CoconutTypography.body3_12
+                                          .setColor(CoconutColors.gray400),
+                                      customPadding: const EdgeInsets.fromLTRB(
+                                        20,
+                                        10,
+                                        20,
+                                        10,
+                                      ),
                                       onPressed: () async {
                                         if (_textFieldFocusNode.hasFocus) {
                                           FocusScope.of(context).unfocus();
                                           return;
                                         }
 
-                                        viewModel.setTempFakeBalanceActive(!viewModel.tempIsFakeBalanceActive);
+                                        viewModel.setTempFakeBalanceActive(
+                                          !viewModel.tempIsFakeBalanceActive,
+                                        );
                                       },
                                       backgroundColor: Colors.transparent,
                                       rightElement: CoconutSwitch(
@@ -251,23 +315,41 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                         trackColor: CoconutColors.gray600,
                                         thumbColor: CoconutColors.gray800,
                                         onChanged: (value) {
-                                          viewModel.setTempFakeBalanceActive(value);
+                                          viewModel.setTempFakeBalanceActive(
+                                            value,
+                                          );
                                         },
                                       ),
                                     ),
                                     _buildDelayedFakeBalanceInput(),
                                     SingleButton(
                                       isVerticalSubtitle: true,
-                                      title: t.wallet_home_screen.edit.hide_fiat_price,
-                                      subtitle: t.wallet_home_screen.edit.hide_fiat_price_on_home,
-                                      subtitleStyle: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
-                                      customPadding: const EdgeInsets.fromLTRB(20, 10, 20, 16),
+                                      title:
+                                          t
+                                              .wallet_home_screen
+                                              .edit
+                                              .hide_fiat_price,
+                                      subtitle:
+                                          t
+                                              .wallet_home_screen
+                                              .edit
+                                              .hide_fiat_price_on_home,
+                                      subtitleStyle: CoconutTypography.body3_12
+                                          .setColor(CoconutColors.gray400),
+                                      customPadding: const EdgeInsets.fromLTRB(
+                                        20,
+                                        10,
+                                        20,
+                                        16,
+                                      ),
                                       onPressed: () async {
                                         if (_textFieldFocusNode.hasFocus) {
                                           FocusScope.of(context).unfocus();
                                           return;
                                         }
-                                        viewModel.setTempIsFiatBalanceHidden(!viewModel.tempIsFiatBalanceHidden);
+                                        viewModel.setTempIsFiatBalanceHidden(
+                                          !viewModel.tempIsFiatBalanceHidden,
+                                        );
                                       },
                                       backgroundColor: CoconutColors.black,
                                       rightElement: CoconutSwitch(
@@ -277,7 +359,9 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                         trackColor: CoconutColors.gray600,
                                         thumbColor: CoconutColors.gray800,
                                         onChanged: (value) {
-                                          viewModel.setTempIsFiatBalanceHidden(value);
+                                          viewModel.setTempIsFiatBalanceHidden(
+                                            value,
+                                          );
                                         },
                                       ),
                                     ),
@@ -285,7 +369,10 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                 );
                               },
                             ),
-                            const Divider(height: 1, color: CoconutColors.gray700),
+                            const Divider(
+                              height: 1,
+                              color: CoconutColors.gray700,
+                            ),
                           ],
                           CoconutLayout.spacing_500h,
                           _buildHomeWidgetSelector(),
@@ -308,17 +395,41 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                           isActive: _shouldEnableCompleteButton(),
                           onButtonClicked: () async {
                             FocusScope.of(context).unfocus();
-                            if (viewModel.tempIsFakeBalanceActive && _textEditingController.text.isEmpty) {
+                            if (viewModel.tempIsFakeBalanceActive &&
+                                _textEditingController.text.isEmpty) {
                               // 가짜 잔액을 활성화 했지만 금액을 입력하지 않았을 때 -> 0으로 설정할지 다시입력할지 물어봄
                               showDialog(
                                 context: context,
                                 builder: (BuildContext context) {
                                   return CoconutPopup(
-                                    languageCode: context.read<PreferenceProvider>().language,
-                                    title: t.wallet_home_screen.edit.alert.empty_fake_balance,
-                                    description: t.wallet_home_screen.edit.alert.empty_fake_balance_description,
-                                    leftButtonText: t.wallet_home_screen.edit.alert.enter_again,
-                                    rightButtonText: t.wallet_home_screen.edit.alert.set_to_0,
+                                    languageCode:
+                                        context
+                                            .read<PreferenceProvider>()
+                                            .language,
+                                    title:
+                                        t
+                                            .wallet_home_screen
+                                            .edit
+                                            .alert
+                                            .empty_fake_balance,
+                                    description:
+                                        t
+                                            .wallet_home_screen
+                                            .edit
+                                            .alert
+                                            .empty_fake_balance_description,
+                                    leftButtonText:
+                                        t
+                                            .wallet_home_screen
+                                            .edit
+                                            .alert
+                                            .enter_again,
+                                    rightButtonText:
+                                        t
+                                            .wallet_home_screen
+                                            .edit
+                                            .alert
+                                            .set_to_0,
                                     onTapRight: () async {
                                       viewModel.setTempFakeBalanceTotalBtc(0);
 
@@ -357,12 +468,17 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
   }
 
   bool _shouldEnableCompleteButton() {
-    final text = _textEditingController.text;
+    final text = normalizeDecimalNumberTextForParsing(
+      _textEditingController.text,
+    );
 
     final isToggleChanged =
-        _viewModel.tempIsFakeBalanceActive != _viewModel.isFakeBalanceActive || // 가짜잔액표시 변동
-        _viewModel.tempIsBalanceHidden != _viewModel.isBalanceHidden || // 잔액숨기기 변동
-        _viewModel.tempIsFiatBalanceHidden != _viewModel.isFiatBalanceHidden || // 법정화폐잔액숨기기 변동
+        _viewModel.tempIsFakeBalanceActive !=
+            _viewModel.isFakeBalanceActive || // 가짜잔액표시 변동
+        _viewModel.tempIsBalanceHidden !=
+            _viewModel.isBalanceHidden || // 잔액숨기기 변동
+        _viewModel.tempIsFiatBalanceHidden !=
+            _viewModel.isFiatBalanceHidden || // 법정화폐잔액숨기기 변동
         !_viewModel.tempHomeFeatures.every((tempFeature) {
           // 홈 화면 기능 변동
           final original = _viewModel.homeFeatures.firstWhere(
@@ -373,14 +489,14 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
         });
     if (_viewModel.tempIsFakeBalanceActive) {
       if (_viewModel.fakeBalanceTotalAmount == null) return true;
-      final expectedText = UnitUtil.convertSatoshiToBitcoin(
+      final expectedValue = UnitUtil.convertSatoshiToBitcoin(
         _viewModel.fakeBalanceTotalAmount!,
-      ).toStringAsFixed(8).replaceFirst(RegExp(r'\.?0*$'), '');
-      final isTextChanged = text != expectedText;
+      );
+      final parsed = text.isEmpty ? null : double.tryParse(text);
+      final isTextChanged = parsed != expectedValue;
       // 가짜 잔액 표시가 활성화 되더라도 입력값이 없으면 변동되지 않음
       if (!isTextChanged) return isToggleChanged;
 
-      final parsed = double.tryParse(text);
       if (parsed != 0 && _viewModel.inputError != FakeBalanceInputError.none) {
         return false;
       }
@@ -392,6 +508,10 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
   void _onComplete() async {
     if (_textEditingController.text.isEmpty) {}
     await _viewModel.onComplete();
+  }
+
+  String _formatBtcTextForDisplay(String text) {
+    return text.replaceAll('.', getNumberDecimalSeparator());
   }
 
   Widget _buildHomeWidgetSelector() {
@@ -438,7 +558,9 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                     int itemsPerRow = 3;
 
                     // 각 아이템의 너비 계산 (spacing과 패딩을 제외하고 가득 차도록 설정)
-                    double itemWidth = (constraints.maxWidth - spacing * (itemsPerRow - 1)) / itemsPerRow;
+                    double itemWidth =
+                        (constraints.maxWidth - spacing * (itemsPerRow - 1)) /
+                        itemsPerRow;
 
                     return Wrap(
                       spacing: spacing,
@@ -452,18 +574,25 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                 onPressed: () {
                                   FocusScope.of(context).unfocus();
                                   if (fixedWidgets.any(
-                                    (fixed) => fixed['homeFeatureTypeString'] == widget['homeFeatureTypeString'],
+                                    (fixed) =>
+                                        fixed['homeFeatureTypeString'] ==
+                                        widget['homeFeatureTypeString'],
                                   )) {
                                     // 고정 위젯인 경우 토글 불가
                                     CoconutToast.showToast(
                                       context: context,
-                                      text: t.wallet_home_screen.cannot_modify_fixed_widget,
+                                      text:
+                                          t
+                                              .wallet_home_screen
+                                              .cannot_modify_fixed_widget,
                                       isVisibleIcon: true,
                                     );
                                     return;
                                   }
                                   // homeFeatureTypeString을 통해 토글
-                                  _viewModel.toggleTempHomeFeatureEnabled(widget['homeFeatureTypeString'].toString());
+                                  _viewModel.toggleTempHomeFeatureEnabled(
+                                    widget['homeFeatureTypeString'].toString(),
+                                  );
                                 },
                                 defaultColor: CoconutColors.gray800,
                                 pressedColor: CoconutColors.gray750,
@@ -471,11 +600,14 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                   child: Container(
                                     height: 100,
                                     width: 100,
-                                    decoration: BoxDecoration(borderRadius: BorderRadius.circular(12)),
+                                    decoration: BoxDecoration(
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
                                     child: Padding(
                                       padding: const EdgeInsets.all(14),
                                       child: Column(
-                                        crossAxisAlignment: CrossAxisAlignment.end,
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.end,
                                         children: [
                                           Stack(
                                             children: [
@@ -484,11 +616,19 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                                 child: FixedTextScale(
                                                   child: FittedBox(
                                                     fit: BoxFit.scaleDown,
-                                                    alignment: Alignment.centerLeft,
+                                                    alignment:
+                                                        Alignment.centerLeft,
                                                     child: Text(
-                                                      _getHomeFeatureLabel(widget['homeFeatureTypeString'].toString()),
+                                                      _getHomeFeatureLabel(
+                                                        widget['homeFeatureTypeString']
+                                                            .toString(),
+                                                      ),
                                                       maxLines: 2,
-                                                      style: CoconutTypography.body2_14.setColor(CoconutColors.white),
+                                                      style: CoconutTypography
+                                                          .body2_14
+                                                          .setColor(
+                                                            CoconutColors.white,
+                                                          ),
                                                     ),
                                                   ),
                                                 ),
@@ -496,18 +636,28 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                               Align(
                                                 alignment: Alignment.topRight,
                                                 child: AnimatedContainer(
-                                                  duration: const Duration(milliseconds: 100),
+                                                  duration: const Duration(
+                                                    milliseconds: 100,
+                                                  ),
                                                   width: 16,
                                                   height: 16,
                                                   decoration: BoxDecoration(
                                                     shape: BoxShape.circle,
                                                     color:
-                                                        (widget['isEnabled'] as bool)
-                                                            ? CoconutColors.white
-                                                            : CoconutColors.gray800,
+                                                        (widget['isEnabled']
+                                                                as bool)
+                                                            ? CoconutColors
+                                                                .white
+                                                            : CoconutColors
+                                                                .gray800,
                                                     border: Border.all(
-                                                      width: (widget['isEnabled'] as bool) ? 0 : 1.5,
-                                                      color: CoconutColors.gray600,
+                                                      width:
+                                                          (widget['isEnabled']
+                                                                  as bool)
+                                                              ? 0
+                                                              : 1.5,
+                                                      color:
+                                                          CoconutColors.gray600,
                                                     ),
                                                   ),
                                                   child: Center(
@@ -515,12 +665,16 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                                       'assets/svg/check.svg',
                                                       width: 6,
                                                       height: 6,
-                                                      colorFilter: ColorFilter.mode(
-                                                        (widget['isEnabled'] as bool)
-                                                            ? CoconutColors.gray800
-                                                            : CoconutColors.gray600,
-                                                        BlendMode.srcIn,
-                                                      ),
+                                                      colorFilter:
+                                                          ColorFilter.mode(
+                                                            (widget['isEnabled']
+                                                                    as bool)
+                                                                ? CoconutColors
+                                                                    .gray800
+                                                                : CoconutColors
+                                                                    .gray600,
+                                                            BlendMode.srcIn,
+                                                          ),
                                                     ),
                                                   ),
                                                 ),
@@ -528,7 +682,10 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                                             ],
                                           ),
                                           const Spacer(),
-                                          SvgPicture.asset(widget['icon']!.toString(), width: 32),
+                                          SvgPicture.asset(
+                                            widget['icon']!.toString(),
+                                            width: 32,
+                                          ),
                                         ],
                                       ),
                                     ),
@@ -582,15 +739,21 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                 height: viewModel.tempIsFakeBalanceActive ? null : 0,
                 padding: const EdgeInsets.symmetric(horizontal: 20),
                 child: CoconutTextField(
-                  textInputType: const TextInputType.numberWithOptions(decimal: true),
+                  textInputType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                  ),
                   textInputFormatter: [
-                    FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+                    FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
                     const BtcAmountInputFormatter(),
                   ],
                   placeholderText:
                       viewModel.tempFakeBalanceTotalBtc != null
                           ? ''
-                          : t.wallet_home_screen.edit.fake_balance.fake_balance_input_placeholder,
+                          : t
+                              .wallet_home_screen
+                              .edit
+                              .fake_balance
+                              .fake_balance_input_placeholder,
                   isLengthVisible: false,
                   controller: _textEditingController,
                   focusNode: _textFieldFocusNode,
@@ -602,7 +765,8 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
                   cursorColor: CoconutColors.white,
                   maxLength: viewModel.maxInputLength,
                   errorText:
-                      _viewModel.inputError == FakeBalanceInputError.exceedsTotalSupply
+                      _viewModel.inputError ==
+                              FakeBalanceInputError.exceedsTotalSupply
                           ? '  ${t.wallet_home_screen.edit.fake_balance.fake_balance_input_exceeds_error}'
                           : '',
                   isError: _viewModel.inputError != FakeBalanceInputError.none,
@@ -612,7 +776,10 @@ class _WalletHomeEditScreenState extends State<WalletHomeEditScreen> with Ticker
               CoconutLayout.spacing_400h,
             ],
           ),
-          crossFadeState: viewModel.tempIsFakeBalanceActive ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+          crossFadeState:
+              viewModel.tempIsFakeBalanceActive
+                  ? CrossFadeState.showSecond
+                  : CrossFadeState.showFirst,
         );
       },
     );

--- a/lib/screens/home/wallet_list_screen.dart
+++ b/lib/screens/home/wallet_list_screen.dart
@@ -224,6 +224,7 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
   Widget _buildEditModeHeader() {
     SvgPicture starIcon = SvgPicture.asset('assets/svg/star-small.svg', width: 16, height: 16);
     SvgPicture hamburgerIcon = SvgPicture.asset('assets/svg/hamburger.svg', width: 16, height: 16);
+    SvgPicture deleteIcon = SvgPicture.asset('assets/svg/delete.svg', width: 16, height: 16);
     return Container(
       width: MediaQuery.sizeOf(context).width,
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -239,6 +240,7 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
               TextSpan(text: '${t.select} '),
               WidgetSpan(alignment: PlaceholderAlignment.top, child: starIcon),
               const TextSpan(text: ' '),
+              TextSpan(text: t.wallet_list.edit.star_description),
             ] else ...[
               WidgetSpan(alignment: PlaceholderAlignment.top, child: starIcon),
               TextSpan(text: t.wallet_list.edit.star_description),
@@ -250,6 +252,7 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
               TextSpan(text: '${t.tap} '),
               WidgetSpan(alignment: PlaceholderAlignment.top, child: hamburgerIcon),
               const TextSpan(text: ' '),
+              TextSpan(text: t.wallet_list.edit.order_description),
             ] else ...[
               WidgetSpan(alignment: PlaceholderAlignment.top, child: hamburgerIcon),
               TextSpan(text: t.wallet_list.edit.order_description),

--- a/lib/screens/send/refactor/send_screen.dart
+++ b/lib/screens/send/refactor/send_screen.dart
@@ -24,6 +24,7 @@ import 'package:coconut_wallet/utils/address_scan_util.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/utils/dashed_border_painter.dart';
 import 'package:coconut_wallet/utils/fee_rate_mixin.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/vibration_util.dart';
 import 'package:coconut_wallet/utils/wallet_util.dart';
 import 'package:coconut_wallet/screens/wallet_detail/wallet_info_screen.dart';
@@ -152,7 +153,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
         final amountText =
             _viewModel.currentUnit.isBasedOnSatoshi
                 ? sats.toString()
-                : BalanceFormatUtil.formatSatoshiToReadableBitcoin(sats);
+                : UnitUtil.convertSatoshiToBitcoin(sats).toString();
         _amountController.text = amountText;
         _viewModel.setAmountText(sats, 0);
       });
@@ -326,7 +327,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
 
   void _setDropdownMenuVisiblility(bool isVisible) {
     if (isVisible) {
-      _feeRateController.text = _removeTrailingDot(_feeRateController.text);
+      _feeRateController.text = _removeTrailingDecimalSeparator(_feeRateController.text);
       _amountController.text = _removeTrailingDot(_amountController.text);
       FocusManager.instance.primaryFocus?.unfocus();
 
@@ -623,7 +624,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
         keyboardType: TextInputType.numberWithOptions(signed: false, decimal: allowDecimal),
         inputFormatters:
             allowDecimal
-                ? [FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')), SingleDotInputFormatter()]
+                ? [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')), const SingleDotInputFormatter()]
                 : [FilteringTextInputFormatter.digitsOnly],
       ),
     );
@@ -701,6 +702,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
   }
 
   Widget _buildFeeItem(String imagePath, double? sats, bool isFetching) {
+    final feeRateText = sats != null ? _formatDecimalTextForDisplay(sats.toStringAsFixed(1)) : "-";
     final child = MediaQuery(
       data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
       child: Container(
@@ -722,7 +724,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
               fit: BoxFit.scaleDown,
               alignment: Alignment.centerRight,
               child: Text(
-                "${sats != null ? sats.toStringAsFixed(1) : "-"} ${t.send_screen.fee_rate_suffix}",
+                "$feeRateText ${t.send_screen.fee_rate_suffix}",
                 style: CoconutTypography.body2_14.setColor(CoconutColors.white),
               ),
             ),
@@ -736,7 +738,9 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
         borderRadius: 8,
         onTap: () {
           if (isFetching) return;
-          _feeRateController.text = sats != null ? sats.toStringAsFixed(1) : '';
+          final feeRateText = sats != null ? sats.toStringAsFixed(1) : '';
+          _feeRateController.text = _formatDecimalTextForDisplay(feeRateText);
+          _viewModel.setFeeRateText(feeRateText);
           _clearFocus();
         },
         child:
@@ -1033,21 +1037,26 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
                     data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
                     child: CoconutTextField(
                       textInputType: const TextInputType.numberWithOptions(signed: false, decimal: true),
-                      textInputFormatter: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.]'))],
+                      textInputFormatter: [
+                        FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+                        const SingleDotInputFormatter(normalizeToDot: false),
+                      ],
                       enableInteractiveSelection: false,
                       textAlign: TextAlign.end,
                       controller: _feeRateController,
                       focusNode: _feeRateFocusNode,
                       backgroundColor: feeRateFieldGray,
                       onEditingComplete: () {
-                        _feeRateController.text = _removeTrailingDot(_feeRateController.text);
+                        _feeRateController.text = _removeTrailingDecimalSeparator(_feeRateController.text);
                         FocusScope.of(context).unfocus();
                       },
                       height: 30,
                       padding: const EdgeInsets.only(left: 12, right: 2),
                       onChanged: (text) {
-                        final isTooLow = _viewModel.handleFeeRateChanged(text, (formattedText) {
-                          _feeRateController.text = formattedText;
+                        final normalizedText = _normalizeDecimalTextForParsing(text);
+                        final isTooLow = _viewModel.handleFeeRateChanged(normalizedText, (formattedText) {
+                          final displayText = _formatDecimalTextForDisplay(formattedText);
+                          _feeRateController.text = displayText;
                           _viewModel.setFeeRateText(formattedText);
                         });
                         if (isTooLow) {
@@ -1898,7 +1907,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
         final amountText =
             _viewModel.currentUnit.isBasedOnSatoshi
                 ? bip21Data.amount!.toString()
-                : BalanceFormatUtil.formatSatoshiToReadableBitcoin(bip21Data.amount!);
+                : UnitUtil.convertSatoshiToBitcoin(bip21Data.amount!).toString();
         _amountController.text = amountText;
         _viewModel.setAmountText(bip21Data.amount!, index);
       }
@@ -1936,7 +1945,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
   }
 
   void _onFeeRateTextUpdate(String text) {
-    _feeRateController.text = text;
+    _feeRateController.text = _formatDecimalTextForDisplay(text);
   }
 
   void _onAmountTextUpdate(String text) {
@@ -1992,7 +2001,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
     final focusNode = FocusNode();
     focusNode.addListener(
       () => setState(() {
-        _feeRateController.text = _removeTrailingDot(_feeRateController.text);
+        _feeRateController.text = _removeTrailingDecimalSeparator(_feeRateController.text);
         _amountController.text = _removeTrailingDot(_amountController.text);
 
         final isOwn = controller.text.length >= 26 && _viewModel.isOwnAddress(controller.text);
@@ -2050,7 +2059,7 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
   }
 
   void _clearFocus() {
-    _feeRateController.text = _removeTrailingDot(_feeRateController.text);
+    _feeRateController.text = _removeTrailingDecimalSeparator(_feeRateController.text);
     _amountController.text = _removeTrailingDot(_amountController.text);
     FocusManager.instance.primaryFocus?.unfocus();
 
@@ -2073,6 +2082,22 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
       return text.substring(0, text.length - 1);
     }
     return text;
+  }
+
+  String _removeTrailingDecimalSeparator(String text) {
+    final decimalSeparator = getNumberDecimalSeparator();
+    if (text.endsWith(decimalSeparator) || text.endsWith('.')) {
+      return text.substring(0, text.length - 1);
+    }
+    return text;
+  }
+
+  String _formatDecimalTextForDisplay(String text) {
+    return text.replaceAll('.', getNumberDecimalSeparator());
+  }
+
+  String _normalizeDecimalTextForParsing(String text) {
+    return text.replaceAll(getNumberDecimalSeparator(), '.').replaceAll(',', '.');
   }
 
   /// recipientList와 _addressControllerList 동기화
@@ -2132,13 +2157,31 @@ class _SendScreenState extends State<SendScreen> with SingleTickerProviderStateM
 }
 
 class SingleDotInputFormatter extends TextInputFormatter {
+  final bool normalizeToDot;
+
+  const SingleDotInputFormatter({this.normalizeToDot = true});
+
   @override
   TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
     final text = newValue.text;
-    // 소수점이 2개 이상이면 입력 취소
-    if ('.'.allMatches(text).length > 1) return oldValue;
+    final decimalSeparator = getNumberDecimalSeparator();
+    final groupingSeparator = getNumberGroupingSeparator();
+    if (_insertedText(oldValue, newValue).contains(groupingSeparator)) {
+      return oldValue;
+    }
 
-    return newValue;
+    final normalizedText = text.replaceAll(decimalSeparator, '.');
+    if ('.'.allMatches(normalizedText).length > 1) return oldValue;
+
+    return newValue.copyWith(text: normalizeToDot ? normalizedText : text);
+  }
+
+  String _insertedText(TextEditingValue oldValue, TextEditingValue newValue) {
+    if (newValue.text.length <= oldValue.text.length) return '';
+
+    final start = oldValue.selection.baseOffset.clamp(0, oldValue.text.length).toInt();
+    final end = (start + (newValue.text.length - oldValue.text.length)).clamp(0, newValue.text.length).toInt();
+    return newValue.text.substring(start, end);
   }
 }
 

--- a/lib/screens/utility/p2p_calculator_screen.dart
+++ b/lib/screens/utility/p2p_calculator_screen.dart
@@ -17,6 +17,7 @@ import 'package:coconut_wallet/screens/home/wallet_home_screen.dart';
 import 'package:coconut_wallet/screens/send/refactor/select_wallet_bottom_sheet.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 import 'package:coconut_wallet/utils/clipboard_copy_util.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/vibration_util.dart';
 import 'package:coconut_wallet/widgets/button/shrink_animation_button.dart';
 import 'package:coconut_wallet/widgets/overlays/common_bottom_sheets.dart';
@@ -64,7 +65,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
   @override
   void initState() {
     super.initState();
-    _premiumController = TextEditingController(text: '1.0');
+    _premiumController = TextEditingController(text: _formatLocaleDecimalText('1.0'));
     _inputController = TextEditingController();
     _scrollController = ScrollController();
 
@@ -84,7 +85,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
   void _resetCalculator() {
     _isUpdatingController = true;
     _inputController.clear();
-    _premiumController.text = '1.0';
+    _premiumController.text = _formatLocaleDecimalText('1.0');
     _isUpdatingController = false;
     _viewModel.resetInput();
   }
@@ -158,30 +159,35 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
   }
 
   void _formatPremiumOnFocusLost() {
-    var text = _premiumController.text;
+    var text = _normalizeLocaleDecimalText(_premiumController.text);
 
     if (text.isEmpty) {
-      _premiumController.text = '0';
+      text = '0';
     } else if (text.endsWith('.')) {
-      _premiumController.text = '${text}0';
+      text = '${text}0';
     } else if (!text.contains('.')) {
-      _premiumController.text = '$text.0';
+      text = '$text.0';
     }
 
-    _viewModel.setPremiumRate(double.tryParse(_premiumController.text) ?? 0);
+    _premiumController.text = _formatLocaleDecimalText(text);
+    _viewModel.setPremiumRate(double.tryParse(text) ?? 0);
   }
 
   void _handlePremiumInputChanged(String value) {
-    var text = value;
+    var text = _normalizeLocaleDecimalText(value);
 
     if (text == '.') {
-      _premiumController.value = const TextEditingValue(text: '0.', selection: TextSelection.collapsed(offset: 2));
+      final formattedText = _formatLocaleDecimalText('0.');
+      _premiumController.value = TextEditingValue(
+        text: formattedText,
+        selection: TextSelection.collapsed(offset: formattedText.length),
+      );
       return;
     }
 
     final regex = RegExp(r'^\d{0,2}(\.\d{0,1})?$');
     if (!regex.hasMatch(text)) {
-      final prevText = _viewModel.premiumRate.toStringAsFixed(1);
+      final prevText = _formatLocaleDecimalText(_viewModel.premiumRate.toStringAsFixed(1));
       _premiumController.value = TextEditingValue(
         text: prevText,
         selection: TextSelection.collapsed(offset: prevText.length),
@@ -204,8 +210,12 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
       }
     }
 
-    if (text != _premiumController.text) {
-      _premiumController.value = TextEditingValue(text: text, selection: TextSelection.collapsed(offset: text.length));
+    final formattedText = _formatLocaleDecimalText(text);
+    if (formattedText != _premiumController.text) {
+      _premiumController.value = TextEditingValue(
+        text: formattedText,
+        selection: TextSelection.collapsed(offset: formattedText.length),
+      );
     }
 
     _viewModel.setPremiumRate(double.tryParse(text) ?? 0);
@@ -584,6 +594,31 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     }
   }
 
+  String _formatLocaleDecimalText(String text) {
+    return text.replaceAll('.', getNumberDecimalSeparator());
+  }
+
+  String _normalizeLocaleDecimalText(String text) {
+    return text.replaceAll(',', '.');
+  }
+
+  double _parsePremiumRate() {
+    return double.tryParse(_normalizeLocaleDecimalText(_premiumController.text)) ?? 0;
+  }
+
+  String _formatPremiumAmount(double amount) {
+    final fixedText = amount.toStringAsFixed(2);
+    final parts = fixedText.split('.');
+    final integerText = int.parse(parts[0]).toThousandsSeparatedString();
+    final decimalText = parts.length > 1 ? parts[1] : '';
+
+    if (decimalText == '00') {
+      return integerText;
+    }
+
+    return '$integerText${getNumberDecimalSeparator()}$decimalText';
+  }
+
   void _onShowTransactionBill() {
     if (!_viewModel.isNetworkOn) {
       CoconutToast.showToast(context: context, text: t.errors.network_error, isVisibleIcon: true);
@@ -615,9 +650,10 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
         _viewModel.inputAssetType == InputAssetType.fiat
             ? _viewModel.formatSatsResult(result)
             : _viewModel.formatSatsResult(input);
-    final premiumRateStr = '${_premiumController.text}%';
+    final premiumRateValueStr = _formatLocaleDecimalText(_premiumController.text);
+    final premiumRateStr = '$premiumRateValueStr%';
 
-    final premiumRate = double.tryParse(_premiumController.text) ?? 0;
+    final premiumRate = _parsePremiumRate();
     double premiumAmount;
     if (_viewModel.inputAssetType == InputAssetType.fiat) {
       premiumAmount = input * premiumRate / 100;
@@ -629,10 +665,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     final btcPrice = _viewModel.btcPrice ?? 0;
     final premiumSats = btcPrice > 0 ? ((premiumAmount / btcPrice) * 100000000).round() : 0;
 
-    final premiumAmountStr = premiumAmount
-        .toStringAsFixed(2)
-        .replaceAll(RegExp(r'\.00$'), '')
-        .replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (Match m) => '${m[1]},');
+    final premiumAmountStr = _formatPremiumAmount(premiumAmount);
     final premiumSatsStr = premiumSats.toThousandsSeparatedString();
 
     vibrateLight();
@@ -710,7 +743,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                               const SizedBox(height: 20),
                               _buildBillRow(
                                 t.utility.p2p_calculator.transaction_premium,
-                                '${_premiumController.text} %',
+                                '$premiumRateValueStr %',
                                 valueLineHeight: 1.0,
                               ),
                               const SizedBox(height: 2),
@@ -1400,6 +1433,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                   height: 22,
                   textInputAction: TextInputAction.done,
                   textInputType: const TextInputType.numberWithOptions(signed: false, decimal: true),
+                  textInputFormatter: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))],
                   onChanged: _handlePremiumInputChanged,
                   textAlign: TextAlign.end,
                   isVisibleBorder: false,
@@ -1590,10 +1624,10 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
 
   void _onToolbarButtonPressed(String value) {
     if (_premiumFocusNode.hasFocus) {
-      final currentPremium = double.tryParse(_premiumController.text) ?? 0;
+      final currentPremium = _parsePremiumRate();
       final addValue = double.tryParse(value) ?? 0;
       final newPremium = (currentPremium + addValue).clamp(0.0, 99.9);
-      _premiumController.text = newPremium.toStringAsFixed(1);
+      _premiumController.text = _formatLocaleDecimalText(newPremium.toStringAsFixed(1));
       _viewModel.setPremiumRate(newPremium);
       _updateResultOnPremiumChange();
     } else if (_inputFocusNode.hasFocus) {
@@ -1621,10 +1655,10 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     final isInputFocused = _inputFocusNode.hasFocus;
     if (isPremiumFocused) {
       return [
-        {'label': '+0.1 %', 'value': '0.1'},
-        {'label': '+0.5 %', 'value': '0.5'},
-        {'label': '+1.0 %', 'value': '1.0'},
-        {'label': '+5.0 %', 'value': '5.0'},
+        {'label': '+${_formatLocaleDecimalText('0.1')} %', 'value': '0.1'},
+        {'label': '+${_formatLocaleDecimalText('0.5')} %', 'value': '0.5'},
+        {'label': '+${_formatLocaleDecimalText('1.0')} %', 'value': '1.0'},
+        {'label': '+${_formatLocaleDecimalText('5.0')} %', 'value': '5.0'},
       ];
     }
 

--- a/lib/screens/utility/p2p_calculator_screen.dart
+++ b/lib/screens/utility/p2p_calculator_screen.dart
@@ -277,8 +277,12 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     // "." 입력 시 "0."으로 자동 변환
     if (btcText == '.') {
       btcText = '0.';
+      final formattedText = _formatLocaleDecimalText('0.');
       _isUpdatingController = true;
-      _inputController.value = const TextEditingValue(text: '0.', selection: TextSelection.collapsed(offset: 2));
+      _inputController.value = TextEditingValue(
+        text: formattedText,
+        selection: TextSelection.collapsed(offset: formattedText.length),
+      );
       _isUpdatingController = false;
       _viewModel.setInputAmount(0);
       return;
@@ -332,11 +336,11 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     final formattedInt = intVal.toThousandsSeparatedString();
 
     if (hasDotOnly) {
-      return '$formattedInt.';
+      return '$formattedInt${getNumberDecimalSeparator()}';
     } else if (decPart.isEmpty) {
       return formattedInt;
     } else {
-      return '$formattedInt.$decPart';
+      return '$formattedInt${getNumberDecimalSeparator()}$decPart';
     }
   }
 
@@ -572,9 +576,10 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     if (!isBtcInput) {
       return value.replaceAll(RegExp(r'[^0-9]'), '');
     } else {
+      final normalizedValue = normalizeNumberTextForParsing(value);
       final buffer = StringBuffer();
       bool dotSeen = false;
-      for (final ch in value.split('')) {
+      for (final ch in normalizedValue.split('')) {
         if (ch == '.' && !dotSeen) {
           buffer.write('.');
           dotSeen = true;
@@ -1351,7 +1356,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                             placeholderText: effectivePlaceholder,
                             textInputFormatter:
                                 postfix == t.btc
-                                    ? [FilteringTextInputFormatter.allow(RegExp(r'[0-9.]'))]
+                                    ? [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))]
                                     : [FilteringTextInputFormatter.digitsOnly],
                             onChanged: _handleAmountInputChanged,
                             textInputType:
@@ -1631,7 +1636,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
       _viewModel.setPremiumRate(newPremium);
       _updateResultOnPremiumChange();
     } else if (_inputFocusNode.hasFocus) {
-      final currentText = _inputController.text.replaceAll(RegExp(r'[^0-9.]'), '');
+      final currentText = normalizeNumberTextForParsing(_inputController.text);
 
       if (_viewModel.inputAssetType == InputAssetType.fiat) {
         final currentValue = int.tryParse(currentText) ?? 0;
@@ -1668,10 +1673,10 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
       switch (_viewModel.fiatCode) {
         case FiatCode.KRW:
           return [
-            {'label': '+10,000', 'value': '10000'},
-            {'label': '+50,000', 'value': '50000'},
-            {'label': '+100,000', 'value': '100000'},
-            {'label': '+500,000', 'value': '500000'},
+            {'label': '+${10000.toThousandsSeparatedString()}', 'value': '10000'},
+            {'label': '+${50000.toThousandsSeparatedString()}', 'value': '50000'},
+            {'label': '+${100000.toThousandsSeparatedString()}', 'value': '100000'},
+            {'label': '+${500000.toThousandsSeparatedString()}', 'value': '500000'},
           ];
         case FiatCode.USD:
           return [
@@ -1682,27 +1687,27 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
           ];
         case FiatCode.JPY:
           return [
-            {'label': '+1,000', 'value': '1000'},
-            {'label': '+5,000', 'value': '5000'},
-            {'label': '+10,000', 'value': '10000'},
-            {'label': '+50,000', 'value': '50000'},
+            {'label': '+${1000.toThousandsSeparatedString()}', 'value': '1000'},
+            {'label': '+${5000.toThousandsSeparatedString()}', 'value': '5000'},
+            {'label': '+${10000.toThousandsSeparatedString()}', 'value': '10000'},
+            {'label': '+${50000.toThousandsSeparatedString()}', 'value': '50000'},
           ];
       }
     } else {
       // BTC/Sats 입력
       if (_viewModel.currentUnit.isBasedOnSatoshi) {
         return [
-          {'label': '+10,000', 'value': '10000'},
-          {'label': '+50,000', 'value': '50000'},
-          {'label': '+100,000', 'value': '100000'},
-          {'label': '+500,000', 'value': '500000'},
+          {'label': '+${10000.toThousandsSeparatedString()}', 'value': '10000'},
+          {'label': '+${50000.toThousandsSeparatedString()}', 'value': '50000'},
+          {'label': '+${100000.toThousandsSeparatedString()}', 'value': '100000'},
+          {'label': '+${500000.toThousandsSeparatedString()}', 'value': '500000'},
         ];
       } else {
         return [
-          {'label': '+0.0001', 'value': '0.0001'},
-          {'label': '+0.0005', 'value': '0.0005'},
-          {'label': '+0.001', 'value': '0.001'},
-          {'label': '+0.005', 'value': '0.005'},
+          {'label': '+${_formatLocaleDecimalText('0.0001')}', 'value': '0.0001'},
+          {'label': '+${_formatLocaleDecimalText('0.0005')}', 'value': '0.0005'},
+          {'label': '+${_formatLocaleDecimalText('0.001')}', 'value': '0.001'},
+          {'label': '+${_formatLocaleDecimalText('0.005')}', 'value': '0.005'},
         ];
       }
     }

--- a/lib/screens/wallet_detail/transaction_detail_screen.dart
+++ b/lib/screens/wallet_detail/transaction_detail_screen.dart
@@ -12,7 +12,6 @@ import 'package:coconut_wallet/providers/connectivity_provider.dart';
 import 'package:coconut_wallet/providers/node_provider/node_provider.dart';
 import 'package:coconut_wallet/providers/preferences/block_explorer_provider.dart';
 import 'package:coconut_wallet/providers/preferences/preference_provider.dart';
-import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/transaction_provider.dart';
 import 'package:coconut_wallet/providers/utxo_tag_provider.dart';
 import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
@@ -23,6 +22,7 @@ import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/screens/wallet_detail/transaction_fee_bumping_screen.dart';
 import 'package:coconut_wallet/utils/datetime_util.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:coconut_wallet/utils/wallet_util.dart';
 import 'package:coconut_wallet/widgets/button/copy_text_container.dart';
@@ -242,7 +242,9 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> with 
                       ),
                       CoconutLayout.spacing_200w,
                       Text(
-                        t.transaction_fee_bumping_screen.existing_fee_value(value: feeHistory.feeRate),
+                        t.transaction_fee_bumping_screen.existing_fee_value(
+                          value: _formatFeeRateForDisplay(feeHistory.feeRate),
+                        ),
                         style: CoconutTypography.body2_14_Number,
                         textScaler: const TextScaler.linear(1.0),
                       ),
@@ -322,7 +324,9 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> with 
                         ),
                         CoconutLayout.spacing_200w,
                         Text(
-                          t.transaction_fee_bumping_screen.existing_fee_value(value: feeHistory.feeRate),
+                          t.transaction_fee_bumping_screen.existing_fee_value(
+                            value: _formatFeeRateForDisplay(feeHistory.feeRate),
+                          ),
                           style: CoconutTypography.body2_14_Number,
                           textScaler: const TextScaler.linear(1.0),
                         ),
@@ -735,7 +739,7 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> with 
       onTapUnderlineButton: () {},
       child: Text(
         // 인풋을 조회할 수 없는 경우, 수수료 표시 안 함.
-        tx.inputAddressList.isNotEmpty ? '${tx.feeRate.toStringAsFixed(2)} sats/vB' : '-',
+        tx.inputAddressList.isNotEmpty ? '${_formatFeeRateForDisplay(tx.feeRate, decimalPlaces: 2)} sats/vB' : '-',
         style: CoconutTypography.body2_14_Number.setColor(CoconutColors.white),
       ),
     );
@@ -942,6 +946,14 @@ class _TransactionDetailScreenState extends State<TransactionDetailScreen> with 
       }
     }
     return '';
+  }
+
+  String _formatFeeRateForDisplay(double value, {int? decimalPlaces}) {
+    final text =
+        decimalPlaces == null
+            ? (value % 1 == 0 ? value.toInt().toString() : value.toString())
+            : value.toStringAsFixed(decimalPlaces);
+    return text.replaceAll('.', getNumberDecimalSeparator());
   }
 
   void _showDialogListener() {

--- a/lib/screens/wallet_detail/transaction_fee_bumping_screen.dart
+++ b/lib/screens/wallet_detail/transaction_fee_bumping_screen.dart
@@ -16,6 +16,7 @@ import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/repository/realm/wallet_preferences_repository.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/text_field_filter_util.dart';
 import 'package:coconut_wallet/utils/transaction_util.dart';
 import 'package:coconut_wallet/widgets/bubble_clipper.dart';
@@ -24,6 +25,7 @@ import 'package:coconut_wallet/widgets/custom_expansion_panel.dart';
 import 'package:coconut_wallet/widgets/overlays/coconut_loading_overlay.dart';
 import 'package:coconut_wallet/widgets/overlays/error_tooltip.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
 
@@ -281,7 +283,7 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
 
     if (!canContinue) return;
 
-    bool success = viewModel.prepareToSend(double.parse(_textEditingController.text));
+    bool success = viewModel.prepareToSend(_parseFeeRateText(_textEditingController.text));
 
     if (success && context.mounted) {
       Navigator.pushNamed(context, '/send-confirm');
@@ -293,7 +295,7 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
       return _buildErrorText(t.transaction_fee_bumping_screen.insufficient_balance_error);
     }
 
-    final double? feeInput = double.tryParse(_textEditingController.text);
+    final double? feeInput = double.tryParse(_normalizeDecimalTextForParsing(_textEditingController.text));
     if (_textEditingController.text.isEmpty || feeInput == null || feeInput == 0) {
       return null;
     }
@@ -350,18 +352,36 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
     );
   }
 
+  String _formatDecimalTextForDisplay(String text) {
+    return text.replaceAll('.', getNumberDecimalSeparator());
+  }
+
+  String _normalizeDecimalTextForParsing(String text) {
+    return text.replaceAll(getNumberDecimalSeparator(), '.').replaceAll(',', '.');
+  }
+
+  double _parseFeeRateText(String text) {
+    return double.parse(_normalizeDecimalTextForParsing(text));
+  }
+
+  String _formatFeeRateForDisplay(double value) {
+    final text = value % 1 == 0 ? value.toInt().toString() : value.toString();
+    return _formatDecimalTextForDisplay(text);
+  }
+
   void _onFeeRateChanged(String input) async {
     if (_viewModel.isInitializedSuccess == false) {
       return;
     }
 
-    final filteredText = filterNumericInput(input, decimalPlaces: 2, integerPlaces: 4);
+    final filteredText = filterNumericInput(_normalizeDecimalTextForParsing(input), decimalPlaces: 2, integerPlaces: 4);
+    final displayText = _formatDecimalTextForDisplay(filteredText);
     _textEditingController.value = TextEditingValue(
-      text: filteredText,
-      selection: TextSelection.collapsed(offset: filteredText.length), // 커서를 맨 끝으로 이동
+      text: displayText,
+      selection: TextSelection.collapsed(offset: displayText.length), // 커서를 맨 끝으로 이동
     );
 
-    double? feeRate = double.tryParse(_textEditingController.text);
+    double? feeRate = double.tryParse(filteredText);
 
     _viewModel.onFeeRateChanged(feeRate);
 
@@ -451,7 +471,9 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
             children: [
               Text(t.transaction_fee_bumping_screen.existing_fee, style: CoconutTypography.body2_14_Bold),
               Text(
-                t.transaction_fee_bumping_screen.existing_fee_value(value: widget.transaction.feeRate),
+                t.transaction_fee_bumping_screen.existing_fee_value(
+                  value: _formatFeeRateForDisplay(widget.transaction.feeRate),
+                ),
                 style: CoconutTypography.body2_14_Bold,
               ),
             ],
@@ -517,6 +539,7 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
                     focusNode: _feeTextFieldFocusNode,
                     cursorColor: CoconutColors.white,
                     textInputType: const TextInputType.numberWithOptions(decimal: true),
+                    textInputFormatter: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))],
                     errorColor: CoconutColors.hotPink,
                     activeColor: CoconutColors.white,
                     backgroundColor: CoconutColors.white.withValues(alpha: 0.15),
@@ -580,7 +603,9 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
                     );
                   },
                   child: Text(
-                    t.transaction_fee_bumping_screen.recommend_fee(fee: _viewModel.recommendFeeRate!),
+                    t.transaction_fee_bumping_screen.recommend_fee(
+                      fee: _formatFeeRateForDisplay(_viewModel.recommendFeeRate!),
+                    ),
                     key: ValueKey(_viewModel.recommendFeeRate),
                     style: CoconutTypography.body2_14,
                   ),
@@ -692,7 +717,11 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.end,
                           children: [
-                            Text(t.transaction_fee_bumping_screen.existing_fee_value(value: fastestFeeSatsPerVb)),
+                            Text(
+                              t.transaction_fee_bumping_screen.existing_fee_value(
+                                value: _formatFeeRateForDisplay(fastestFeeSatsPerVb),
+                              ),
+                            ),
                           ],
                         ),
                       ),
@@ -722,7 +751,11 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
                       child: FittedBox(
                         fit: BoxFit.scaleDown,
                         alignment: Alignment.centerRight,
-                        child: Text(t.transaction_fee_bumping_screen.existing_fee_value(value: halfhourFeeSatsPerVb)),
+                        child: Text(
+                          t.transaction_fee_bumping_screen.existing_fee_value(
+                            value: _formatFeeRateForDisplay(halfhourFeeSatsPerVb),
+                          ),
+                        ),
                       ),
                     ),
                   ],
@@ -750,7 +783,11 @@ class _TransactionFeeBumpingScreenState extends State<TransactionFeeBumpingScree
                       child: FittedBox(
                         fit: BoxFit.scaleDown,
                         alignment: Alignment.centerRight,
-                        child: Text(t.transaction_fee_bumping_screen.existing_fee_value(value: hourFeeSatsPerVb)),
+                        child: Text(
+                          t.transaction_fee_bumping_screen.existing_fee_value(
+                            value: _formatFeeRateForDisplay(hourFeeSatsPerVb),
+                          ),
+                        ),
                       ),
                     ),
                   ],

--- a/lib/screens/wallet_detail/utxo_merge/utxo_merge_screen.dart
+++ b/lib/screens/wallet_detail/utxo_merge/utxo_merge_screen.dart
@@ -22,6 +22,7 @@ import 'package:coconut_wallet/utils/address_util.dart';
 import 'package:coconut_wallet/utils/address_scan_util.dart';
 import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/utils/datetime_util.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/text_field_filter_util.dart';
 import 'package:coconut_wallet/utils/vibration_util.dart';
 import 'package:coconut_wallet/widgets/bottom_sheet/estimated_fee_bottom_sheet.dart';
@@ -55,9 +56,12 @@ class UtxoMergeScreen extends StatefulWidget {
   State<UtxoMergeScreen> createState() => _UtxoMergeScreenState();
 }
 
-class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProviderStateMixin {
+class _UtxoMergeScreenState extends State<UtxoMergeScreen>
+    with SingleTickerProviderStateMixin {
   static const Duration _headerAnimationDuration = Duration(milliseconds: 800);
-  static const Duration _optionPickerAnimationDuration = Duration(milliseconds: 600);
+  static const Duration _optionPickerAnimationDuration = Duration(
+    milliseconds: 600,
+  );
   static const Duration _newestPickerRevealDelay = Duration(milliseconds: 1500);
   static const Duration _autoOpenBottomSheetDelay = Duration(milliseconds: 0);
 
@@ -80,7 +84,10 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
   @override
   void initState() {
     super.initState();
-    _receiveAddressSummaryLottieController = AnimationController(vsync: this, duration: const Duration(seconds: 1));
+    _receiveAddressSummaryLottieController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 1),
+    );
     _viewModel = UtxoMergeViewModel(
       widget.id,
       context.read<UtxoRepository>(),
@@ -232,7 +239,11 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
   Widget _buildMergeContent(BuildContext context) {
     return Selector<
       UtxoMergeViewModel,
-      ({bool hasUnexpectedError, bool isMergeButtonVisible, UtxoMergeStep currentStep})
+      ({
+        bool hasUnexpectedError,
+        bool isMergeButtonVisible,
+        UtxoMergeStep currentStep,
+      })
     >(
       selector:
           (context, viewModel) => (
@@ -244,7 +255,10 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
         _scheduleHeaderAnimation(selector.currentStep);
         _scheduleOptionPickerAnimation(selector.currentStep);
         return SizedBox(
-          height: MediaQuery.sizeOf(context).height - MediaQuery.paddingOf(context).top - kToolbarHeight,
+          height:
+              MediaQuery.sizeOf(context).height -
+              MediaQuery.paddingOf(context).top -
+              kToolbarHeight,
           child: Stack(
             children: [
               SingleChildScrollView(
@@ -253,12 +267,17 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
                     16,
                     selector.hasUnexpectedError
                         ? 100
-                        : (selector.currentStep == UtxoMergeStep.selectReceiveAddress ? 8 : 32),
+                        : (selector.currentStep ==
+                                UtxoMergeStep.selectReceiveAddress
+                            ? 8
+                            : 32),
                     16,
                     selector.isMergeButtonVisible ? 160 : 16,
                   ),
                   child: MediaQuery(
-                    data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
+                    data: MediaQuery.of(
+                      context,
+                    ).copyWith(textScaler: const TextScaler.linear(1.0)),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -283,7 +302,10 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
 
   Widget _buildUnexpectedErrorTooltip() {
     return Selector<UtxoMergeViewModel, ({bool hasUnexpectedError})>(
-      selector: (context, viewModel) => (hasUnexpectedError: viewModel.hasUnexpectedError),
+      selector:
+          (context, viewModel) => (
+            hasUnexpectedError: viewModel.hasUnexpectedError,
+          ),
       builder: (context, selector, child) {
         return Positioned(
           top: 16,
@@ -293,11 +315,14 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
             duration: const Duration(milliseconds: 300),
             switchInCurve: Curves.easeOut,
             switchOutCurve: Curves.easeIn,
-            transitionBuilder: (child, animation) => FadeTransition(opacity: animation, child: child),
+            transitionBuilder:
+                (child, animation) =>
+                    FadeTransition(opacity: animation, child: child),
             child: ErrorTooltip(
               key: const ValueKey('unexpected-error-tooltip'),
               isShown: selector.hasUnexpectedError,
-              errorMessage: '${t.errors.unexpected}\n${_viewModel.unexpectedErrorMessage}',
+              errorMessage:
+                  '${t.errors.unexpected}\n${_viewModel.unexpectedErrorMessage}',
             ),
           ),
         );
@@ -320,7 +345,8 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
             isMergeButtonVisible: viewModel.isMergeButtonVisible,
             isMergeButtonEnabled: viewModel.isMergeButtonEnabled,
             summaryState: viewModel.mergeState,
-            mergeRecommendationLevelAndInfo: viewModel.mergeRecommendationLevelAndInfo,
+            mergeRecommendationLevelAndInfo:
+                viewModel.mergeRecommendationLevelAndInfo,
           ),
       builder: (context, ctaState, child) {
         if (!ctaState.isMergeButtonVisible) {
@@ -364,7 +390,8 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
       case MergeState.ready:
         if (mergeRecommendationLevelAndInfo != null) {
           message = mergeRecommendationLevelAndInfo.message;
-          color = switch (mergeRecommendationLevelAndInfo.mergeRecommendationLevel) {
+          color = switch (mergeRecommendationLevelAndInfo
+              .mergeRecommendationLevel) {
             MergeRecommendationLevel.discouraged => CoconutColors.hotPink,
             MergeRecommendationLevel.neutral => CoconutColors.yellow,
             MergeRecommendationLevel.recommended => CoconutColors.white,
@@ -381,8 +408,14 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
     }
 
     return MediaQuery(
-      data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
-      child: Text(message, style: CoconutTypography.body3_12.setColor(color), textAlign: TextAlign.center),
+      data: MediaQuery.of(
+        context,
+      ).copyWith(textScaler: const TextScaler.linear(1.0)),
+      child: Text(
+        message,
+        style: CoconutTypography.body3_12.setColor(color),
+        textAlign: TextAlign.center,
+      ),
     );
   }
 
@@ -401,7 +434,9 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
       Navigator.pushNamed(
         context,
         '/send-confirm',
-        arguments: {"currentUnit": context.read<PreferenceProvider>().currentUnit},
+        arguments: {
+          "currentUnit": context.read<PreferenceProvider>().currentUnit,
+        },
       );
     } finally {
       if (mounted && context.loaderOverlay.visible) {
@@ -476,14 +511,24 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _buildTransactionSummaryCard(),
-          Selector<UtxoMergeViewModel, ({bool hasDustUtxosInInputs, UtxoMergeMethod currentMethod})>(
-            selector: (_, vm) => (hasDustUtxosInInputs: vm.hasDustUtxosInInputs, currentMethod: vm.currentMethod),
+          Selector<
+            UtxoMergeViewModel,
+            ({bool hasDustUtxosInInputs, UtxoMergeMethod currentMethod})
+          >(
+            selector:
+                (_, vm) => (
+                  hasDustUtxosInInputs: vm.hasDustUtxosInInputs,
+                  currentMethod: vm.currentMethod,
+                ),
             builder: (context, value, _) {
-              if (!value.hasDustUtxosInInputs || value.currentMethod == UtxoMergeMethod.smallAmounts) {
+              if (!value.hasDustUtxosInInputs ||
+                  value.currentMethod == UtxoMergeMethod.smallAmounts) {
                 return const SizedBox.shrink();
               }
 
-              return Column(children: [const SizedBox(height: 12), _buildDustWarningRow()]);
+              return Column(
+                children: [const SizedBox(height: 12), _buildDustWarningRow()],
+              );
             },
           ),
           const SizedBox(height: 12),
@@ -530,7 +575,12 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
   Widget _buildTransactionSummaryCard() {
     return Selector<
       UtxoMergeViewModel,
-      ({UtxoMergeMethod method, MergeState mergeState, String selectedUtxosTotalAmountText, int selectedUtxoCount})
+      ({
+        UtxoMergeMethod method,
+        MergeState mergeState,
+        String selectedUtxosTotalAmountText,
+        int selectedUtxoCount,
+      })
     >(
       selector:
           (_, vm) => (
@@ -543,7 +593,8 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
         final isPreparing = selector.mergeState == MergeState.preparing;
         final isReady = selector.mergeState == MergeState.ready;
         final isFailed = selector.mergeState == MergeState.failed;
-        final isInputOne = selector.mergeState == MergeState.notEnoughSelectedUtxo;
+        final isInputOne =
+            selector.mergeState == MergeState.notEnoughSelectedUtxo;
         final summaryContent = _buildReceiveAddressSummaryContent(
           method: selector.method,
           selectedUtxoCount: selector.selectedUtxoCount,
@@ -557,13 +608,17 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
           cardKey: const ValueKey('merge-transaction-summary-card'),
           lottieController: _receiveAddressSummaryLottieController,
           onLottieLoaded: (composition) {
-            _receiveAddressSummaryLottieController.duration = composition.duration;
+            _receiveAddressSummaryLottieController.duration =
+                composition.duration;
             if (_displayedHeaderStep == UtxoMergeStep.selectReceiveAddress) {
               if (isReady || isFailed || isInputOne) {
                 _receiveAddressSummaryLottieController.value = 1;
-              } else if (isPreparing && !_receiveAddressSummaryLottieController.isAnimating) {
+              } else if (isPreparing &&
+                  !_receiveAddressSummaryLottieController.isAnimating) {
                 _receiveAddressSummaryLottieController.repeat(
-                  period: _receiveAddressSummaryLottieController.duration ?? composition.duration,
+                  period:
+                      _receiveAddressSummaryLottieController.duration ??
+                      composition.duration,
                 );
               } else if (!isPreparing) {
                 _receiveAddressSummaryLottieController.reset();
@@ -612,7 +667,10 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
                               'assets/svg/check.svg',
                               width: 12,
                               height: 12,
-                              colorFilter: const ColorFilter.mode(CoconutColors.white, BlendMode.srcIn),
+                              colorFilter: const ColorFilter.mode(
+                                CoconutColors.white,
+                                BlendMode.srcIn,
+                              ),
                             ),
                           )
                           : null,
@@ -620,7 +678,9 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
                 const SizedBox(width: 8),
                 Text(
                   t.merge_utxos_screen.exclude_dust,
-                  style: CoconutTypography.body3_12.setColor(CoconutColors.white),
+                  style: CoconutTypography.body3_12.setColor(
+                    CoconutColors.white,
+                  ),
                 ),
               ],
             ),
@@ -657,13 +717,19 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
                           'assets/svg/check.svg',
                           width: 14,
                           height: 14,
-                          colorFilter: const ColorFilter.mode(CoconutColors.white, BlendMode.srcIn),
+                          colorFilter: const ColorFilter.mode(
+                            CoconutColors.white,
+                            BlendMode.srcIn,
+                          ),
                         ),
                       )
                       : null,
             ),
             const SizedBox(width: 8),
-            Text(t.merge_utxos_screen.exclude_dust, style: CoconutTypography.body3_12.setColor(CoconutColors.white)),
+            Text(
+              t.merge_utxos_screen.exclude_dust,
+              style: CoconutTypography.body3_12.setColor(CoconutColors.white),
+            ),
           ],
         ),
       ),
@@ -701,7 +767,9 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
               );
 
       return content.fadeInAnimation(
-        key: ValueKey('receive-address-summary-text-fade-${_viewModel.receiveAddressSummaryAnimationNonce}'),
+        key: ValueKey(
+          'receive-address-summary-text-fade-${_viewModel.receiveAddressSummaryAnimationNonce}',
+        ),
         duration: const Duration(milliseconds: 260),
       );
     }
@@ -723,9 +791,15 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
       text: TextSpan(
         style: CoconutTypography.body1_16_Bold.setColor(CoconutColors.white),
         children: [
-          _buildSelectableSummaryHeadlineSpan(_getSummaryCardHeadlineText(method, selectedUtxoCount)),
+          _buildSelectableSummaryHeadlineSpan(
+            _getSummaryCardHeadlineText(method, selectedUtxoCount),
+          ),
           const TextSpan(text: ','),
-          TextSpan(text: t.merge_utxos_screen.summary_card_total(amount: selectedUtxosTotalAmountText)),
+          TextSpan(
+            text: t.merge_utxos_screen.summary_card_total(
+              amount: selectedUtxosTotalAmountText,
+            ),
+          ),
           TextSpan(text: _summaryCardDestinationText),
         ],
       ),
@@ -742,9 +816,15 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
       text: TextSpan(
         style: CoconutTypography.body1_16_Bold.setColor(CoconutColors.white),
         children: [
-          _buildSelectableSummaryHeadlineSpan(_getSummaryCardHeadlineText(method, selectedUtxoCount)),
+          _buildSelectableSummaryHeadlineSpan(
+            _getSummaryCardHeadlineText(method, selectedUtxoCount),
+          ),
           const TextSpan(text: ','),
-          TextSpan(text: t.merge_utxos_screen.summary_card_total(amount: selectedUtxosTotalAmountText)),
+          TextSpan(
+            text: t.merge_utxos_screen.summary_card_total(
+              amount: selectedUtxosTotalAmountText,
+            ),
+          ),
           TextSpan(text: _summaryCardDestinationText),
         ],
       ),
@@ -756,7 +836,10 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
       text: text,
       style: TextStyle(
         decoration: TextDecoration.underline,
-        color: _isAmountTextHighlighted ? CoconutColors.gray350 : CoconutColors.white,
+        color:
+            _isAmountTextHighlighted
+                ? CoconutColors.gray350
+                : CoconutColors.white,
       ),
       recognizer:
           TapGestureRecognizer()
@@ -789,31 +872,38 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
   String get _summaryCardDestinationText {
     if (_viewModel.isDirectInputReceiveAddressWarning) {
       return t.merge_utxos_screen.summary_card_destination(
-        destination: t.merge_utxos_screen.summary_card_to_unowned_address_destination,
+        destination:
+            t.merge_utxos_screen.summary_card_to_unowned_address_destination,
       );
     }
     final walletName = _viewModel.selectedReceiveAddressWalletName;
     if (walletName != null && walletName.isNotEmpty) {
       return t.merge_utxos_screen.summary_card_destination(
-        destination: t.merge_utxos_screen.summary_card_to_wallet_destination(wallet_name: walletName),
+        destination: t.merge_utxos_screen.summary_card_to_wallet_destination(
+          wallet_name: walletName,
+        ),
       );
     }
     return t.merge_utxos_screen.summary_card_destination(
-      destination: t.merge_utxos_screen.summary_card_to_selected_address_destination,
+      destination:
+          t.merge_utxos_screen.summary_card_to_selected_address_destination,
     );
   }
 
   String get _summaryAmountThresholdText {
     switch (_viewModel.currentAmountRange) {
       case UtxoAmountRange.below001:
-        return '0.01 BTC';
+        return '${_formatCustomAmountText('0.01')} BTC';
       case UtxoAmountRange.below0001:
-        return '0.001 BTC';
+        return '${_formatCustomAmountText('0.001')} BTC';
       case UtxoAmountRange.below00001:
-        return '0.0001 BTC';
+        return '${_formatCustomAmountText('0.0001')} BTC';
       case UtxoAmountRange.custom:
         final customAmount = _viewModel.customAmountRangeText ?? '';
-        final formattedAmount = customAmount.isEmpty ? customAmount : '${_formatCustomAmountText(customAmount)} BTC';
+        final formattedAmount =
+            customAmount.isEmpty
+                ? customAmount
+                : '${_formatCustomAmountText(customAmount)} BTC';
         return formattedAmount;
     }
   }
@@ -822,10 +912,16 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
     switch (method) {
       case UtxoMergeMethod.smallAmounts:
         return _viewModel.isCustomAmountLessThan
-            ? t.merge_utxos_screen.summary_card_headline_under(amount: _summaryAmountThresholdText)
-            : t.merge_utxos_screen.summary_card_headline_or_less(amount: _summaryAmountThresholdText);
+            ? t.merge_utxos_screen.summary_card_headline_under(
+              amount: _summaryAmountThresholdText,
+            )
+            : t.merge_utxos_screen.summary_card_headline_or_less(
+              amount: _summaryAmountThresholdText,
+            );
       case UtxoMergeMethod.sameTag:
-        return t.merge_utxos_screen.selected_tag_title(name: _viewModel.effectiveSelectedTagName ?? '');
+        return t.merge_utxos_screen.selected_tag_title(
+          name: _viewModel.effectiveSelectedTagName ?? '',
+        );
       case UtxoMergeMethod.sameAddress:
         return t.merge_utxos_screen.reused_address;
     }
@@ -843,19 +939,28 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
           Container(
             width: 132,
             height: 16,
-            decoration: BoxDecoration(color: CoconutColors.white, borderRadius: BorderRadius.circular(4)),
+            decoration: BoxDecoration(
+              color: CoconutColors.white,
+              borderRadius: BorderRadius.circular(4),
+            ),
           ),
           const SizedBox(height: 6),
           Container(
             width: 120,
             height: 16,
-            decoration: BoxDecoration(color: CoconutColors.white, borderRadius: BorderRadius.circular(4)),
+            decoration: BoxDecoration(
+              color: CoconutColors.white,
+              borderRadius: BorderRadius.circular(4),
+            ),
           ),
           const SizedBox(height: 6),
           Container(
             width: 168,
             height: 16,
-            decoration: BoxDecoration(color: CoconutColors.white, borderRadius: BorderRadius.circular(4)),
+            decoration: BoxDecoration(
+              color: CoconutColors.white,
+              borderRadius: BorderRadius.circular(4),
+            ),
           ),
         ],
       ),
@@ -877,7 +982,9 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
       case UtxoMergeMethod.sameAddress:
         return t.merge_utxos_screen.reused_address;
       case UtxoMergeMethod.sameTag:
-        return t.merge_utxos_screen.selected_tag_title(name: _viewModel.effectiveSelectedTagName ?? '');
+        return t.merge_utxos_screen.selected_tag_title(
+          name: _viewModel.effectiveSelectedTagName ?? '',
+        );
     }
   }
 
@@ -890,8 +997,13 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
 
     final reusedAddresses = _viewModel.reusedAddressesInWallet;
     final isEditingNotifier = ValueNotifier(false);
-    final initialSelectedUtxoIds = _viewModel.selectedUtxosForCurrentMethod.map((utxo) => utxo.utxoId).toSet();
-    final draftSelectedUtxoIdsNotifier = ValueNotifier<Set<String>>(initialSelectedUtxoIds);
+    final initialSelectedUtxoIds =
+        _viewModel.selectedUtxosForCurrentMethod
+            .map((utxo) => utxo.utxoId)
+            .toSet();
+    final draftSelectedUtxoIdsNotifier = ValueNotifier<Set<String>>(
+      initialSelectedUtxoIds,
+    );
     final method = _viewModel.currentMethod;
 
     try {
@@ -911,11 +1023,15 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
               mergeMethod: method,
               amountRangeText: _currentAmountRangeText,
               selectedTagInlineWidgets:
-                  method == UtxoMergeMethod.sameTag ? _buildSelectedTagInlineWidgets(context) : const [],
+                  method == UtxoMergeMethod.sameTag
+                      ? _buildSelectedTagInlineWidgets(context)
+                      : const [],
               isEditingListenable: isEditingNotifier,
               initialSelectedUtxoIds: initialSelectedUtxoIds,
               onSelectionChanged: (selectedUtxoIds) {
-                draftSelectedUtxoIdsNotifier.value = Set<String>.from(selectedUtxoIds);
+                draftSelectedUtxoIdsNotifier.value = Set<String>.from(
+                  selectedUtxoIds,
+                );
               },
               addressType: _viewModel.addressType,
             ),
@@ -924,14 +1040,20 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
             valueListenable: isEditingNotifier,
             builder:
                 (context, isEditing, _) => MediaQuery(
-                  data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
+                  data: MediaQuery.of(
+                    context,
+                  ).copyWith(textScaler: const TextScaler.linear(1.0)),
                   child: CoconutUnderlinedButton(
                     text: isEditing ? t.done : t.edit,
                     onTap: () {
                       if (isEditing) {
-                        final committedSelectedUtxoIds = Set<String>.from(draftSelectedUtxoIdsNotifier.value);
+                        final committedSelectedUtxoIds = Set<String>.from(
+                          draftSelectedUtxoIdsNotifier.value,
+                        );
                         setState(() {
-                          _viewModel.commitEditedSelectedUtxoIds(committedSelectedUtxoIds);
+                          _viewModel.commitEditedSelectedUtxoIds(
+                            committedSelectedUtxoIds,
+                          );
                         });
                         unawaited(_viewModel.prepareMergeTransaction());
                       }
@@ -953,7 +1075,10 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
   String? _getCurrentMethodText(UtxoMergeMethod? method) {
     switch (method) {
       case UtxoMergeMethod.smallAmounts:
-        return t.merge_utxos_screen.merge_method_bottomsheet.merge_small_amounts;
+        return t
+            .merge_utxos_screen
+            .merge_method_bottomsheet
+            .merge_small_amounts;
       case UtxoMergeMethod.sameTag:
         return t.merge_utxos_screen.merge_method_bottomsheet.merge_same_tag;
       case UtxoMergeMethod.sameAddress:
@@ -963,7 +1088,8 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
     }
   }
 
-  String get _currentAmountRangeText => _amountRangeText(_viewModel.currentAmountRange);
+  String get _currentAmountRangeText =>
+      _amountRangeText(_viewModel.currentAmountRange);
   String _amountRangeText(UtxoAmountRange range) {
     switch (range) {
       case UtxoAmountRange.below001:
@@ -973,7 +1099,8 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
       case UtxoAmountRange.below00001:
         return t.merge_utxos_screen.amount_range_bottomsheet.below_00001;
       case UtxoAmountRange.custom:
-        if (_viewModel.customAmountRangeText != null && _viewModel.customAmountRangeText!.isNotEmpty) {
+        if (_viewModel.customAmountRangeText != null &&
+            _viewModel.customAmountRangeText!.isNotEmpty) {
           return '${_viewModel.isCustomAmountLessThan ? '${t.merge_utxos_screen.amount_range_bottomsheet.less_than} ' : ''}${_formatCustomAmountText(_viewModel.customAmountRangeText!)}${t.btc} ${_viewModel.isCustomAmountLessThan ? '' : ' ${t.merge_utxos_screen.amount_range_bottomsheet.or_less}'}';
         }
         return t.merge_utxos_screen.amount_range_bottomsheet.custom;
@@ -994,17 +1121,26 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
       chunks.add(decimalPart.substring(i, end));
     }
 
-    return '$integerPart.${chunks.join(' ')}';
+    return '$integerPart${getNumberDecimalSeparator()}${chunks.join(' ')}';
   }
 
   String? _amountRangeDescription(UtxoAmountRange range) {
     switch (range) {
       case UtxoAmountRange.below001:
-        return t.merge_utxos_screen.amount_range_bottomsheet.below_001_description;
+        return t
+            .merge_utxos_screen
+            .amount_range_bottomsheet
+            .below_001_description;
       case UtxoAmountRange.below0001:
-        return t.merge_utxos_screen.amount_range_bottomsheet.below_0001_description;
+        return t
+            .merge_utxos_screen
+            .amount_range_bottomsheet
+            .below_0001_description;
       case UtxoAmountRange.below00001:
-        return t.merge_utxos_screen.amount_range_bottomsheet.below_00001_description;
+        return t
+            .merge_utxos_screen
+            .amount_range_bottomsheet
+            .below_00001_description;
       case UtxoAmountRange.custom:
         return null;
     }
@@ -1016,14 +1152,20 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
         _visibleOptionPickerSteps.indexed.map(((int, UtxoMergeStep) entry) {
           final index = entry.$1;
           final step = entry.$2;
-          final picker = _buildStepOptionPicker(context, step, _viewModel.currentMethod);
+          final picker = _buildStepOptionPicker(
+            context,
+            step,
+            _viewModel.currentMethod,
+          );
           final isNewest = step == _displayedOptionPickerStep && index == 0;
 
           if (isNewest) {
             return Padding(
               padding: const EdgeInsets.only(bottom: gapBetweenWidgets),
               child: picker.slideUpAnimation(
-                key: ValueKey('merge-picker-in-${step.name}-$_optionPickerAnimationNonce'),
+                key: ValueKey(
+                  'merge-picker-in-${step.name}-$_optionPickerAnimationNonce',
+                ),
                 duration: _optionPickerAnimationDuration,
                 delay: _newestPickerRevealDelay,
                 offset: const Offset(0, 24),
@@ -1034,12 +1176,20 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
             );
           }
 
-          return Padding(padding: EdgeInsets.only(bottom: index == 0 ? 0 : gapBetweenWidgets), child: picker);
+          return Padding(
+            padding: EdgeInsets.only(
+              bottom: index == 0 ? 0 : gapBetweenWidgets,
+            ),
+            child: picker,
+          );
         }).toList();
 
     if (_viewModel.currentStep == UtxoMergeStep.selectReceiveAddress) {
       pickerWidgets.add(
-        Padding(padding: const EdgeInsets.only(bottom: gapBetweenWidgets), child: _buildEstimatedFeeOptionPicker()),
+        Padding(
+          padding: const EdgeInsets.only(bottom: gapBetweenWidgets),
+          child: _buildEstimatedFeeOptionPicker(),
+        ),
       );
     }
 
@@ -1051,27 +1201,49 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
     );
   }
 
-  Widget _buildStepOptionPicker(BuildContext context, UtxoMergeStep step, UtxoMergeMethod? mergeMethod) {
+  Widget _buildStepOptionPicker(
+    BuildContext context,
+    UtxoMergeStep step,
+    UtxoMergeMethod? mergeMethod,
+  ) {
     return switch (step) {
       UtxoMergeStep.selectMergeMethod => CoconutOptionPicker(
         text: _getCurrentMethodText(mergeMethod),
-        label: _viewModel.currentStep == UtxoMergeStep.selectMergeMethod ? null : t.merge_utxos_screen.merge_method,
+        label:
+            _viewModel.currentStep == UtxoMergeStep.selectMergeMethod
+                ? null
+                : t.merge_utxos_screen.merge_method,
         onTap: _showMergeOptionBottomSheet,
       ),
       UtxoMergeStep.selectAmountRange => CoconutOptionPicker(
         text: _currentAmountRangeText,
-        label: _viewModel.currentStep == UtxoMergeStep.selectAmountRange ? null : t.merge_utxos_screen.amount_range,
+        label:
+            _viewModel.currentStep == UtxoMergeStep.selectAmountRange
+                ? null
+                : t.merge_utxos_screen.amount_range,
         onTap: _showAmountRangeBottomSheet,
         coconutOptionStateEnum:
             _viewModel.hasDustUtxosInInputs && !_viewModel.excludeDustUtxos
                 ? CoconutOptionStateEnum.warning
                 : CoconutOptionStateEnum.normal,
-        guideText: _viewModel.hasDustUtxosInInputs ? t.merge_utxos_screen.dust_warning : null,
-        subWidget: _viewModel.hasDustUtxosInInputs ? _buildDustWarningToggleCompact() : null,
+        guideText:
+            _viewModel.hasDustUtxosInInputs
+                ? t.merge_utxos_screen.dust_warning
+                : null,
+        subWidget:
+            _viewModel.hasDustUtxosInInputs
+                ? _buildDustWarningToggleCompact()
+                : null,
       ),
       UtxoMergeStep.selectTag => CoconutOptionPicker(
-        text: _viewModel.effectiveSelectedTagName == null ? t.merge_utxos_screen.select_tag : '',
-        label: _viewModel.currentStep == UtxoMergeStep.selectTag ? null : t.merge_utxos_screen.selected_tag,
+        text:
+            _viewModel.effectiveSelectedTagName == null
+                ? t.merge_utxos_screen.select_tag
+                : '',
+        label:
+            _viewModel.currentStep == UtxoMergeStep.selectTag
+                ? null
+                : t.merge_utxos_screen.selected_tag,
         onTap: _showTagSelectBottomSheet,
         inlineWidgets: _buildSelectedTagInlineWidgets(context),
         inlineSpacing: 0,
@@ -1087,7 +1259,10 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
                 : CoconutOptionStateEnum.normal,
         guideText:
             _viewModel.isDirectInputReceiveAddressWarning
-                ? t.merge_utxos_screen.receive_address_bottomsheet.not_your_owned_wallet
+                ? t
+                    .merge_utxos_screen
+                    .receive_address_bottomsheet
+                    .not_your_owned_wallet
                 : null,
       ),
       _ => const SizedBox.shrink(),
@@ -1096,20 +1271,33 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
 
   Widget _buildReceiveAddressOptionText() {
     final address = _viewModel.selectedReceiveAddress ?? '';
-    final baseStyle = CoconutTypography.body1_16_Number.setColor(CoconutColors.white);
-    final boldStyle = CoconutTypography.body1_16_NumberBold.setColor(CoconutColors.white);
+    final baseStyle = CoconutTypography.body1_16_Number.setColor(
+      CoconutColors.white,
+    );
+    final boldStyle = CoconutTypography.body1_16_NumberBold.setColor(
+      CoconutColors.white,
+    );
 
-    return _buildHighlightedSegwitAddressText(address: address, baseStyle: baseStyle, highlightedStyle: boldStyle);
+    return _buildHighlightedSegwitAddressText(
+      address: address,
+      baseStyle: baseStyle,
+      highlightedStyle: boldStyle,
+    );
   }
 
   Widget _buildEstimatedFeeOptionPicker() {
-    return Selector<UtxoMergeViewModel, ({bool isFeeRateInputEmpty, String estimatedFeeText, bool isFeeTooHigh})>(
+    return Selector<
+      UtxoMergeViewModel,
+      ({bool isFeeRateInputEmpty, String estimatedFeeText, bool isFeeTooHigh})
+    >(
       selector: (_, vm) {
         final exception = vm.preparedMergeTransactionBuildResult?.exception;
         return (
           isFeeRateInputEmpty: vm.feeRateInput.isEmpty,
           estimatedFeeText: vm.estimatedFeeText,
-          isFeeTooHigh: exception is InsufficientBalanceException || exception is SendAmountTooLowException,
+          isFeeTooHigh:
+              exception is InsufficientBalanceException ||
+              exception is SendAmountTooLowException,
         );
       },
       builder: (context, selector, _) {
@@ -1121,10 +1309,17 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
                   ? t.merge_utxos_screen.fee_rate_input_placeholder
                   : selector.estimatedFeeText,
           label: t.estimated_fee,
-          textColor: shouldShowFeeRatePlaceholder ? CoconutColors.gray500 : CoconutColors.white,
+          textColor:
+              shouldShowFeeRatePlaceholder
+                  ? CoconutColors.gray500
+                  : CoconutColors.white,
           onTap: _showEstimatedFeeBottomSheet,
-          coconutOptionStateEnum: isFeeTooHigh ? CoconutOptionStateEnum.error : CoconutOptionStateEnum.normal,
-          guideText: isFeeTooHigh ? t.merge_utxos_screen.exception.fee_too_high : null,
+          coconutOptionStateEnum:
+              isFeeTooHigh
+                  ? CoconutOptionStateEnum.error
+                  : CoconutOptionStateEnum.normal,
+          guideText:
+              isFeeTooHigh ? t.merge_utxos_screen.exception.fee_too_high : null,
         );
       },
     );
@@ -1151,7 +1346,8 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProv
         FocusScope.of(context).unfocus();
         Navigator.pop(context);
       },
-      recommendedFeeFetchStatusGetter: () => _viewModel.recommendedFeeFetchStatus,
+      recommendedFeeFetchStatusGetter:
+          () => _viewModel.recommendedFeeFetchStatus,
       feeInfosGetter: () => _viewModel.feeInfos,
       refreshRecommendedFees: _viewModel.refreshRecommendedFees,
       onFeeRateSelected: (sats) {

--- a/lib/screens/wallet_detail/utxo_merge/utxo_merge_screen.dart
+++ b/lib/screens/wallet_detail/utxo_merge/utxo_merge_screen.dart
@@ -5,6 +5,7 @@ import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/core/exceptions/transaction_creation/transaction_creation_exception.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/enums/utxo_merge_enums.dart';
+import 'package:coconut_wallet/extensions/int_extensions.dart';
 import 'package:coconut_wallet/extensions/widget_animation_extensions.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
@@ -16,7 +17,6 @@ import 'package:coconut_wallet/providers/utxo_tag_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/constants/dust_constants.dart';
 import 'package:coconut_wallet/screens/common/tag_select_bottom_sheet.dart';
-import 'package:coconut_wallet/screens/send/refactor/send_screen.dart';
 import 'package:coconut_wallet/screens/wallet_detail/utxo_overview/utxo_bucket_card_row.dart';
 import 'package:coconut_wallet/utils/address_util.dart';
 import 'package:coconut_wallet/utils/address_scan_util.dart';
@@ -56,12 +56,9 @@ class UtxoMergeScreen extends StatefulWidget {
   State<UtxoMergeScreen> createState() => _UtxoMergeScreenState();
 }
 
-class _UtxoMergeScreenState extends State<UtxoMergeScreen>
-    with SingleTickerProviderStateMixin {
+class _UtxoMergeScreenState extends State<UtxoMergeScreen> with SingleTickerProviderStateMixin {
   static const Duration _headerAnimationDuration = Duration(milliseconds: 800);
-  static const Duration _optionPickerAnimationDuration = Duration(
-    milliseconds: 600,
-  );
+  static const Duration _optionPickerAnimationDuration = Duration(milliseconds: 600);
   static const Duration _newestPickerRevealDelay = Duration(milliseconds: 1500);
   static const Duration _autoOpenBottomSheetDelay = Duration(milliseconds: 0);
 
@@ -84,10 +81,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
   @override
   void initState() {
     super.initState();
-    _receiveAddressSummaryLottieController = AnimationController(
-      vsync: this,
-      duration: const Duration(seconds: 1),
-    );
+    _receiveAddressSummaryLottieController = AnimationController(vsync: this, duration: const Duration(seconds: 1));
     _viewModel = UtxoMergeViewModel(
       widget.id,
       context.read<UtxoRepository>(),
@@ -239,11 +233,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
   Widget _buildMergeContent(BuildContext context) {
     return Selector<
       UtxoMergeViewModel,
-      ({
-        bool hasUnexpectedError,
-        bool isMergeButtonVisible,
-        UtxoMergeStep currentStep,
-      })
+      ({bool hasUnexpectedError, bool isMergeButtonVisible, UtxoMergeStep currentStep})
     >(
       selector:
           (context, viewModel) => (
@@ -255,10 +245,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
         _scheduleHeaderAnimation(selector.currentStep);
         _scheduleOptionPickerAnimation(selector.currentStep);
         return SizedBox(
-          height:
-              MediaQuery.sizeOf(context).height -
-              MediaQuery.paddingOf(context).top -
-              kToolbarHeight,
+          height: MediaQuery.sizeOf(context).height - MediaQuery.paddingOf(context).top - kToolbarHeight,
           child: Stack(
             children: [
               SingleChildScrollView(
@@ -267,17 +254,12 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
                     16,
                     selector.hasUnexpectedError
                         ? 100
-                        : (selector.currentStep ==
-                                UtxoMergeStep.selectReceiveAddress
-                            ? 8
-                            : 32),
+                        : (selector.currentStep == UtxoMergeStep.selectReceiveAddress ? 8 : 32),
                     16,
                     selector.isMergeButtonVisible ? 160 : 16,
                   ),
                   child: MediaQuery(
-                    data: MediaQuery.of(
-                      context,
-                    ).copyWith(textScaler: const TextScaler.linear(1.0)),
+                    data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -302,10 +284,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
 
   Widget _buildUnexpectedErrorTooltip() {
     return Selector<UtxoMergeViewModel, ({bool hasUnexpectedError})>(
-      selector:
-          (context, viewModel) => (
-            hasUnexpectedError: viewModel.hasUnexpectedError,
-          ),
+      selector: (context, viewModel) => (hasUnexpectedError: viewModel.hasUnexpectedError),
       builder: (context, selector, child) {
         return Positioned(
           top: 16,
@@ -315,14 +294,11 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
             duration: const Duration(milliseconds: 300),
             switchInCurve: Curves.easeOut,
             switchOutCurve: Curves.easeIn,
-            transitionBuilder:
-                (child, animation) =>
-                    FadeTransition(opacity: animation, child: child),
+            transitionBuilder: (child, animation) => FadeTransition(opacity: animation, child: child),
             child: ErrorTooltip(
               key: const ValueKey('unexpected-error-tooltip'),
               isShown: selector.hasUnexpectedError,
-              errorMessage:
-                  '${t.errors.unexpected}\n${_viewModel.unexpectedErrorMessage}',
+              errorMessage: '${t.errors.unexpected}\n${_viewModel.unexpectedErrorMessage}',
             ),
           ),
         );
@@ -345,8 +321,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
             isMergeButtonVisible: viewModel.isMergeButtonVisible,
             isMergeButtonEnabled: viewModel.isMergeButtonEnabled,
             summaryState: viewModel.mergeState,
-            mergeRecommendationLevelAndInfo:
-                viewModel.mergeRecommendationLevelAndInfo,
+            mergeRecommendationLevelAndInfo: viewModel.mergeRecommendationLevelAndInfo,
           ),
       builder: (context, ctaState, child) {
         if (!ctaState.isMergeButtonVisible) {
@@ -390,8 +365,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
       case MergeState.ready:
         if (mergeRecommendationLevelAndInfo != null) {
           message = mergeRecommendationLevelAndInfo.message;
-          color = switch (mergeRecommendationLevelAndInfo
-              .mergeRecommendationLevel) {
+          color = switch (mergeRecommendationLevelAndInfo.mergeRecommendationLevel) {
             MergeRecommendationLevel.discouraged => CoconutColors.hotPink,
             MergeRecommendationLevel.neutral => CoconutColors.yellow,
             MergeRecommendationLevel.recommended => CoconutColors.white,
@@ -408,14 +382,8 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
     }
 
     return MediaQuery(
-      data: MediaQuery.of(
-        context,
-      ).copyWith(textScaler: const TextScaler.linear(1.0)),
-      child: Text(
-        message,
-        style: CoconutTypography.body3_12.setColor(color),
-        textAlign: TextAlign.center,
-      ),
+      data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
+      child: Text(message, style: CoconutTypography.body3_12.setColor(color), textAlign: TextAlign.center),
     );
   }
 
@@ -434,9 +402,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
       Navigator.pushNamed(
         context,
         '/send-confirm',
-        arguments: {
-          "currentUnit": context.read<PreferenceProvider>().currentUnit,
-        },
+        arguments: {"currentUnit": context.read<PreferenceProvider>().currentUnit},
       );
     } finally {
       if (mounted && context.loaderOverlay.visible) {
@@ -511,24 +477,14 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _buildTransactionSummaryCard(),
-          Selector<
-            UtxoMergeViewModel,
-            ({bool hasDustUtxosInInputs, UtxoMergeMethod currentMethod})
-          >(
-            selector:
-                (_, vm) => (
-                  hasDustUtxosInInputs: vm.hasDustUtxosInInputs,
-                  currentMethod: vm.currentMethod,
-                ),
+          Selector<UtxoMergeViewModel, ({bool hasDustUtxosInInputs, UtxoMergeMethod currentMethod})>(
+            selector: (_, vm) => (hasDustUtxosInInputs: vm.hasDustUtxosInInputs, currentMethod: vm.currentMethod),
             builder: (context, value, _) {
-              if (!value.hasDustUtxosInInputs ||
-                  value.currentMethod == UtxoMergeMethod.smallAmounts) {
+              if (!value.hasDustUtxosInInputs || value.currentMethod == UtxoMergeMethod.smallAmounts) {
                 return const SizedBox.shrink();
               }
 
-              return Column(
-                children: [const SizedBox(height: 12), _buildDustWarningRow()],
-              );
+              return Column(children: [const SizedBox(height: 12), _buildDustWarningRow()]);
             },
           ),
           const SizedBox(height: 12),
@@ -575,12 +531,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
   Widget _buildTransactionSummaryCard() {
     return Selector<
       UtxoMergeViewModel,
-      ({
-        UtxoMergeMethod method,
-        MergeState mergeState,
-        String selectedUtxosTotalAmountText,
-        int selectedUtxoCount,
-      })
+      ({UtxoMergeMethod method, MergeState mergeState, String selectedUtxosTotalAmountText, int selectedUtxoCount})
     >(
       selector:
           (_, vm) => (
@@ -593,8 +544,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
         final isPreparing = selector.mergeState == MergeState.preparing;
         final isReady = selector.mergeState == MergeState.ready;
         final isFailed = selector.mergeState == MergeState.failed;
-        final isInputOne =
-            selector.mergeState == MergeState.notEnoughSelectedUtxo;
+        final isInputOne = selector.mergeState == MergeState.notEnoughSelectedUtxo;
         final summaryContent = _buildReceiveAddressSummaryContent(
           method: selector.method,
           selectedUtxoCount: selector.selectedUtxoCount,
@@ -608,17 +558,13 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
           cardKey: const ValueKey('merge-transaction-summary-card'),
           lottieController: _receiveAddressSummaryLottieController,
           onLottieLoaded: (composition) {
-            _receiveAddressSummaryLottieController.duration =
-                composition.duration;
+            _receiveAddressSummaryLottieController.duration = composition.duration;
             if (_displayedHeaderStep == UtxoMergeStep.selectReceiveAddress) {
               if (isReady || isFailed || isInputOne) {
                 _receiveAddressSummaryLottieController.value = 1;
-              } else if (isPreparing &&
-                  !_receiveAddressSummaryLottieController.isAnimating) {
+              } else if (isPreparing && !_receiveAddressSummaryLottieController.isAnimating) {
                 _receiveAddressSummaryLottieController.repeat(
-                  period:
-                      _receiveAddressSummaryLottieController.duration ??
-                      composition.duration,
+                  period: _receiveAddressSummaryLottieController.duration ?? composition.duration,
                 );
               } else if (!isPreparing) {
                 _receiveAddressSummaryLottieController.reset();
@@ -667,10 +613,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
                               'assets/svg/check.svg',
                               width: 12,
                               height: 12,
-                              colorFilter: const ColorFilter.mode(
-                                CoconutColors.white,
-                                BlendMode.srcIn,
-                              ),
+                              colorFilter: const ColorFilter.mode(CoconutColors.white, BlendMode.srcIn),
                             ),
                           )
                           : null,
@@ -678,9 +621,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
                 const SizedBox(width: 8),
                 Text(
                   t.merge_utxos_screen.exclude_dust,
-                  style: CoconutTypography.body3_12.setColor(
-                    CoconutColors.white,
-                  ),
+                  style: CoconutTypography.body3_12.setColor(CoconutColors.white),
                 ),
               ],
             ),
@@ -717,19 +658,13 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
                           'assets/svg/check.svg',
                           width: 14,
                           height: 14,
-                          colorFilter: const ColorFilter.mode(
-                            CoconutColors.white,
-                            BlendMode.srcIn,
-                          ),
+                          colorFilter: const ColorFilter.mode(CoconutColors.white, BlendMode.srcIn),
                         ),
                       )
                       : null,
             ),
             const SizedBox(width: 8),
-            Text(
-              t.merge_utxos_screen.exclude_dust,
-              style: CoconutTypography.body3_12.setColor(CoconutColors.white),
-            ),
+            Text(t.merge_utxos_screen.exclude_dust, style: CoconutTypography.body3_12.setColor(CoconutColors.white)),
           ],
         ),
       ),
@@ -767,9 +702,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
               );
 
       return content.fadeInAnimation(
-        key: ValueKey(
-          'receive-address-summary-text-fade-${_viewModel.receiveAddressSummaryAnimationNonce}',
-        ),
+        key: ValueKey('receive-address-summary-text-fade-${_viewModel.receiveAddressSummaryAnimationNonce}'),
         duration: const Duration(milliseconds: 260),
       );
     }
@@ -791,15 +724,9 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
       text: TextSpan(
         style: CoconutTypography.body1_16_Bold.setColor(CoconutColors.white),
         children: [
-          _buildSelectableSummaryHeadlineSpan(
-            _getSummaryCardHeadlineText(method, selectedUtxoCount),
-          ),
+          _buildSelectableSummaryHeadlineSpan(_getSummaryCardHeadlineText(method, selectedUtxoCount)),
           const TextSpan(text: ','),
-          TextSpan(
-            text: t.merge_utxos_screen.summary_card_total(
-              amount: selectedUtxosTotalAmountText,
-            ),
-          ),
+          TextSpan(text: t.merge_utxos_screen.summary_card_total(amount: selectedUtxosTotalAmountText)),
           TextSpan(text: _summaryCardDestinationText),
         ],
       ),
@@ -816,15 +743,9 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
       text: TextSpan(
         style: CoconutTypography.body1_16_Bold.setColor(CoconutColors.white),
         children: [
-          _buildSelectableSummaryHeadlineSpan(
-            _getSummaryCardHeadlineText(method, selectedUtxoCount),
-          ),
+          _buildSelectableSummaryHeadlineSpan(_getSummaryCardHeadlineText(method, selectedUtxoCount)),
           const TextSpan(text: ','),
-          TextSpan(
-            text: t.merge_utxos_screen.summary_card_total(
-              amount: selectedUtxosTotalAmountText,
-            ),
-          ),
+          TextSpan(text: t.merge_utxos_screen.summary_card_total(amount: selectedUtxosTotalAmountText)),
           TextSpan(text: _summaryCardDestinationText),
         ],
       ),
@@ -836,10 +757,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
       text: text,
       style: TextStyle(
         decoration: TextDecoration.underline,
-        color:
-            _isAmountTextHighlighted
-                ? CoconutColors.gray350
-                : CoconutColors.white,
+        color: _isAmountTextHighlighted ? CoconutColors.gray350 : CoconutColors.white,
       ),
       recognizer:
           TapGestureRecognizer()
@@ -872,21 +790,17 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
   String get _summaryCardDestinationText {
     if (_viewModel.isDirectInputReceiveAddressWarning) {
       return t.merge_utxos_screen.summary_card_destination(
-        destination:
-            t.merge_utxos_screen.summary_card_to_unowned_address_destination,
+        destination: t.merge_utxos_screen.summary_card_to_unowned_address_destination,
       );
     }
     final walletName = _viewModel.selectedReceiveAddressWalletName;
     if (walletName != null && walletName.isNotEmpty) {
       return t.merge_utxos_screen.summary_card_destination(
-        destination: t.merge_utxos_screen.summary_card_to_wallet_destination(
-          wallet_name: walletName,
-        ),
+        destination: t.merge_utxos_screen.summary_card_to_wallet_destination(wallet_name: walletName),
       );
     }
     return t.merge_utxos_screen.summary_card_destination(
-      destination:
-          t.merge_utxos_screen.summary_card_to_selected_address_destination,
+      destination: t.merge_utxos_screen.summary_card_to_selected_address_destination,
     );
   }
 
@@ -900,10 +814,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
         return '${_formatCustomAmountText('0.0001')} BTC';
       case UtxoAmountRange.custom:
         final customAmount = _viewModel.customAmountRangeText ?? '';
-        final formattedAmount =
-            customAmount.isEmpty
-                ? customAmount
-                : '${_formatCustomAmountText(customAmount)} BTC';
+        final formattedAmount = customAmount.isEmpty ? customAmount : '${_formatCustomAmountText(customAmount)} BTC';
         return formattedAmount;
     }
   }
@@ -912,16 +823,10 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
     switch (method) {
       case UtxoMergeMethod.smallAmounts:
         return _viewModel.isCustomAmountLessThan
-            ? t.merge_utxos_screen.summary_card_headline_under(
-              amount: _summaryAmountThresholdText,
-            )
-            : t.merge_utxos_screen.summary_card_headline_or_less(
-              amount: _summaryAmountThresholdText,
-            );
+            ? t.merge_utxos_screen.summary_card_headline_under(amount: _summaryAmountThresholdText)
+            : t.merge_utxos_screen.summary_card_headline_or_less(amount: _summaryAmountThresholdText);
       case UtxoMergeMethod.sameTag:
-        return t.merge_utxos_screen.selected_tag_title(
-          name: _viewModel.effectiveSelectedTagName ?? '',
-        );
+        return t.merge_utxos_screen.selected_tag_title(name: _viewModel.effectiveSelectedTagName ?? '');
       case UtxoMergeMethod.sameAddress:
         return t.merge_utxos_screen.reused_address;
     }
@@ -939,28 +844,19 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
           Container(
             width: 132,
             height: 16,
-            decoration: BoxDecoration(
-              color: CoconutColors.white,
-              borderRadius: BorderRadius.circular(4),
-            ),
+            decoration: BoxDecoration(color: CoconutColors.white, borderRadius: BorderRadius.circular(4)),
           ),
           const SizedBox(height: 6),
           Container(
             width: 120,
             height: 16,
-            decoration: BoxDecoration(
-              color: CoconutColors.white,
-              borderRadius: BorderRadius.circular(4),
-            ),
+            decoration: BoxDecoration(color: CoconutColors.white, borderRadius: BorderRadius.circular(4)),
           ),
           const SizedBox(height: 6),
           Container(
             width: 168,
             height: 16,
-            decoration: BoxDecoration(
-              color: CoconutColors.white,
-              borderRadius: BorderRadius.circular(4),
-            ),
+            decoration: BoxDecoration(color: CoconutColors.white, borderRadius: BorderRadius.circular(4)),
           ),
         ],
       ),
@@ -982,9 +878,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
       case UtxoMergeMethod.sameAddress:
         return t.merge_utxos_screen.reused_address;
       case UtxoMergeMethod.sameTag:
-        return t.merge_utxos_screen.selected_tag_title(
-          name: _viewModel.effectiveSelectedTagName ?? '',
-        );
+        return t.merge_utxos_screen.selected_tag_title(name: _viewModel.effectiveSelectedTagName ?? '');
     }
   }
 
@@ -997,13 +891,8 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
 
     final reusedAddresses = _viewModel.reusedAddressesInWallet;
     final isEditingNotifier = ValueNotifier(false);
-    final initialSelectedUtxoIds =
-        _viewModel.selectedUtxosForCurrentMethod
-            .map((utxo) => utxo.utxoId)
-            .toSet();
-    final draftSelectedUtxoIdsNotifier = ValueNotifier<Set<String>>(
-      initialSelectedUtxoIds,
-    );
+    final initialSelectedUtxoIds = _viewModel.selectedUtxosForCurrentMethod.map((utxo) => utxo.utxoId).toSet();
+    final draftSelectedUtxoIdsNotifier = ValueNotifier<Set<String>>(initialSelectedUtxoIds);
     final method = _viewModel.currentMethod;
 
     try {
@@ -1023,15 +912,11 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
               mergeMethod: method,
               amountRangeText: _currentAmountRangeText,
               selectedTagInlineWidgets:
-                  method == UtxoMergeMethod.sameTag
-                      ? _buildSelectedTagInlineWidgets(context)
-                      : const [],
+                  method == UtxoMergeMethod.sameTag ? _buildSelectedTagInlineWidgets(context) : const [],
               isEditingListenable: isEditingNotifier,
               initialSelectedUtxoIds: initialSelectedUtxoIds,
               onSelectionChanged: (selectedUtxoIds) {
-                draftSelectedUtxoIdsNotifier.value = Set<String>.from(
-                  selectedUtxoIds,
-                );
+                draftSelectedUtxoIdsNotifier.value = Set<String>.from(selectedUtxoIds);
               },
               addressType: _viewModel.addressType,
             ),
@@ -1040,20 +925,14 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
             valueListenable: isEditingNotifier,
             builder:
                 (context, isEditing, _) => MediaQuery(
-                  data: MediaQuery.of(
-                    context,
-                  ).copyWith(textScaler: const TextScaler.linear(1.0)),
+                  data: MediaQuery.of(context).copyWith(textScaler: const TextScaler.linear(1.0)),
                   child: CoconutUnderlinedButton(
                     text: isEditing ? t.done : t.edit,
                     onTap: () {
                       if (isEditing) {
-                        final committedSelectedUtxoIds = Set<String>.from(
-                          draftSelectedUtxoIdsNotifier.value,
-                        );
+                        final committedSelectedUtxoIds = Set<String>.from(draftSelectedUtxoIdsNotifier.value);
                         setState(() {
-                          _viewModel.commitEditedSelectedUtxoIds(
-                            committedSelectedUtxoIds,
-                          );
+                          _viewModel.commitEditedSelectedUtxoIds(committedSelectedUtxoIds);
                         });
                         unawaited(_viewModel.prepareMergeTransaction());
                       }
@@ -1075,10 +954,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
   String? _getCurrentMethodText(UtxoMergeMethod? method) {
     switch (method) {
       case UtxoMergeMethod.smallAmounts:
-        return t
-            .merge_utxos_screen
-            .merge_method_bottomsheet
-            .merge_small_amounts;
+        return t.merge_utxos_screen.merge_method_bottomsheet.merge_small_amounts;
       case UtxoMergeMethod.sameTag:
         return t.merge_utxos_screen.merge_method_bottomsheet.merge_same_tag;
       case UtxoMergeMethod.sameAddress:
@@ -1088,19 +964,17 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
     }
   }
 
-  String get _currentAmountRangeText =>
-      _amountRangeText(_viewModel.currentAmountRange);
+  String get _currentAmountRangeText => _amountRangeText(_viewModel.currentAmountRange);
   String _amountRangeText(UtxoAmountRange range) {
     switch (range) {
       case UtxoAmountRange.below001:
-        return t.merge_utxos_screen.amount_range_bottomsheet.below_001;
+        return _localizedAmountRangeText(t.merge_utxos_screen.amount_range_bottomsheet.below_001, '0.01');
       case UtxoAmountRange.below0001:
-        return t.merge_utxos_screen.amount_range_bottomsheet.below_0001;
+        return _localizedAmountRangeText(t.merge_utxos_screen.amount_range_bottomsheet.below_0001, '0.001');
       case UtxoAmountRange.below00001:
-        return t.merge_utxos_screen.amount_range_bottomsheet.below_00001;
+        return _localizedAmountRangeText(t.merge_utxos_screen.amount_range_bottomsheet.below_00001, '0.0001');
       case UtxoAmountRange.custom:
-        if (_viewModel.customAmountRangeText != null &&
-            _viewModel.customAmountRangeText!.isNotEmpty) {
+        if (_viewModel.customAmountRangeText != null && _viewModel.customAmountRangeText!.isNotEmpty) {
           return '${_viewModel.isCustomAmountLessThan ? '${t.merge_utxos_screen.amount_range_bottomsheet.less_than} ' : ''}${_formatCustomAmountText(_viewModel.customAmountRangeText!)}${t.btc} ${_viewModel.isCustomAmountLessThan ? '' : ' ${t.merge_utxos_screen.amount_range_bottomsheet.or_less}'}';
         }
         return t.merge_utxos_screen.amount_range_bottomsheet.custom;
@@ -1108,12 +982,17 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
   }
 
   String _formatCustomAmountText(String value) {
-    final parts = value.split('.');
-    if (parts.length != 2) return value;
+    final normalizedValue = normalizeDecimalNumberTextForParsing(value);
+    final parts = normalizedValue.split('.');
 
-    final integerPart = parts.first;
+    final integerPart = parts.first.isEmpty ? '0' : parts.first;
+    final formattedIntegerPart = int.tryParse(integerPart)?.toThousandsSeparatedString() ?? integerPart;
+    if (parts.length != 2) return formattedIntegerPart;
+
     final decimalPart = parts.last;
-    if (decimalPart.isEmpty) return value;
+    if (decimalPart.isEmpty) {
+      return '$formattedIntegerPart${getNumberDecimalSeparator()}';
+    }
 
     final chunks = <String>[];
     for (var i = 0; i < decimalPart.length; i += 4) {
@@ -1121,26 +1000,21 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
       chunks.add(decimalPart.substring(i, end));
     }
 
-    return '$integerPart${getNumberDecimalSeparator()}${chunks.join(' ')}';
+    return '$formattedIntegerPart${getNumberDecimalSeparator()}${chunks.join(' ')}';
+  }
+
+  String _localizedAmountRangeText(String text, String amount) {
+    return text.replaceFirst(amount, _formatCustomAmountText(amount));
   }
 
   String? _amountRangeDescription(UtxoAmountRange range) {
     switch (range) {
       case UtxoAmountRange.below001:
-        return t
-            .merge_utxos_screen
-            .amount_range_bottomsheet
-            .below_001_description;
+        return t.merge_utxos_screen.amount_range_bottomsheet.below_001_description;
       case UtxoAmountRange.below0001:
-        return t
-            .merge_utxos_screen
-            .amount_range_bottomsheet
-            .below_0001_description;
+        return t.merge_utxos_screen.amount_range_bottomsheet.below_0001_description;
       case UtxoAmountRange.below00001:
-        return t
-            .merge_utxos_screen
-            .amount_range_bottomsheet
-            .below_00001_description;
+        return t.merge_utxos_screen.amount_range_bottomsheet.below_00001_description;
       case UtxoAmountRange.custom:
         return null;
     }
@@ -1152,20 +1026,14 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
         _visibleOptionPickerSteps.indexed.map(((int, UtxoMergeStep) entry) {
           final index = entry.$1;
           final step = entry.$2;
-          final picker = _buildStepOptionPicker(
-            context,
-            step,
-            _viewModel.currentMethod,
-          );
+          final picker = _buildStepOptionPicker(context, step, _viewModel.currentMethod);
           final isNewest = step == _displayedOptionPickerStep && index == 0;
 
           if (isNewest) {
             return Padding(
               padding: const EdgeInsets.only(bottom: gapBetweenWidgets),
               child: picker.slideUpAnimation(
-                key: ValueKey(
-                  'merge-picker-in-${step.name}-$_optionPickerAnimationNonce',
-                ),
+                key: ValueKey('merge-picker-in-${step.name}-$_optionPickerAnimationNonce'),
                 duration: _optionPickerAnimationDuration,
                 delay: _newestPickerRevealDelay,
                 offset: const Offset(0, 24),
@@ -1176,20 +1044,12 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
             );
           }
 
-          return Padding(
-            padding: EdgeInsets.only(
-              bottom: index == 0 ? 0 : gapBetweenWidgets,
-            ),
-            child: picker,
-          );
+          return Padding(padding: EdgeInsets.only(bottom: index == 0 ? 0 : gapBetweenWidgets), child: picker);
         }).toList();
 
     if (_viewModel.currentStep == UtxoMergeStep.selectReceiveAddress) {
       pickerWidgets.add(
-        Padding(
-          padding: const EdgeInsets.only(bottom: gapBetweenWidgets),
-          child: _buildEstimatedFeeOptionPicker(),
-        ),
+        Padding(padding: const EdgeInsets.only(bottom: gapBetweenWidgets), child: _buildEstimatedFeeOptionPicker()),
       );
     }
 
@@ -1201,49 +1061,27 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
     );
   }
 
-  Widget _buildStepOptionPicker(
-    BuildContext context,
-    UtxoMergeStep step,
-    UtxoMergeMethod? mergeMethod,
-  ) {
+  Widget _buildStepOptionPicker(BuildContext context, UtxoMergeStep step, UtxoMergeMethod? mergeMethod) {
     return switch (step) {
       UtxoMergeStep.selectMergeMethod => CoconutOptionPicker(
         text: _getCurrentMethodText(mergeMethod),
-        label:
-            _viewModel.currentStep == UtxoMergeStep.selectMergeMethod
-                ? null
-                : t.merge_utxos_screen.merge_method,
+        label: _viewModel.currentStep == UtxoMergeStep.selectMergeMethod ? null : t.merge_utxos_screen.merge_method,
         onTap: _showMergeOptionBottomSheet,
       ),
       UtxoMergeStep.selectAmountRange => CoconutOptionPicker(
         text: _currentAmountRangeText,
-        label:
-            _viewModel.currentStep == UtxoMergeStep.selectAmountRange
-                ? null
-                : t.merge_utxos_screen.amount_range,
+        label: _viewModel.currentStep == UtxoMergeStep.selectAmountRange ? null : t.merge_utxos_screen.amount_range,
         onTap: _showAmountRangeBottomSheet,
         coconutOptionStateEnum:
             _viewModel.hasDustUtxosInInputs && !_viewModel.excludeDustUtxos
                 ? CoconutOptionStateEnum.warning
                 : CoconutOptionStateEnum.normal,
-        guideText:
-            _viewModel.hasDustUtxosInInputs
-                ? t.merge_utxos_screen.dust_warning
-                : null,
-        subWidget:
-            _viewModel.hasDustUtxosInInputs
-                ? _buildDustWarningToggleCompact()
-                : null,
+        guideText: _viewModel.hasDustUtxosInInputs ? t.merge_utxos_screen.dust_warning : null,
+        subWidget: _viewModel.hasDustUtxosInInputs ? _buildDustWarningToggleCompact() : null,
       ),
       UtxoMergeStep.selectTag => CoconutOptionPicker(
-        text:
-            _viewModel.effectiveSelectedTagName == null
-                ? t.merge_utxos_screen.select_tag
-                : '',
-        label:
-            _viewModel.currentStep == UtxoMergeStep.selectTag
-                ? null
-                : t.merge_utxos_screen.selected_tag,
+        text: _viewModel.effectiveSelectedTagName == null ? t.merge_utxos_screen.select_tag : '',
+        label: _viewModel.currentStep == UtxoMergeStep.selectTag ? null : t.merge_utxos_screen.selected_tag,
         onTap: _showTagSelectBottomSheet,
         inlineWidgets: _buildSelectedTagInlineWidgets(context),
         inlineSpacing: 0,
@@ -1259,10 +1097,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
                 : CoconutOptionStateEnum.normal,
         guideText:
             _viewModel.isDirectInputReceiveAddressWarning
-                ? t
-                    .merge_utxos_screen
-                    .receive_address_bottomsheet
-                    .not_your_owned_wallet
+                ? t.merge_utxos_screen.receive_address_bottomsheet.not_your_owned_wallet
                 : null,
       ),
       _ => const SizedBox.shrink(),
@@ -1271,33 +1106,20 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
 
   Widget _buildReceiveAddressOptionText() {
     final address = _viewModel.selectedReceiveAddress ?? '';
-    final baseStyle = CoconutTypography.body1_16_Number.setColor(
-      CoconutColors.white,
-    );
-    final boldStyle = CoconutTypography.body1_16_NumberBold.setColor(
-      CoconutColors.white,
-    );
+    final baseStyle = CoconutTypography.body1_16_Number.setColor(CoconutColors.white);
+    final boldStyle = CoconutTypography.body1_16_NumberBold.setColor(CoconutColors.white);
 
-    return _buildHighlightedSegwitAddressText(
-      address: address,
-      baseStyle: baseStyle,
-      highlightedStyle: boldStyle,
-    );
+    return _buildHighlightedSegwitAddressText(address: address, baseStyle: baseStyle, highlightedStyle: boldStyle);
   }
 
   Widget _buildEstimatedFeeOptionPicker() {
-    return Selector<
-      UtxoMergeViewModel,
-      ({bool isFeeRateInputEmpty, String estimatedFeeText, bool isFeeTooHigh})
-    >(
+    return Selector<UtxoMergeViewModel, ({bool isFeeRateInputEmpty, String estimatedFeeText, bool isFeeTooHigh})>(
       selector: (_, vm) {
         final exception = vm.preparedMergeTransactionBuildResult?.exception;
         return (
           isFeeRateInputEmpty: vm.feeRateInput.isEmpty,
           estimatedFeeText: vm.estimatedFeeText,
-          isFeeTooHigh:
-              exception is InsufficientBalanceException ||
-              exception is SendAmountTooLowException,
+          isFeeTooHigh: exception is InsufficientBalanceException || exception is SendAmountTooLowException,
         );
       },
       builder: (context, selector, _) {
@@ -1309,17 +1131,10 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
                   ? t.merge_utxos_screen.fee_rate_input_placeholder
                   : selector.estimatedFeeText,
           label: t.estimated_fee,
-          textColor:
-              shouldShowFeeRatePlaceholder
-                  ? CoconutColors.gray500
-                  : CoconutColors.white,
+          textColor: shouldShowFeeRatePlaceholder ? CoconutColors.gray500 : CoconutColors.white,
           onTap: _showEstimatedFeeBottomSheet,
-          coconutOptionStateEnum:
-              isFeeTooHigh
-                  ? CoconutOptionStateEnum.error
-                  : CoconutOptionStateEnum.normal,
-          guideText:
-              isFeeTooHigh ? t.merge_utxos_screen.exception.fee_too_high : null,
+          coconutOptionStateEnum: isFeeTooHigh ? CoconutOptionStateEnum.error : CoconutOptionStateEnum.normal,
+          guideText: isFeeTooHigh ? t.merge_utxos_screen.exception.fee_too_high : null,
         );
       },
     );
@@ -1346,8 +1161,7 @@ class _UtxoMergeScreenState extends State<UtxoMergeScreen>
         FocusScope.of(context).unfocus();
         Navigator.pop(context);
       },
-      recommendedFeeFetchStatusGetter:
-          () => _viewModel.recommendedFeeFetchStatus,
+      recommendedFeeFetchStatusGetter: () => _viewModel.recommendedFeeFetchStatus,
       feeInfosGetter: () => _viewModel.feeInfos,
       refreshRecommendedFees: _viewModel.refreshRecommendedFees,
       onFeeRateSelected: (sats) {

--- a/lib/screens/wallet_detail/utxo_merge/utxo_merge_screen_bottom_sheets.dart
+++ b/lib/screens/wallet_detail/utxo_merge/utxo_merge_screen_bottom_sheets.dart
@@ -88,7 +88,9 @@ extension _UtxoMergeScreenBottomSheetsExtension on _UtxoMergeScreenState {
                 _viewModel.hasCandidateUtxosForAmountRange(currentAmountRange)
             ? currentAmountRange
             : firstAvailableRecommendedRange;
-    final customAmountController = TextEditingController(text: _viewModel.customAmountRangeText ?? '');
+    final customAmountController = TextEditingController(
+      text: _viewModel.customAmountRangeText == null ? '' : _formatCustomAmountText(_viewModel.customAmountRangeText!),
+    );
     final customAmountFocusNode = FocusNode();
     var isCustomAmountLessThan = _viewModel.isCustomAmountLessThan;
 
@@ -115,7 +117,7 @@ extension _UtxoMergeScreenBottomSheetsExtension on _UtxoMergeScreenState {
         childBuilder:
             (scrollController) => StatefulBuilder(
               builder: (context, modalSetState) {
-                final customAmountText = customAmountController.text.trim();
+                final customAmountText = normalizeDecimalNumberTextForParsing(customAmountController.text.trim());
                 final customAmountValue = double.tryParse(customAmountText);
                 final hasCustomAmountInput =
                     customAmountText.isNotEmpty && customAmountValue != null && customAmountValue != 0;
@@ -149,12 +151,13 @@ extension _UtxoMergeScreenBottomSheetsExtension on _UtxoMergeScreenState {
                       return;
                     }
 
-                    if (customAmountController.text.trim().isEmpty) return;
+                    final customAmountText = normalizeDecimalNumberTextForParsing(customAmountController.text.trim());
+                    if (customAmountText.isEmpty) return;
                     Navigator.pop(
                       context,
                       _AmountRangeSelectionResult(
                         range: UtxoAmountRange.custom,
-                        customAmountText: customAmountController.text.trim(),
+                        customAmountText: customAmountText,
                         isLessThan: isCustomAmountLessThan,
                       ),
                     );
@@ -682,8 +685,7 @@ extension _UtxoMergeScreenBottomSheetsExtension on _UtxoMergeScreenState {
                       textInputType: const TextInputType.numberWithOptions(decimal: true),
                       isErrorTextMultiline: true,
                       textInputFormatter: [
-                        FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
-                        SingleDotInputFormatter(),
+                        FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
                         const BtcAmountInputFormatter(),
                       ],
                       placeholderText: '',

--- a/lib/screens/wallet_detail/wallet_info_screen.dart
+++ b/lib/screens/wallet_detail/wallet_info_screen.dart
@@ -20,6 +20,7 @@ import 'package:coconut_wallet/widgets/custom_loading_overlay.dart';
 import 'package:coconut_wallet/widgets/dialog.dart';
 import 'package:coconut_wallet/screens/common/qr_with_copy_text_screen.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/text_field_filter_util.dart';
 import 'package:coconut_wallet/widgets/button/shrink_animation_button.dart';
 import 'package:coconut_wallet/widgets/overlays/common_bottom_sheets.dart';
@@ -378,7 +379,8 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
   }
 
   void _showTargetSettingBottomSheet(BuildContext context, WalletInfoViewModel viewModel) {
-    final btcString = viewModel.targetSats != null ? _satsToBtcInputString(viewModel.targetSats!) : '';
+    final btcString =
+        viewModel.targetSats != null ? BalanceFormatUtil.formatSatoshiToBtcInputText(viewModel.targetSats!) : '';
     final parentContext = context;
 
     SingleTextFieldBottomSheet.show(
@@ -389,13 +391,9 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
       placeholder: t.wallet_info_screen.target_set_placeholder,
       keyboardType: const TextInputType.numberWithOptions(decimal: true),
       visibleTextLimit: false,
-      maxLength: 17,
+      maxLength: 20,
       collapsedHeight: 300,
-      textInputFormatters: [
-        FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
-        _SingleDotInputFormatter(),
-        const BtcAmountInputFormatter(),
-      ],
+      textInputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')), const BtcAmountInputFormatter()],
       completeEnabledWhen: (current, original) {
         final currentText = current.trim();
         return currentText.isNotEmpty && currentText != original.trim();
@@ -408,7 +406,7 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
       cursorColor: CoconutColors.white,
       suffix: Text(BitcoinUnit.btc.symbol, style: CoconutTypography.body2_14_Bold),
       onComplete: (text) {
-        final btc = double.tryParse(text.replaceAll(',', ''));
+        final btc = double.tryParse(normalizeDecimalNumberTextForParsing(text));
         if (btc == null || btc <= 0) {
           if (text.isNotEmpty) {
             CoconutToast.showToast(
@@ -448,11 +446,6 @@ class _WalletInfoScreenState extends State<WalletInfoScreen> {
         );
       },
     );
-  }
-
-  static String _satsToBtcInputString(int sats) {
-    final btc = sats / 100000000.0;
-    return btc.toStringAsFixed(8).replaceFirst(RegExp(r'0+$'), '').replaceFirst(RegExp(r'\.$'), '');
   }
 
   Future<void> _deleteWalletAndGoToEntryPoint(BuildContext context, WalletInfoViewModel viewModel) async {
@@ -799,13 +792,5 @@ class _TargetQuantityCard extends StatelessWidget {
     }
 
     return count;
-  }
-}
-
-class _SingleDotInputFormatter extends TextInputFormatter {
-  @override
-  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
-    if ('.'.allMatches(newValue.text).length > 1) return oldValue;
-    return newValue;
   }
 }

--- a/lib/utils/balance_format_util.dart
+++ b/lib/utils/balance_format_util.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/extensions/int_extensions.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:decimal/decimal.dart';
 
 class UnitUtil {
@@ -22,7 +23,8 @@ class UnitUtil {
 class BalanceFormatUtil {
   /// 사용자 친화적 형식의 비트코인 잔액 보이기
   /// 예) 1 satoshi -> 0.0000 0001
-  static String formatSatoshiToReadableBitcoin(int satoshi, {bool forceEightDecimals = false}) {
+  static String formatSatoshiToReadableBitcoin(int satoshi, {bool forceEightDecimals = false, String? localeName}) {
+    final decimalSeparator = getNumberDecimalSeparator(localeName: localeName);
     double toBitcoin = UnitUtil.convertSatoshiToBitcoin(satoshi);
 
     String bitcoinString;
@@ -40,7 +42,8 @@ class BalanceFormatUtil {
     String integerPart = parts[0];
     String decimalPart = parts.length > 1 ? parts[1] : '';
 
-    final integerPartFormatted = integerPart == '-0' ? '-0' : int.parse(integerPart).toThousandsSeparatedString();
+    final integerPartFormatted =
+        integerPart == '-0' ? '-0' : int.parse(integerPart).toThousandsSeparatedString(localeName: localeName);
 
     String decimalPartGrouped = '';
     if (decimalPart.isNotEmpty) {
@@ -57,50 +60,64 @@ class BalanceFormatUtil {
       return '0';
     }
 
-    return decimalPartGrouped.isNotEmpty ? '$integerPartFormatted.$decimalPartGrouped' : integerPartFormatted;
+    return decimalPartGrouped.isNotEmpty
+        ? '$integerPartFormatted$decimalSeparator$decimalPartGrouped'
+        : integerPartFormatted;
   }
 
   /// BIP21/입력용 BTC 텍스트 포맷팅
   ///
   /// - 항상 소수부는 최대 8자리까지 표현
   /// - 소수부: trailing zero 제거
-  /// - 정수부: 천단위 콤마
-  static String formatSatoshiToBtcInputText(int satoshi) {
+  /// - 정수부: locale 천단위 구분자
+  static String formatSatoshiToBtcInputText(int satoshi, {String? localeName}) {
+    final decimalSeparator = getNumberDecimalSeparator(localeName: localeName);
     final rawBtcText = UnitUtil.convertSatoshiToBitcoinString(satoshi); // 8자리 고정 문자열
     final normalizedBtcText = rawBtcText.replaceFirst(RegExp(r'0+$'), '').replaceFirst(RegExp(r'\.$'), '');
 
     final parts = normalizedBtcText.split('.');
     final integerPart = parts[0].isEmpty ? '0' : parts[0];
-    final formattedIntegerPart = int.parse(integerPart).toThousandsSeparatedString();
+    final formattedIntegerPart = int.parse(integerPart).toThousandsSeparatedString(localeName: localeName);
 
     if (parts.length == 1) {
       return formattedIntegerPart;
     }
 
-    return '$formattedIntegerPart.${parts[1]}';
+    return '$formattedIntegerPart$decimalSeparator${parts[1]}';
   }
 
   /// BIP21에서 사용되는 초기 입력 텍스트(표시 형식 포함)
-  static String formatSatsToBip21InputText({required BitcoinUnit currentUnit, required int? initialAmountSats}) {
+  static String formatSatsToBip21InputText({
+    required BitcoinUnit currentUnit,
+    required int? initialAmountSats,
+    String? localeName,
+  }) {
     if (initialAmountSats == null) return '';
 
     if (currentUnit.isBtcUnit) {
-      return formatSatoshiToBtcInputText(initialAmountSats);
+      return formatSatoshiToBtcInputText(initialAmountSats, localeName: localeName);
     }
 
-    return initialAmountSats.toThousandsSeparatedString();
+    return initialAmountSats.toThousandsSeparatedString(localeName: localeName);
   }
 
   /// BIP21 입력 문자열(회계 표기로 `,` 포함)을 sats(int)로 변환
-  static int? parseBip21AmountTextToSats({required BitcoinUnit currentUnit, required String inputText}) {
-    final rawText = inputText.trim().replaceAll(',', '');
-    if (rawText.isEmpty) return null;
-
+  static int? parseBip21AmountTextToSats({
+    required BitcoinUnit currentUnit,
+    required String inputText,
+    String? localeName,
+  }) {
     if (currentUnit.isBtcUnit) {
+      final rawText = normalizeNumberTextForParsing(inputText, localeName: localeName);
+      if (rawText.isEmpty) return null;
+
       final amount = double.tryParse(rawText);
       if (amount == null) return null;
       return currentUnit.toSatoshi(amount);
     }
+
+    final rawText = inputText.trim().replaceAll(RegExp(r'[^0-9]'), '');
+    if (rawText.isEmpty) return null;
 
     return int.tryParse(rawText);
   }

--- a/lib/utils/locale_util.dart
+++ b/lib/utils/locale_util.dart
@@ -29,6 +29,70 @@ String normalizeNumberTextForParsing(String text, {String? localeName}) {
   return text.trim().replaceAll(groupingSeparator, '').replaceAll(decimalSeparator, '.');
 }
 
+String normalizeDecimalNumberTextForParsing(String text, {String? localeName}) {
+  final groupingSeparator = getNumberGroupingSeparator(localeName: localeName);
+  final decimalSeparator = getNumberDecimalSeparator(localeName: localeName);
+  final compactText = text.trim().replaceAll(RegExp(r'\s+'), '');
+  if (compactText.isEmpty) return compactText;
+
+  final lastDotIndex = compactText.lastIndexOf('.');
+  final lastCommaIndex = compactText.lastIndexOf(',');
+  if (lastDotIndex != -1 && lastCommaIndex != -1) {
+    final inferredDecimalSeparator = lastDotIndex > lastCommaIndex ? '.' : ',';
+    final inferredGroupingSeparator = inferredDecimalSeparator == '.' ? ',' : '.';
+    return compactText.replaceAll(inferredGroupingSeparator, '').replaceAll(inferredDecimalSeparator, '.');
+  }
+
+  if (decimalSeparator == ',' && compactText.contains(',')) {
+    return normalizeNumberTextForParsing(compactText, localeName: localeName);
+  }
+
+  if (decimalSeparator == '.' && compactText.contains('.')) {
+    return normalizeNumberTextForParsing(compactText, localeName: localeName);
+  }
+
+  if (compactText.contains(',')) {
+    return _normalizeSingleSeparatorDecimalText(
+      compactText,
+      separator: ',',
+      groupingSeparator: groupingSeparator,
+      localeName: localeName,
+    );
+  }
+
+  if (compactText.contains('.')) {
+    return _normalizeSingleSeparatorDecimalText(
+      compactText,
+      separator: '.',
+      groupingSeparator: groupingSeparator,
+      localeName: localeName,
+    );
+  }
+
+  return compactText;
+}
+
+String _normalizeSingleSeparatorDecimalText(
+  String text, {
+  required String separator,
+  required String groupingSeparator,
+  String? localeName,
+}) {
+  final parts = text.split(separator);
+  if (parts.length != 2) {
+    return normalizeNumberTextForParsing(text, localeName: localeName);
+  }
+
+  final integerPart = parts.first;
+  final fractionalPart = parts.last;
+  final shouldTreatAsDecimal = separator != groupingSeparator || integerPart == '0' || fractionalPart.length != 3;
+  if (!shouldTreatAsDecimal) {
+    return normalizeNumberTextForParsing(text, localeName: localeName);
+  }
+
+  return '${integerPart.isEmpty ? '0' : integerPart}.$fractionalPart';
+}
+
 /// 시스템 언어를 감지하여 적절한 언어 코드를 반환합니다.
 String getSystemLanguageCode() {
   final Locale systemLocale = PlatformDispatcher.instance.locale;

--- a/lib/utils/locale_util.dart
+++ b/lib/utils/locale_util.dart
@@ -1,5 +1,34 @@
 import 'dart:ui';
 
+import 'package:intl/intl.dart';
+import 'package:intl/number_symbols.dart';
+
+String getNumberFormatLocaleName() {
+  final locales = PlatformDispatcher.instance.locales;
+  final locale = locales.isNotEmpty ? locales.first : PlatformDispatcher.instance.locale;
+
+  return Intl.canonicalizedLocale(locale.toLanguageTag());
+}
+
+NumberSymbols getNumberFormatSymbols({String? localeName}) {
+  return NumberFormat.decimalPattern(localeName ?? getNumberFormatLocaleName()).symbols;
+}
+
+String getNumberDecimalSeparator({String? localeName}) {
+  return getNumberFormatSymbols(localeName: localeName).DECIMAL_SEP;
+}
+
+String getNumberGroupingSeparator({String? localeName}) {
+  return getNumberFormatSymbols(localeName: localeName).GROUP_SEP;
+}
+
+String normalizeNumberTextForParsing(String text, {String? localeName}) {
+  final groupingSeparator = getNumberGroupingSeparator(localeName: localeName);
+  final decimalSeparator = getNumberDecimalSeparator(localeName: localeName);
+
+  return text.trim().replaceAll(groupingSeparator, '').replaceAll(decimalSeparator, '.');
+}
+
 /// 시스템 언어를 감지하여 적절한 언어 코드를 반환합니다.
 String getSystemLanguageCode() {
   final Locale systemLocale = PlatformDispatcher.instance.locale;

--- a/lib/utils/text_field_filter_util.dart
+++ b/lib/utils/text_field_filter_util.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/services.dart';
 import 'package:coconut_wallet/extensions/int_extensions.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 
 String filterNumericInput(String input, {required int decimalPlaces, int integerPlaces = -1}) {
-  String allowedCharsInput = input.replaceAll(RegExp(r'[^0-9.]'), '');
+  String allowedCharsInput = input.replaceAll(',', '.').replaceAll(RegExp(r'[^0-9.]'), '');
   if (input == '00') return '0';
-  if (input == '.') return '0.';
+  if (input == '.' || input == ',') return '0.';
   if (RegExp(r'^0[1-9]$').hasMatch(input)) return input.substring(1);
 
   var splitedInput = allowedCharsInput.split('.');
@@ -39,12 +40,22 @@ class BtcAmountInputFormatter extends TextInputFormatter {
   static const double maxBtc = 21_000_000;
 
   final int decimalPlaces;
+  final String? localeName;
 
-  const BtcAmountInputFormatter({this.decimalPlaces = 8});
+  const BtcAmountInputFormatter({this.decimalPlaces = 8, this.localeName});
 
   @override
   TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
-    final text = newValue.text.replaceAll(RegExp(r'[^0-9.]'), '');
+    final decimalSeparator = getNumberDecimalSeparator(localeName: localeName);
+    final groupingSeparator = getNumberGroupingSeparator(localeName: localeName);
+    if (_insertedText(oldValue, newValue).contains(groupingSeparator)) {
+      return oldValue;
+    }
+
+    final text = newValue.text
+        .replaceAll(groupingSeparator, '')
+        .replaceAll(decimalSeparator, '.')
+        .replaceAll(RegExp(r'[^0-9.]'), '');
     if (text.isEmpty) return newValue;
 
     final parts = text.split('.');
@@ -56,11 +67,13 @@ class BtcAmountInputFormatter extends TextInputFormatter {
     final btc = double.tryParse(text);
     if (btc != null && btc > maxBtc) return oldValue;
 
-    final formattedText = _formatBtcText(text);
+    final formattedText = _formatBtcText(text, localeName: localeName, decimalSeparator: decimalSeparator);
     final offset = _calculateSelectionOffset(
       originalText: newValue.text,
       formattedText: formattedText,
       baseOffset: newValue.selection.baseOffset,
+      decimalSeparator: decimalSeparator,
+      groupingSeparator: groupingSeparator,
     );
     return TextEditingValue(text: formattedText, selection: TextSelection.collapsed(offset: offset));
   }
@@ -69,7 +82,9 @@ class BtcAmountInputFormatter extends TextInputFormatter {
 class SatoshiAmountInputFormatter extends TextInputFormatter {
   static const int maxSats = 2_100_000_000_000_000;
 
-  const SatoshiAmountInputFormatter();
+  final String? localeName;
+
+  const SatoshiAmountInputFormatter({this.localeName});
 
   @override
   TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
@@ -79,43 +94,66 @@ class SatoshiAmountInputFormatter extends TextInputFormatter {
     final sats = int.tryParse(text);
     if (sats != null && sats > maxSats) return oldValue;
 
-    final formattedText = int.parse(text).toThousandsSeparatedString();
+    final groupingSeparator = getNumberGroupingSeparator(localeName: localeName);
+    final formattedText = int.parse(text).toThousandsSeparatedString(localeName: localeName);
     final offset = _calculateSelectionOffset(
       originalText: newValue.text,
       formattedText: formattedText,
       baseOffset: newValue.selection.baseOffset,
+      groupingSeparator: groupingSeparator,
     );
     return TextEditingValue(text: formattedText, selection: TextSelection.collapsed(offset: offset));
   }
 }
 
-String _formatBtcText(String text) {
-  if (text == '.') return '0.';
+String _insertedText(TextEditingValue oldValue, TextEditingValue newValue) {
+  if (newValue.text.length <= oldValue.text.length) return '';
 
-  final parts = text.split('.');
+  final start = oldValue.selection.baseOffset.clamp(0, oldValue.text.length);
+  final end = (start + (newValue.text.length - oldValue.text.length)).clamp(0, newValue.text.length);
+  return newValue.text.substring(start, end);
+}
+
+String _formatBtcText(String text, {String? localeName, required String decimalSeparator}) {
+  if (text == '.' || text == ',') return '0$decimalSeparator';
+
+  final parts = text.replaceAll(',', '.').split('.');
   final integerPart = parts[0].isEmpty ? '0' : parts[0];
-  final formattedIntegerPart = int.parse(integerPart).toThousandsSeparatedString();
+  final formattedIntegerPart = int.parse(integerPart).toThousandsSeparatedString(localeName: localeName);
 
   if (parts.length == 1) {
     return formattedIntegerPart;
   }
 
-  return '$formattedIntegerPart.${parts[1]}';
+  return '$formattedIntegerPart$decimalSeparator${parts[1]}';
 }
 
-int _calculateSelectionOffset({required String originalText, required String formattedText, required int baseOffset}) {
+int _calculateSelectionOffset({
+  required String originalText,
+  required String formattedText,
+  required int baseOffset,
+  String decimalSeparator = '.',
+  String groupingSeparator = ',',
+}) {
   final clampedOffset = baseOffset.clamp(0, originalText.length);
 
   // .을 입력하면 0.으로 바뀌는 경우(BTC 단위 입력 시 해당) .뒤에 커서를 두기 위해 따로 처리
-  if (originalText.startsWith('.') && formattedText.startsWith('0.')) {
+  if ((originalText.startsWith('.') || originalText.startsWith(',')) &&
+      formattedText.startsWith('0$decimalSeparator')) {
     return (clampedOffset + 1).clamp(0, formattedText.length);
   }
 
-  final meaningfulCharCount = originalText.substring(0, clampedOffset).replaceAll(',', '').length;
+  final textBeforeCursor = originalText.substring(0, clampedOffset);
+  if (textBeforeCursor.endsWith('.') || textBeforeCursor.endsWith(',')) {
+    final decimalOffset = formattedText.indexOf(decimalSeparator) + 1;
+    if (decimalOffset > 0) return decimalOffset;
+  }
+
+  final meaningfulCharCount = textBeforeCursor.replaceAll(groupingSeparator, '').length;
 
   var seenMeaningfulChars = 0;
   for (var i = 0; i < formattedText.length; i++) {
-    if (formattedText[i] != ',') {
+    if (formattedText[i] != groupingSeparator) {
       seenMeaningfulChars++;
     }
     if (seenMeaningfulChars >= meaningfulCharCount) {

--- a/lib/widgets/bottom_sheet/bip21_amount_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheet/bip21_amount_bottom_sheet.dart
@@ -1,8 +1,8 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
-import 'package:coconut_wallet/extensions/int_extensions.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/utils/text_field_filter_util.dart';
 import 'package:coconut_wallet/widgets/button/fixed_bottom_button.dart';
 import 'package:coconut_wallet/widgets/overlays/common_bottom_sheets.dart';
@@ -45,10 +45,14 @@ class Bip21AmountBottomSheet extends StatefulWidget {
 class _Bip21AmountBottomSheetState extends State<Bip21AmountBottomSheet> {
   final TextEditingController _amountController = TextEditingController();
   final FocusNode _amountFocusNode = FocusNode();
+  late final String _localeName;
   late final String _initialAmountText;
 
   int? get _amountInSats {
-    final rawText = _amountController.text.trim().replaceAll(',', '');
+    final rawText =
+        widget.currentUnit.isBtcUnit
+            ? normalizeNumberTextForParsing(_amountController.text, localeName: _localeName)
+            : _amountController.text.trim().replaceAll(RegExp(r'[^0-9]'), '');
     if (rawText.isEmpty) return null;
 
     final amount = double.tryParse(rawText);
@@ -61,6 +65,7 @@ class _Bip21AmountBottomSheetState extends State<Bip21AmountBottomSheet> {
   @override
   void initState() {
     super.initState();
+    _localeName = getNumberFormatLocaleName();
     _initialAmountText = _buildInitialAmountText();
     _amountController.text = _initialAmountText;
     _amountController.addListener(_onFieldChanged);
@@ -68,29 +73,11 @@ class _Bip21AmountBottomSheetState extends State<Bip21AmountBottomSheet> {
   }
 
   String _buildInitialAmountText() {
-    final initialAmountSats = widget.initialAmountSats;
-    if (initialAmountSats == null) return '';
-
-    if (widget.currentUnit.isBtcUnit) {
-      return _formatInitialBtcAmountText(initialAmountSats);
-    }
-
-    return initialAmountSats.toThousandsSeparatedString();
-  }
-
-  String _formatInitialBtcAmountText(int amountSats) {
-    final rawBtcText = UnitUtil.convertSatoshiToBitcoinString(amountSats);
-    final normalizedBtcText = rawBtcText.replaceFirst(RegExp(r'0+$'), '').replaceFirst(RegExp(r'\.$'), '');
-
-    final parts = normalizedBtcText.split('.');
-    final integerPart = parts[0].isEmpty ? '0' : parts[0];
-    final formattedIntegerPart = int.parse(integerPart).toThousandsSeparatedString();
-
-    if (parts.length == 1) {
-      return formattedIntegerPart;
-    }
-
-    return '$formattedIntegerPart.${parts[1]}';
+    return BalanceFormatUtil.formatSatsToBip21InputText(
+      currentUnit: widget.currentUnit,
+      initialAmountSats: widget.initialAmountSats,
+      localeName: _localeName,
+    );
   }
 
   @override
@@ -150,14 +137,10 @@ class _Bip21AmountBottomSheetState extends State<Bip21AmountBottomSheet> {
 
   List<TextInputFormatter> _buildInputFormatters() {
     if (widget.currentUnit.isBtcUnit) {
-      return [
-        FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
-        SingleDotInputFormatter(),
-        const BtcAmountInputFormatter(),
-      ];
+      return [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')), BtcAmountInputFormatter(localeName: _localeName)];
     }
 
-    return [FilteringTextInputFormatter.digitsOnly, const SatoshiAmountInputFormatter()];
+    return [FilteringTextInputFormatter.digitsOnly, SatoshiAmountInputFormatter(localeName: _localeName)];
   }
 
   @override
@@ -205,16 +188,5 @@ class _Bip21AmountBottomSheetState extends State<Bip21AmountBottomSheet> {
         ],
       ),
     );
-  }
-}
-
-class SingleDotInputFormatter extends TextInputFormatter {
-  @override
-  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
-    if ('.'.allMatches(newValue.text).length > 1) {
-      return oldValue;
-    }
-
-    return newValue;
   }
 }

--- a/lib/widgets/bottom_sheet/estimated_fee_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheet/estimated_fee_bottom_sheet.dart
@@ -3,6 +3,7 @@ import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/send/fee_info.dart';
 import 'package:coconut_wallet/providers/connectivity_provider.dart';
 import 'package:coconut_wallet/utils/fee_rate_mixin.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/widgets/overlays/common_bottom_sheets.dart';
 import 'package:coconut_wallet/widgets/ripple_effect.dart';
 import 'package:flutter/material.dart';
@@ -11,7 +12,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
 
-class EstimatedFeeBottomSheet extends StatelessWidget {
+class EstimatedFeeBottomSheet extends StatefulWidget {
   final ScrollController scrollController;
   final Listenable listenable;
   final String Function() estimatedFeeTextGetter;
@@ -38,6 +39,9 @@ class EstimatedFeeBottomSheet extends StatelessWidget {
     required this.refreshRecommendedFees,
     required this.onFeeRateSelected,
   });
+
+  @override
+  State<EstimatedFeeBottomSheet> createState() => _EstimatedFeeBottomSheetState();
 
   static Future<T?> show<T>({
     required BuildContext context,
@@ -85,6 +89,22 @@ class EstimatedFeeBottomSheet extends StatelessWidget {
       onClosed?.call();
     });
   }
+}
+
+class _EstimatedFeeBottomSheetState extends State<EstimatedFeeBottomSheet> {
+  bool _isApplyingControllerText = false;
+
+  ScrollController get scrollController => widget.scrollController;
+  Listenable get listenable => widget.listenable;
+  String Function() get estimatedFeeTextGetter => widget.estimatedFeeTextGetter;
+  TextEditingController get feeRateController => widget.feeRateController;
+  FocusNode get feeRateFocusNode => widget.feeRateFocusNode;
+  bool Function(String) get onFeeRateChanged => widget.onFeeRateChanged;
+  VoidCallback get onEditingComplete => widget.onEditingComplete;
+  RecommendedFeeFetchStatus Function() get recommendedFeeFetchStatusGetter => widget.recommendedFeeFetchStatusGetter;
+  List<FeeInfoWithLevel> Function() get feeInfosGetter => widget.feeInfosGetter;
+  VoidCallback get refreshRecommendedFees => widget.refreshRecommendedFees;
+  void Function(double) get onFeeRateSelected => widget.onFeeRateSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -163,7 +183,7 @@ class EstimatedFeeBottomSheet extends StatelessWidget {
                     child: CoconutTextField(
                       textInputType: const TextInputType.numberWithOptions(signed: false, decimal: true),
                       textInputAction: TextInputAction.done,
-                      textInputFormatter: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.]'))],
+                      textInputFormatter: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))],
                       enableInteractiveSelection: false,
                       textAlign: TextAlign.end,
                       controller: feeRateController,
@@ -173,7 +193,13 @@ class EstimatedFeeBottomSheet extends StatelessWidget {
                       height: 30,
                       padding: const EdgeInsets.only(left: 12, right: 2),
                       onChanged: (text) {
-                        final isTooLow = onFeeRateChanged(text);
+                        if (_isApplyingControllerText) return;
+
+                        final isTooLow = onFeeRateChanged(_normalizeFeeRateText(text));
+                        final displayText = _formatFeeRateTextForDisplay(feeRateController.text);
+                        if (feeRateController.text != displayText) {
+                          _setFeeRateControllerText(displayText);
+                        }
                         if (isTooLow) {
                           CoconutToast.showBottomToast(
                             context: context,
@@ -287,7 +313,7 @@ class EstimatedFeeBottomSheet extends StatelessWidget {
             ),
             CoconutLayout.spacing_100w,
             Text(
-              "${sats != null ? sats.toStringAsFixed(1) : "-"} ${t.send_screen.fee_rate_suffix}",
+              "${sats != null ? _formatFeeRateTextForDisplay(sats.toStringAsFixed(1)) : "-"} ${t.send_screen.fee_rate_suffix}",
               style: CoconutTypography.body2_14.setColor(CoconutColors.white),
             ),
           ],
@@ -302,6 +328,10 @@ class EstimatedFeeBottomSheet extends StatelessWidget {
           if (isFetching) return;
           if (sats != null) {
             onFeeRateSelected(sats);
+            final displayText = _formatFeeRateTextForDisplay(feeRateController.text);
+            if (feeRateController.text != displayText) {
+              _setFeeRateControllerText(displayText);
+            }
           }
         },
         child:
@@ -314,5 +344,19 @@ class EstimatedFeeBottomSheet extends StatelessWidget {
                 ),
       ),
     );
+  }
+
+  String _normalizeFeeRateText(String text) {
+    return text.replaceAll(getNumberDecimalSeparator(), '.').replaceAll(',', '.');
+  }
+
+  String _formatFeeRateTextForDisplay(String text) {
+    return text.replaceAll('.', getNumberDecimalSeparator());
+  }
+
+  void _setFeeRateControllerText(String text) {
+    _isApplyingControllerText = true;
+    feeRateController.value = TextEditingValue(text: text, selection: TextSelection.collapsed(offset: text.length));
+    _isApplyingControllerText = false;
   }
 }

--- a/lib/widgets/card/transaction_draft_card.dart
+++ b/lib/widgets/card/transaction_draft_card.dart
@@ -10,6 +10,7 @@ import 'package:coconut_wallet/providers/send_info_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/utils/datetime_util.dart';
+import 'package:coconut_wallet/utils/locale_util.dart';
 import 'package:coconut_wallet/widgets/button/shrink_animation_button.dart';
 import 'package:coconut_wallet/widgets/icon/wallet_icon_small.dart';
 import 'package:flutter/material.dart';
@@ -397,10 +398,14 @@ class _TransactionDraftCardState extends State<TransactionDraftCard> with Single
       children: [
         Text(t.transaction_draft.fee_rate, style: CoconutTypography.body3_12.setColor(CoconutColors.gray400)),
         CoconutLayout.spacing_100w,
-        Text(feeRate.toString(), style: CoconutTypography.body3_12.setColor(CoconutColors.white)),
+        Text(_formatFeeRateForDisplay(feeRate), style: CoconutTypography.body3_12.setColor(CoconutColors.white)),
         CoconutLayout.spacing_100w,
         Text(t.transaction_draft.sats_per_vbyte, style: CoconutTypography.body3_12.setColor(CoconutColors.white)),
       ],
     );
+  }
+
+  String _formatFeeRateForDisplay(double feeRate) {
+    return feeRate.toString().replaceAll('.', getNumberDecimalSeparator());
   }
 }

--- a/test/extensions/int_extensions_test.dart
+++ b/test/extensions/int_extensions_test.dart
@@ -4,33 +4,55 @@ import 'package:coconut_wallet/extensions/int_extensions.dart';
 void main() {
   group('IntFormatting Extension Tests', () {
     test('toThousandsSeparatedString formats zero correctly', () {
-      expect(0.toThousandsSeparatedString(), '0');
+      expect(0.toThousandsSeparatedString(localeName: 'en_US'), '0');
     });
 
     test('toThousandsSeparatedString formats small numbers correctly', () {
-      expect(1.toThousandsSeparatedString(), '1');
-      expect(999.toThousandsSeparatedString(), '999');
+      expect(1.toThousandsSeparatedString(localeName: 'en_US'), '1');
+      expect(999.toThousandsSeparatedString(localeName: 'en_US'), '999');
     });
 
     test('toThousandsSeparatedString formats thousands correctly', () {
-      expect(1000.toThousandsSeparatedString(), '1,000');
-      expect(10000.toThousandsSeparatedString(), '10,000');
-      expect(100000.toThousandsSeparatedString(), '100,000');
+      expect(1000.toThousandsSeparatedString(localeName: 'en_US'), '1,000');
+      expect(10000.toThousandsSeparatedString(localeName: 'en_US'), '10,000');
+      expect(100000.toThousandsSeparatedString(localeName: 'en_US'), '100,000');
     });
 
     test('toThousandsSeparatedString formats millions correctly', () {
-      expect(1000000.toThousandsSeparatedString(), '1,000,000');
-      expect(1234567.toThousandsSeparatedString(), '1,234,567');
+      expect(
+        1000000.toThousandsSeparatedString(localeName: 'en_US'),
+        '1,000,000',
+      );
+      expect(
+        1234567.toThousandsSeparatedString(localeName: 'en_US'),
+        '1,234,567',
+      );
+    });
+
+    test('toThousandsSeparatedString formats by locale', () {
+      expect(
+        1234567.toThousandsSeparatedString(localeName: 'de_DE'),
+        '1.234.567',
+      );
     });
 
     test('toThousandsSeparatedString formats negative numbers correctly', () {
-      expect((-1000).toThousandsSeparatedString(), '-1,000');
-      expect((-1000000).toThousandsSeparatedString(), '-1,000,000');
+      expect((-1000).toThousandsSeparatedString(localeName: 'en_US'), '-1,000');
+      expect(
+        (-1000000).toThousandsSeparatedString(localeName: 'en_US'),
+        '-1,000,000',
+      );
     });
 
     test('toThousandsSeparatedString formats max/min int values correctly', () {
-      expect(2147483647.toThousandsSeparatedString(), '2,147,483,647'); // max 32-bit int
-      expect((-2147483648).toThousandsSeparatedString(), '-2,147,483,648'); // min 32-bit int
+      expect(
+        2147483647.toThousandsSeparatedString(localeName: 'en_US'),
+        '2,147,483,647',
+      ); // max 32-bit int
+      expect(
+        (-2147483648).toThousandsSeparatedString(localeName: 'en_US'),
+        '-2,147,483,648',
+      ); // min 32-bit int
     });
   });
 }

--- a/test/extensions/string_extensions_test.dart
+++ b/test/extensions/string_extensions_test.dart
@@ -5,17 +5,25 @@ void main() {
   group('StringFormatting', () {
     group('toThousandsSeparatedString', () {
       test('정수 문자열에 대해 천 단위 구분자를 추가한다', () {
-        expect('1234'.toThousandsSeparatedString(), '1,234');
-        expect('1234567'.toThousandsSeparatedString(), '1,234,567');
-        expect('0'.toThousandsSeparatedString(), '0');
-        expect('-1234'.toThousandsSeparatedString(), '-1,234');
+        expect('1234'.toThousandsSeparatedString(localeName: 'en_US'), '1,234');
+        expect('1234567'.toThousandsSeparatedString(localeName: 'en_US'), '1,234,567');
+        expect('0'.toThousandsSeparatedString(localeName: 'en_US'), '0');
+        expect('-1234'.toThousandsSeparatedString(localeName: 'en_US'), '-1,234');
       });
 
       test('소수 문자열에 대해 천 단위 구분자와 소수점 2자리를 표시한다', () {
-        expect('123124141234.54959454859345'.toThousandsSeparatedString(), '123,124,141,234.54959454859345');
-        expect('1234.56'.toThousandsSeparatedString(), '1,234.56');
-        expect('1234.567'.toThousandsSeparatedString(), '1,234.567');
-        expect('-1234.5'.toThousandsSeparatedString(), '-1,234.5');
+        expect(
+          '123124141234.54959454859345'.toThousandsSeparatedString(localeName: 'en_US'),
+          '123,124,141,234.5495 9454859345',
+        );
+        expect('1234.56'.toThousandsSeparatedString(localeName: 'en_US'), '1,234.56');
+        expect('1234.567'.toThousandsSeparatedString(localeName: 'en_US'), '1,234.567');
+        expect('-1234.5'.toThousandsSeparatedString(localeName: 'en_US'), '-1,234.5');
+      });
+
+      test('locale에 맞는 구분자를 사용한다', () {
+        expect('1234567'.toThousandsSeparatedString(localeName: 'de_DE'), '1.234.567');
+        expect('1234.56'.toThousandsSeparatedString(localeName: 'de_DE'), '1.234,56');
       });
 
       test('숫자가 아닌 문자열은 원래 값을 반환한다', () {

--- a/test/utils/balance_format_util_test.dart
+++ b/test/utils/balance_format_util_test.dart
@@ -110,6 +110,16 @@ void main() {
       expect(BalanceFormatUtil.formatSatoshiToReadableBitcoin(-123456), '-0.0012 3456');
       expect(BalanceFormatUtil.formatSatoshiToReadableBitcoin(-12345678), '-0.1234 5678');
     });
+
+    test('satoshiToReadableBitcoin - locale에 맞는 구분자 사용', () {
+      expect(BalanceFormatUtil.formatSatoshiToReadableBitcoin(123456000, localeName: 'en_US'), '1.2345 6000');
+      expect(BalanceFormatUtil.formatSatoshiToReadableBitcoin(123456000, localeName: 'de_DE'), '1,2345 6000');
+      expect(BalanceFormatUtil.formatSatoshiToReadableBitcoin(100000000000, localeName: 'de_DE'), '1.000');
+      expect(
+        BalanceFormatUtil.formatSatoshiToReadableBitcoin(100000000000, forceEightDecimals: true, localeName: 'de_DE'),
+        '1.000,0000 0000',
+      );
+    });
   });
 
   group('BalanceFormatUtil.satoshiToReadableBitcoin', () {
@@ -218,6 +228,56 @@ void main() {
       expect(BalanceFormatUtil.formatSatoshiToReadableBitcoin(-1000), '-0.0000 1000');
       expect(BalanceFormatUtil.formatSatoshiToReadableBitcoin(-123456), '-0.0012 3456');
       expect(BalanceFormatUtil.formatSatoshiToReadableBitcoin(-12345678), '-0.1234 5678');
+    });
+  });
+
+  group('BalanceFormatUtil.parseBip21AmountTextToSats', () {
+    test('BTC 입력값을 locale의 소수/천단위 구분자 기준으로 파싱한다', () {
+      expect(
+        BalanceFormatUtil.parseBip21AmountTextToSats(
+          currentUnit: BitcoinUnit.btc,
+          inputText: '1,234.56',
+          localeName: 'en_US',
+        ),
+        123456000000,
+      );
+      expect(
+        BalanceFormatUtil.parseBip21AmountTextToSats(
+          currentUnit: BitcoinUnit.btc,
+          inputText: '1.234,56',
+          localeName: 'de_DE',
+        ),
+        123456000000,
+      );
+    });
+  });
+
+  group('BalanceFormatUtil.formatSatsToBip21InputText', () {
+    test('BTC 초기 표시값에 locale 구분자를 사용한다', () {
+      expect(
+        BalanceFormatUtil.formatSatsToBip21InputText(
+          currentUnit: BitcoinUnit.btc,
+          initialAmountSats: 123456000,
+          localeName: 'en_US',
+        ),
+        '1.23456',
+      );
+      expect(
+        BalanceFormatUtil.formatSatsToBip21InputText(
+          currentUnit: BitcoinUnit.btc,
+          initialAmountSats: 123456000,
+          localeName: 'de_DE',
+        ),
+        '1,23456',
+      );
+      expect(
+        BalanceFormatUtil.formatSatsToBip21InputText(
+          currentUnit: BitcoinUnit.btc,
+          initialAmountSats: 100000000000,
+          localeName: 'de_DE',
+        ),
+        '1.000',
+      );
     });
   });
 

--- a/test/utils/locale_util_test.dart
+++ b/test/utils/locale_util_test.dart
@@ -29,6 +29,14 @@ void main() {
       expect(normalizeNumberTextForParsing('1.234,56', localeName: 'de_DE'), '1234.56');
     });
 
+    test('normalizeDecimalNumberTextForParsing preserves decimal separator for decimal inputs', () {
+      expect(normalizeDecimalNumberTextForParsing('0,0001', localeName: 'en_US'), '0.0001');
+      expect(normalizeDecimalNumberTextForParsing('1,234', localeName: 'en_US'), '1234');
+      expect(normalizeDecimalNumberTextForParsing('1,2345', localeName: 'en_US'), '1.2345');
+      expect(normalizeDecimalNumberTextForParsing('1.234,56', localeName: 'de_DE'), '1234.56');
+      expect(normalizeDecimalNumberTextForParsing('1,234.56', localeName: 'en_US'), '1234.56');
+    });
+
     test('getSystemLanguageCode should return en for non-Korean locale', () {
       // 이 테스트는 로직을 검증하는 용도입니다.
       // 실제로는 window.locale이 필요하지만, 여기서는 함수가 올바른 값을 반환하는지 확인합니다.

--- a/test/utils/locale_util_test.dart
+++ b/test/utils/locale_util_test.dart
@@ -24,6 +24,11 @@ void main() {
       expect(isSystemLanguageJapanese(), isA<bool>());
     });
 
+    test('normalizeNumberTextForParsing uses locale separators', () {
+      expect(normalizeNumberTextForParsing('1,234.56', localeName: 'en_US'), '1234.56');
+      expect(normalizeNumberTextForParsing('1.234,56', localeName: 'de_DE'), '1234.56');
+    });
+
     test('getSystemLanguageCode should return en for non-Korean locale', () {
       // 이 테스트는 로직을 검증하는 용도입니다.
       // 실제로는 window.locale이 필요하지만, 여기서는 함수가 올바른 값을 반환하는지 확인합니다.

--- a/test/utils/text_field_filter_util_test.dart
+++ b/test/utils/text_field_filter_util_test.dart
@@ -1,0 +1,54 @@
+import 'package:coconut_wallet/utils/text_field_filter_util.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BtcAmountInputFormatter', () {
+    TextEditingValue format(String text, {String localeName = 'en_US'}) {
+      final formatter = BtcAmountInputFormatter(localeName: localeName);
+      return formatter.formatEditUpdate(
+        const TextEditingValue(),
+        TextEditingValue(text: text, selection: TextSelection.collapsed(offset: text.length)),
+      );
+    }
+
+    test('uses dot as decimal separator for en_US and rejects comma grouping separator', () {
+      expect(format('0.1').text, '0.1');
+
+      const oldValue = TextEditingValue(text: '0', selection: TextSelection.collapsed(offset: 1));
+      const newValue = TextEditingValue(text: '0,', selection: TextSelection.collapsed(offset: 2));
+      const formatter = BtcAmountInputFormatter(localeName: 'en_US');
+      expect(formatter.formatEditUpdate(oldValue, newValue), oldValue);
+    });
+
+    test('uses comma as decimal separator for de_DE and rejects dot grouping separator', () {
+      expect(format('0,1', localeName: 'de_DE').text, '0,1');
+      expect(format(',', localeName: 'de_DE').text, '0,');
+
+      const oldValue = TextEditingValue(text: '0', selection: TextSelection.collapsed(offset: 1));
+      const newValue = TextEditingValue(text: '0.', selection: TextSelection.collapsed(offset: 2));
+      const formatter = BtcAmountInputFormatter(localeName: 'de_DE');
+      expect(formatter.formatEditUpdate(oldValue, newValue), oldValue);
+    });
+
+    test('rejects multiple decimal separators', () {
+      const oldValue = TextEditingValue(text: '0.1', selection: TextSelection.collapsed(offset: 3));
+      const newValue = TextEditingValue(text: '0.1.', selection: TextSelection.collapsed(offset: 4));
+      const formatter = BtcAmountInputFormatter(localeName: 'en_US');
+      expect(formatter.formatEditUpdate(oldValue, newValue), oldValue);
+    });
+  });
+
+  group('SatoshiAmountInputFormatter', () {
+    test('keeps cursor at the end when locale grouping separator is dot', () {
+      const formatter = SatoshiAmountInputFormatter(localeName: 'de_DE');
+      const oldValue = TextEditingValue(text: '123', selection: TextSelection.collapsed(offset: 3));
+      const newValue = TextEditingValue(text: '1234', selection: TextSelection.collapsed(offset: 4));
+
+      final result = formatter.formatEditUpdate(oldValue, newValue);
+
+      expect(result.text, '1.234');
+      expect(result.selection.baseOffset, result.text.length);
+    });
+  });
+}


### PR DESCRIPTION
UI에 표기되는 BTC/Sats 단위, FiatPrice 단위, fee rate등 회계(숫자) 표기를 각 국가에 맞게 반영
(유럽 일부 국가의 경우 천의자리 단위로 '.' 을 사용하고 소수점 단위로 ','를 사용한다는 점을 고려)

PSBT 생성과 Transaction Build에 필요한 데이터에는 기존 en-US 방식을 고수합니다.

#684 