### PR TITLE
feat: add Floresta client support

### DIFF
--- a/lib/constants/shared_pref_keys.dart
+++ b/lib/constants/shared_pref_keys.dart
@@ -61,6 +61,8 @@ class SharedPrefKeys {
   static const String kCustomElectrumHost = 'CUSTOM_ELECTRUM_HOST';
   static const String kCustomElectrumPort = 'CUSTOM_ELECTRUM_PORT';
   static const String kCustomElectrumIsSsl = 'CUSTOM_ELECTRUM_IS_SSL';
+  static const String kCustomElectrumIsFloresta = 'CUSTOM_ELECTRUM_IS_FLORESTA';
+  static const String kCustomElectrumRpcPort = 'CUSTOM_ELECTRUM_RPC_PORT';
   static const String kUserServers = 'USER_SERVERS';
 
   /// kHasLaunchedBefore 절대 초기화 금지

--- a/lib/enums/electrum_enums.dart
+++ b/lib/enums/electrum_enums.dart
@@ -24,6 +24,12 @@ enum DefaultElectrumServer {
     'REGTEST',
     99,
     true, // isRegtest
+  ),
+  florestaRegtest(
+    ElectrumServer('localhost', 50001, false, isFloresta: true, rpcPort: 50001),
+    'FLORESTA_REGTEST',
+    100,
+    true, // isRegtest
   );
 
   const DefaultElectrumServer(this.server, this.serverName, this.order, this.isRegtest);

--- a/lib/model/node/electrum_server.dart
+++ b/lib/model/node/electrum_server.dart
@@ -2,10 +2,24 @@ class ElectrumServer {
   final String host;
   final int port;
   final bool ssl;
+  final bool isFloresta;
+  final int rpcPort;
 
-  const ElectrumServer(this.host, this.port, this.ssl);
+  const ElectrumServer(
+    this.host,
+    this.port,
+    this.ssl, {
+    this.isFloresta = false,
+    this.rpcPort = 0,
+  });
 
-  factory ElectrumServer.custom(String host, int port, bool ssl) {
-    return ElectrumServer(host, port, host.contains('.onion') ? false : ssl);
+  factory ElectrumServer.custom(String host, int port, bool ssl, {bool isFloresta = false, int rpcPort = 0}) {
+    return ElectrumServer(
+      host,
+      port,
+      host.contains('.onion') ? false : ssl,
+      isFloresta: isFloresta,
+      rpcPort: rpcPort > 0 ? rpcPort : port,
+    );
   }
 }

--- a/lib/model/node/spawn_isolate_dto.dart
+++ b/lib/model/node/spawn_isolate_dto.dart
@@ -8,6 +8,16 @@ class SpawnIsolateDto {
   final int port;
   final bool ssl;
   final NetworkType networkType;
+  final bool isFloresta;
+  final int rpcPort;
 
-  SpawnIsolateDto(this.isolateToMainSendPort, this.host, this.port, this.ssl, this.networkType);
+  SpawnIsolateDto(
+    this.isolateToMainSendPort,
+    this.host,
+    this.port,
+    this.ssl,
+    this.networkType, {
+    this.isFloresta = false,
+    this.rpcPort = 0,
+  });
 }

--- a/lib/providers/node_provider/isolate/isolate_controller.dart
+++ b/lib/providers/node_provider/isolate/isolate_controller.dart
@@ -6,6 +6,8 @@ import 'package:coconut_wallet/providers/node_provider/network_service.dart';
 import 'package:coconut_wallet/providers/node_provider/subscription/subscription_service.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_record_service.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/floresta_rpc_client.dart';
+import 'package:coconut_wallet/model/error/app_error.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/result.dart';
 
@@ -15,13 +17,15 @@ class IsolateController {
   final IsolateStateManager _isolateStateManager;
   final ElectrumService _electrumService;
   final TransactionRecordService _transactionRecordService;
+  final FlorestaRpcClient? _florestaClient;
   IsolateController(
     this._subscriptionService,
     this._networkManager,
     this._isolateStateManager,
     this._electrumService,
-    this._transactionRecordService,
-  );
+    this._transactionRecordService, {
+    FlorestaRpcClient? florestaClient,
+  }) : _florestaClient = florestaClient;
 
   Future<void> executeNetworkCommand(
     IsolateControllerCommand messageType,
@@ -80,6 +84,45 @@ class IsolateController {
           final txHash = params[1] as String;
           Logger.log('IsolateController: getTransactionRecord executing in isolate (txHash: $txHash)');
           isolateToMainSendPort.send(await _transactionRecordService.getTransactionRecord(params[0], params[1]));
+          break;
+        case IsolateControllerCommand.florestaRegisterDescriptors:
+          if (_florestaClient == null) {
+            isolateToMainSendPort.send(Result.failure(ErrorCodes.withMessage(ErrorCodes.nodeUnknown, 'Floresta client not initialized')));
+            return;
+          }
+          try {
+            final walletItems = params[0] as List<dynamic>;
+            Logger.log('IsolateController: florestaRegisterDescriptors started, wallets=${walletItems.length}');
+            for (final walletItem in walletItems) {
+              final descriptor = walletItem.descriptor as String?;
+              final walletId = walletItem.id;
+              Logger.log('IsolateController: registering walletId=$walletId descriptor=${descriptor != null && descriptor.isNotEmpty ? 'present' : 'missing'}');
+              if (descriptor != null && descriptor.isNotEmpty) {
+                await _florestaClient.loadDescriptor(descriptor);
+              } else {
+                Logger.log('IsolateController: skipping walletId=$walletId, descriptor is null or empty');
+              }
+            }
+            Logger.log('IsolateController: florestaRegisterDescriptors completed');
+            isolateToMainSendPort.send(Result.success(true));
+          } catch (e) {
+            Logger.error('IsolateController: florestaRegisterDescriptors failed: $e');
+            isolateToMainSendPort.send(Result.failure(ErrorCodes.withMessage(ErrorCodes.nodeUnknown, 'florestaRegisterDescriptors: $e')));
+          }
+          break;
+        case IsolateControllerCommand.florestaRescan:
+          if (_florestaClient == null) {
+            isolateToMainSendPort.send(Result.failure(ErrorCodes.withMessage(ErrorCodes.nodeUnknown, 'Floresta client not initialized')));
+            return;
+          }
+          try {
+            final startHeight = params.isNotEmpty ? params[0] as int? : null;
+            await _florestaClient.rescan(startHeight: startHeight);
+            isolateToMainSendPort.send(Result.success(true));
+          } catch (e) {
+            Logger.error('IsolateController: florestaRescan failed: $e');
+            isolateToMainSendPort.send(Result.failure(ErrorCodes.withMessage(ErrorCodes.nodeUnknown, 'florestaRescan: $e')));
+          }
           break;
       }
     } catch (e, stack) {

--- a/lib/providers/node_provider/isolate/isolate_enum.dart
+++ b/lib/providers/node_provider/isolate/isolate_enum.dart
@@ -9,6 +9,8 @@ enum IsolateControllerCommand {
   getRecommendedFees,
   getSocketConnectionStatus,
   getTransactionRecord,
+  florestaRegisterDescriptors,
+  florestaRescan,
 }
 
 enum IsolateStateMethod {

--- a/lib/providers/node_provider/isolate/isolate_initializer.dart
+++ b/lib/providers/node_provider/isolate/isolate_initializer.dart
@@ -18,9 +18,10 @@ import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/repository/realm/wallet_repository.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/floresta_rpc_client.dart';
 
 class IsolateInitializer {
-  static IsolateController entryInitialize(SendPort sendPort, ElectrumService electrumService) {
+  static IsolateController entryInitialize(SendPort sendPort, ElectrumService electrumService, {FlorestaRpcClient? florestaClient}) {
     // TODO: isSetPin, 핀 설정/해제할 때 isolate에서도 인지할 수 있는 로직 추가
     final realmManager = RealmManager();
     final addressRepository = AddressRepository(realmManager);
@@ -78,6 +79,7 @@ class IsolateInitializer {
       isolateStateManager,
       electrumService,
       transactionRecordService,
+      florestaClient: florestaClient,
     );
 
     // 소켓 연결 종료 시 상태 콜백

--- a/lib/providers/node_provider/isolate/isolate_manager.dart
+++ b/lib/providers/node_provider/isolate/isolate_manager.dart
@@ -11,6 +11,7 @@ import 'package:coconut_wallet/providers/node_provider/isolate/isolate_enum.dart
 import 'package:coconut_wallet/providers/node_provider/isolate/isolate_initializer.dart';
 import 'package:coconut_wallet/model/node/isolate_state_message.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/floresta_rpc_client.dart';
 import 'package:coconut_wallet/model/node/spawn_isolate_dto.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/recommended_fee.dart';
@@ -62,7 +63,7 @@ class IsolateManager {
     _isolateReady = Completer<void>();
   }
 
-  Future<void> initialize(String host, int port, bool ssl, NetworkType networkType) async {
+  Future<void> initialize(String host, int port, bool ssl, NetworkType networkType, {bool isFloresta = false, int rpcPort = 0}) async {
     // 이미 초기화 중인 경우 기존 작업 완료 대기
     if (_isInitializing) {
       Logger.log('IsolateManager: Already initializing, waiting for completion');
@@ -83,7 +84,15 @@ class IsolateManager {
       _createIsolateCompleter();
 
       final isolateToMainSendPort = _mainFromIsolateReceivePort!.sendPort;
-      final data = SpawnIsolateDto(isolateToMainSendPort, host, port, ssl, networkType);
+      final data = SpawnIsolateDto(
+        isolateToMainSendPort,
+        host,
+        port,
+        ssl,
+        networkType,
+        isFloresta: isFloresta,
+        rpcPort: rpcPort,
+      );
 
       _isolate = await Isolate.spawn<SpawnIsolateDto>(_isolateEntry, data);
       _setUpReceivePortListener();
@@ -267,16 +276,26 @@ class IsolateManager {
     final isolateFromMainReceivePort = ReceivePort('isolateFromMainReceivePort');
     final electrumService = ElectrumService();
 
+    FlorestaRpcClient? florestaClient;
+    if (data.isFloresta) {
+      florestaClient = FlorestaRpcClient(data.host, data.rpcPort, data.ssl);
+    }
+
     try {
       final isConnected = await electrumService.connect(data.host, data.port, ssl: data.ssl);
-
-      final isolateController = IsolateInitializer.entryInitialize(data.isolateToMainSendPort, electrumService);
 
       if (!isConnected) {
         Logger.error("Isolate: Failed to connect to Electrum server");
         data.isolateToMainSendPort.send([IsolateManagerCommand.initializationFailed]);
-        return; // throw 대신 return으로 변경
+        florestaClient?.close();
+        return;
       }
+
+      final isolateController = IsolateInitializer.entryInitialize(
+        data.isolateToMainSendPort,
+        electrumService,
+        florestaClient: florestaClient,
+      );
 
       // 모든 초기화 완료 후 메시지 전송
       data.isolateToMainSendPort.send([
@@ -300,6 +319,7 @@ class IsolateManager {
       );
     } catch (e) {
       Logger.error("Isolate: ERROR during initialization: $e");
+      florestaClient?.close();
       try {
         data.isolateToMainSendPort.send([IsolateManagerCommand.initializationFailed]);
       } catch (sendError) {
@@ -321,6 +341,8 @@ class IsolateManager {
       case IsolateControllerCommand.subscribeWallet:
       case IsolateControllerCommand.unsubscribeWallet:
       case IsolateControllerCommand.getTransactionRecord:
+      case IsolateControllerCommand.florestaRegisterDescriptors:
+      case IsolateControllerCommand.florestaRescan:
         return kIsolateResponseTimeout;
 
       // 간단한 작업: .onion인 경우 kIsolateSimpleResponseTimeoutForOnion, 그 외 kIsolateSimpleResponseTimeout
@@ -544,6 +566,14 @@ class IsolateManager {
       'IsolateManager: getTransactionRecord called (txHash: $txHash, timeout: ${timeout?.inSeconds ?? "default"}s)',
     );
     return _send(IsolateControllerCommand.getTransactionRecord, [walletItem, txHash], commandTimeoutOverride: timeout);
+  }
+
+  Future<Result<bool>> florestaRegisterDescriptors(List<WalletListItemBase> walletItems) async {
+    return _send(IsolateControllerCommand.florestaRegisterDescriptors, [walletItems]);
+  }
+
+  Future<Result<bool>> florestaRescan({int? startHeight}) async {
+    return _send(IsolateControllerCommand.florestaRescan, startHeight != null ? [startHeight] : []);
   }
 
   /// isolate 연결만 종료하는 메서드

--- a/lib/providers/node_provider/node_provider.dart
+++ b/lib/providers/node_provider/node_provider.dart
@@ -19,6 +19,7 @@ import 'package:coconut_wallet/providers/node_provider/isolate/isolate_manager.d
 import 'package:coconut_wallet/providers/connectivity_provider.dart';
 import 'package:coconut_wallet/services/analytics_service.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/floresta_rpc_client.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/recommended_fee.dart';
 import 'package:coconut_wallet/utils/result.dart';
@@ -224,49 +225,86 @@ class NodeProvider extends ChangeNotifier {
 
   void _subscribeInitialWallets() {
     _isFirstInitialization = false;
-    subscribeWallets().then((result) async {
-      if (result.isFailure) {
-        Logger.error('NodeProvider: 초기 지갑 구독 실패: ${result.error}');
-        _stateManager?.setNodeSyncStateToFailed();
-      } else {
-        _setConnectionError(false);
 
-        await Future.delayed(const Duration(seconds: 1));
-        await _startBlockUpdates();
-      }
+    // Floresta: 먼저 descriptor 등록 후 구독
+    _registerFlorestaDescriptorsIfNeeded().then((_) {
+      subscribeWallets().then((result) async {
+        if (result.isFailure) {
+          Logger.error('NodeProvider: 초기 지갑 구독 실패: ${result.error}');
+          _stateManager?.setNodeSyncStateToFailed();
+        } else {
+          _setConnectionError(false);
+
+          await Future.delayed(const Duration(seconds: 1));
+          await _startBlockUpdates();
+        }
+      });
     });
+  }
+
+  Future<void> _registerFlorestaDescriptorsIfNeeded() async {
+    if (!_electrumServer.isFloresta) {
+      Logger.log('NodeProvider: skip Floresta descriptor registration, server is not floresta ($_electrumServer)');
+      return;
+    }
+
+    final walletItems = _walletItemListNotifier.value;
+    if (walletItems.isEmpty) {
+      Logger.log('NodeProvider: skip Floresta descriptor registration, no wallets');
+      return;
+    }
+
+    Logger.log('NodeProvider: Registering Floresta descriptors for ${walletItems.length} wallets');
+    final registerResult = await _isolateManager.florestaRegisterDescriptors(walletItems);
+    if (registerResult.isFailure) {
+      Logger.error('NodeProvider: Floresta descriptor registration failed: ${registerResult.error}');
+      return;
+    }
+
+    Logger.log('NodeProvider: Triggering Floresta rescan');
+    final rescanResult = await _isolateManager.florestaRescan();
+    if (rescanResult.isFailure) {
+      Logger.error('NodeProvider: Floresta rescan failed: ${rescanResult.error}');
+    }
   }
 
   /// WalletItemList 변경 감지 및 처리
   void _onWalletItemListChanged() {
     if (_isFirstInitialization) {
-      // 최초 실행 시에는 _subscribeInitialWallets에서 처리
       return;
     }
 
     final currentWallets = _walletItemListNotifier.value;
     final registeredWallets = state.registeredWallets.keys.toList();
 
-    // 삭제된 지갑 찾기
     for (final walletId in registeredWallets) {
       if (!currentWallets.any((wallet) => wallet.id == walletId)) {
         _stateManager?.unregisterWalletUpdateState(walletId);
       }
     }
 
-    // 새로 추가된 지갑 찾기
     for (final wallet in currentWallets) {
       if (!registeredWallets.contains(wallet.id)) {
-        // 새로운 지갑 발견
-        subscribeWallet(wallet).then((result) {
-          if (result.isFailure) {
-            Logger.error('NodeProvider: [${wallet.name}] 지갑 구독 실패: ${result.error}');
-            _stateManager?.setNodeSyncStateToFailed();
-          } else {
-            _analyticsService?.logEvent(eventName: AnalyticsEventNames.walletAddSyncCompleted);
-          }
+        _registerFlorestaDescriptorsIfNeededSingle(wallet).then((_) {
+          subscribeWallet(wallet).then((result) {
+            if (result.isFailure) {
+              Logger.error('NodeProvider: [${wallet.name}] 지갑 구독 실패: ${result.error}');
+              _stateManager?.setNodeSyncStateToFailed();
+            } else {
+              _analyticsService?.logEvent(eventName: AnalyticsEventNames.walletAddSyncCompleted);
+            }
+          });
         });
       }
+    }
+  }
+
+  Future<void> _registerFlorestaDescriptorsIfNeededSingle(WalletListItemBase wallet) async {
+    if (!_electrumServer.isFloresta) return;
+    Logger.log('NodeProvider: Registering Floresta descriptor for new wallet ${wallet.id}');
+    final result = await _isolateManager.florestaRegisterDescriptors([wallet]);
+    if (result.isFailure) {
+      Logger.error('NodeProvider: Floresta descriptor registration failed for wallet ${wallet.id}: ${result.error}');
     }
   }
 
@@ -323,7 +361,7 @@ class NodeProvider extends ChangeNotifier {
     try {
       _createNewCompleter();
       _createStateManager();
-      await _isolateManager.initialize(host, port, ssl, _networkType);
+      await _isolateManager.initialize(host, port, ssl, _networkType, isFloresta: _electrumServer.isFloresta, rpcPort: _electrumServer.rpcPort);
 
       if (_initCompleter != null && !_initCompleter!.isCompleted) {
         _initCompleter!.complete();
@@ -476,6 +514,7 @@ class NodeProvider extends ChangeNotifier {
 
       if (walletLoadState == WalletLoadState.loadCompleted && walletItems.isNotEmpty) {
         Logger.log('NodeProvider: Wallet Loaded & Wallet Items is Not Empty, start subscribing');
+        await _registerFlorestaDescriptorsIfNeeded();
         final result = await subscribeWallets();
         notifyListeners();
 
@@ -558,6 +597,20 @@ class NodeProvider extends ChangeNotifier {
     try {
       await _establishSocketConnection(electrumService, electrumServer);
       await _verifyProtocolCommunication(electrumService);
+
+      if (electrumServer.isFloresta) {
+        final florestaClient = FlorestaRpcClient(
+          electrumServer.host,
+          electrumServer.rpcPort,
+          electrumServer.ssl,
+        );
+        final isFlorestaConnected = await florestaClient.checkConnection();
+        florestaClient.close();
+        if (!isFlorestaConnected) {
+          Logger.error('NodeProvider: Floresta RPC connection failed');
+          return Result.failure(ErrorCodes.networkError);
+        }
+      }
 
       Logger.log('NodeProvider: 서버 연결 테스트 성공 - ${electrumServer.host}:${electrumServer.port}');
       return Result.success(true);

--- a/lib/providers/preferences/electrum_server_provider.dart
+++ b/lib/providers/preferences/electrum_server_provider.dart
@@ -22,12 +22,14 @@ class ElectrumServerProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> setCustomElectrumServer(String host, int port, bool ssl) async {
+  Future<void> setCustomElectrumServer(String host, int port, bool ssl, {bool isFloresta = false, int rpcPort = 0}) async {
     _validateCustomElectrumServerParams(host, port, ssl);
     await _sharedPrefs.setString(SharedPrefKeys.kElectrumServerName, _customServerLabel);
     await _sharedPrefs.setString(SharedPrefKeys.kCustomElectrumHost, host);
     await _sharedPrefs.setInt(SharedPrefKeys.kCustomElectrumPort, port);
     await _sharedPrefs.setBool(SharedPrefKeys.kCustomElectrumIsSsl, ssl);
+    await _sharedPrefs.setBool(SharedPrefKeys.kCustomElectrumIsFloresta, isFloresta);
+    await _sharedPrefs.setInt(SharedPrefKeys.kCustomElectrumRpcPort, rpcPort);
     notifyListeners();
   }
 
@@ -48,6 +50,8 @@ class ElectrumServerProvider extends ChangeNotifier {
         _sharedPrefs.getString(SharedPrefKeys.kCustomElectrumHost),
         _sharedPrefs.getInt(SharedPrefKeys.kCustomElectrumPort),
         _sharedPrefs.getBool(SharedPrefKeys.kCustomElectrumIsSsl),
+        isFloresta: _sharedPrefs.getBool(SharedPrefKeys.kCustomElectrumIsFloresta),
+        rpcPort: _sharedPrefs.getInt(SharedPrefKeys.kCustomElectrumRpcPort),
       );
     }
 
@@ -58,8 +62,8 @@ class ElectrumServerProvider extends ChangeNotifier {
     return (await _sharedPrefs.getUserServers()) ?? [];
   }
 
-  Future<void> addUserServer(String host, int port, bool ssl) async {
-    await _sharedPrefs.addUserServer(ElectrumServer.custom(host, port, ssl));
+  Future<void> addUserServer(String host, int port, bool ssl, {bool isFloresta = false, int rpcPort = 0}) async {
+    await _sharedPrefs.addUserServer(ElectrumServer.custom(host, port, ssl, isFloresta: isFloresta, rpcPort: rpcPort));
     notifyListeners();
   }
 

--- a/lib/providers/view_model/settings/electrum_server_view_model.dart
+++ b/lib/providers/view_model/settings/electrum_server_view_model.dart
@@ -24,15 +24,19 @@ class ElectrumServerViewModel extends ChangeNotifier {
 
   NodeConnectionStatus _nodeConnectionStatus = NodeConnectionStatus.waiting;
   final Map<ElectrumServer, NodeConnectionStatus> _connectionStatusMap = {};
-  bool _isServerAddressFormatError = false; // 서버 주소 형식
-  bool _isPortOutOfRangeError = false; // 1 ~ 65535 포트 범위
-  bool _isDefaultServerMenuVisible = false; // 기본 서버 메뉴 visibility
+  bool _isServerAddressFormatError = false;
+  bool _isPortOutOfRangeError = false;
+  bool _isDefaultServerMenuVisible = false;
+  bool _isFloresta = false;
+  int _rpcPort = 0;
 
   NodeConnectionStatus get nodeConnectionStatus => _nodeConnectionStatus;
   Map<ElectrumServer, NodeConnectionStatus> get connectionStatusMap => _connectionStatusMap;
   bool get isServerAddressFormatError => _isServerAddressFormatError;
   bool get isPortOutOfRangeError => _isPortOutOfRangeError;
   bool get isDefaultServerMenuVisible => _isDefaultServerMenuVisible;
+  bool get isFloresta => _isFloresta;
+  int get rpcPort => _rpcPort;
 
   ElectrumServerViewModel(this._nodeProvider, this._electrumServerProvider) {
     // 현재 설정된 서버 정보 가져오기
@@ -112,6 +116,16 @@ class ElectrumServerViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  void setFloresta(bool value) {
+    _isFloresta = value;
+    notifyListeners();
+  }
+
+  void setRpcPort(int value) {
+    _rpcPort = value;
+    notifyListeners();
+  }
+
   void _setCurrentServer(ElectrumServer server) {
     _currentServer = server;
     notifyListeners();
@@ -183,17 +197,27 @@ class ElectrumServerViewModel extends ChangeNotifier {
 
     final result = await _nodeProvider.changeServer(newServer);
 
-    // 서버 연결 상태 상관없이 서버 정보 업데이트
     _setCurrentServer(newServer);
-    _electrumServerProvider.setCustomElectrumServer(newServer.host, newServer.port, newServer.ssl);
+    _electrumServerProvider.setCustomElectrumServer(
+      newServer.host,
+      newServer.port,
+      newServer.ssl,
+      isFloresta: newServer.isFloresta,
+      rpcPort: newServer.rpcPort,
+    );
 
-    // 연결된 서버가 default 서버에도 없고, 사용자 서버에도 없으면 사용자 서버 추가
     if (!_isDefaultServer(newServer) && !_isUserServer(newServer)) {
-      await _electrumServerProvider.addUserServer(newServer.host, newServer.port, newServer.ssl);
+      await _electrumServerProvider.addUserServer(
+        newServer.host,
+        newServer.port,
+        newServer.ssl,
+        isFloresta: newServer.isFloresta,
+        rpcPort: newServer.rpcPort,
+      );
       await _loadUserServers();
     }
 
-    debugPrint('서버 정보 업데이트: ${newServer.host} ${newServer.port} ${newServer.ssl}');
+    debugPrint('서버 정보 업데이트: ${newServer.host} ${newServer.port} ${newServer.ssl} isFloresta=${newServer.isFloresta}');
 
     if (result.isFailure) {
       setNodeConnectionStatus(NodeConnectionStatus.failed);

--- a/lib/repository/shared_preference/shared_prefs_repository.dart
+++ b/lib/repository/shared_preference/shared_prefs_repository.dart
@@ -170,11 +170,14 @@ class SharedPrefsRepository {
         final serverData = jsonDecode(serverJson) as Map<String, dynamic>;
         final servers = <ElectrumServer>[];
         for (final server in serverData.entries) {
+          final value = server.value as Map<String, dynamic>;
           servers.add(
             ElectrumServer.custom(
-              server.value['host'] as String,
-              server.value['port'] as int,
-              server.value['ssl'] as bool,
+              value['host'] as String,
+              value['port'] as int,
+              value['ssl'] as bool,
+              isFloresta: value['isFloresta'] as bool? ?? false,
+              rpcPort: value['rpcPort'] as int? ?? 0,
             ),
           );
         }
@@ -212,7 +215,13 @@ class SharedPrefsRepository {
 
     for (final server in servers) {
       final key = '${server.host}:${server.port}';
-      serversMap[key] = {'host': server.host, 'port': server.port, 'ssl': server.ssl};
+      serversMap[key] = {
+        'host': server.host,
+        'port': server.port,
+        'ssl': server.ssl,
+        'isFloresta': server.isFloresta,
+        'rpcPort': server.rpcPort,
+      };
     }
 
     await prefs.setString(SharedPrefKeys.kUserServers, jsonEncode(serversMap));

--- a/lib/screens/settings/electrum_server_screen.dart
+++ b/lib/screens/settings/electrum_server_screen.dart
@@ -27,12 +27,15 @@ class ElectrumServerScreen extends StatefulWidget {
 class _ElectrumServerScreen extends State<ElectrumServerScreen> {
   final TextEditingController _serverAddressController = TextEditingController();
   final TextEditingController _portController = TextEditingController();
+  final TextEditingController _rpcPortController = TextEditingController();
   bool _currentSslState = false;
+  bool _currentFlorestaState = false;
   ServerTab _selectedTab = ServerTab.defaultServer;
 
   final ScrollController _defaultServerScrollController = ScrollController();
   FocusNode serverAddressFocusNode = FocusNode();
   FocusNode portFocusNode = FocusNode();
+  FocusNode rpcPortFocusNode = FocusNode();
 
   final GlobalKey _defaultServerButtonKey = GlobalKey();
   final GlobalKey _serverAddressFieldKey = GlobalKey();
@@ -52,12 +55,14 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
       }
     };
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      setState(() {
-        _serverAddressController.text = _viewModel.initialServer.host;
-        _portController.text = _viewModel.initialServer.port.toString();
-        _currentSslState = _viewModel.initialServer.ssl;
-      });
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        setState(() {
+          _serverAddressController.text = _viewModel.initialServer.host;
+          _portController.text = _viewModel.initialServer.port.toString();
+          _currentSslState = _viewModel.initialServer.ssl;
+          _currentFlorestaState = _viewModel.initialServer.isFloresta;
+          _rpcPortController.text = _viewModel.initialServer.rpcPort > 0 ? _viewModel.initialServer.rpcPort.toString() : _viewModel.initialServer.port.toString();
+        });
 
       serverAddressFocusNode.addListener(() {
         if (serverAddressFocusNode.hasFocus) {
@@ -71,8 +76,10 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
   void dispose() {
     _serverAddressController.dispose();
     _portController.dispose();
+    _rpcPortController.dispose();
     serverAddressFocusNode.dispose();
     portFocusNode.dispose();
+    rpcPortFocusNode.dispose();
     super.dispose();
   }
 
@@ -93,10 +100,13 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
   }
 
   void _onSave() async {
+    final rpcPort = int.tryParse(_rpcPortController.text) ?? int.parse(_portController.text);
     final newServer = ElectrumServer.custom(
       _serverAddressController.text,
       int.parse(_portController.text),
       _currentSslState,
+      isFloresta: _currentFlorestaState,
+      rpcPort: rpcPort,
     );
 
     final success = await _viewModel.changeServerAndUpdateState(newServer);
@@ -113,13 +123,14 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
   void _onReset() async {
     final initialServer = _viewModel.initialServer;
 
-    _onServerInputChanged(); // 상태 변경 감지
+    _onServerInputChanged();
 
     setState(() {
-      // 화면 진입 시의 초기 서버 정보로 초기화
       _serverAddressController.text = initialServer.host;
       _portController.text = initialServer.port.toString();
       _currentSslState = initialServer.ssl;
+      _currentFlorestaState = initialServer.isFloresta;
+      _rpcPortController.text = initialServer.rpcPort > 0 ? initialServer.rpcPort.toString() : initialServer.port.toString();
     });
 
     final success = await _viewModel.changeServerAndUpdateState(initialServer);
@@ -141,10 +152,12 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
   /// 초기화 버튼 활성화 조건: 현재 입력된 서버 정보가 초기 서버 정보와 다른지 확인
   bool _isDifferentFromInitialServer() {
     return _viewModel.isDifferentFromInitialServer(
-      _serverAddressController.text,
-      _portController.text,
-      _currentSslState,
-    );
+          _serverAddressController.text,
+          _portController.text,
+          _currentSslState,
+        ) ||
+        _currentFlorestaState != _viewModel.initialServer.isFloresta ||
+        _rpcPortController.text != (_viewModel.initialServer.rpcPort > 0 ? _viewModel.initialServer.rpcPort.toString() : _viewModel.initialServer.port.toString());
   }
 
   /// 저장 버튼 활성화 조건: 현재 입력된 서버 정보가 현재 연결된 서버와 다른지 확인
@@ -155,7 +168,9 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
         !_viewModel.isValidPort(_portController.text))
       return false;
 
-    return !_viewModel.isSameWithCurrentServer(_serverAddressController.text, _portController.text, _currentSslState);
+    return !_viewModel.isSameWithCurrentServer(_serverAddressController.text, _portController.text, _currentSslState) ||
+        _currentFlorestaState != (_viewModel.currentServer?.isFloresta ?? false) ||
+        _rpcPortController.text != ((_viewModel.currentServer?.rpcPort ?? 0) > 0 ? (_viewModel.currentServer?.rpcPort.toString() ?? '') : (_viewModel.currentServer?.port.toString() ?? ''));
   }
 
   @override
@@ -210,11 +225,13 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
                               return isDefaultServerMenuVisible
                                   ? Container()
                                   : Column(
-                                    children: [
-                                      _buildPortTextField(),
-                                      _buildSslToggle(),
-                                      _buildAlertBox(nodeConnectionStatus),
-                                    ],
+                    children: [
+                      _buildPortTextField(),
+                      _buildSslToggle(),
+                      _buildFlorestaToggle(),
+                      if (_currentFlorestaState) _buildRpcPortTextField(),
+                      _buildAlertBox(nodeConnectionStatus),
+                    ],
                                   );
                             },
                           ),
@@ -347,6 +364,8 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
                   _portController.text = serverList[i].port.toString();
                   setState(() {
                     _currentSslState = serverList[i].ssl;
+                    _currentFlorestaState = serverList[i].isFloresta;
+                    _rpcPortController.text = serverList[i].rpcPort > 0 ? serverList[i].rpcPort.toString() : serverList[i].port.toString();
                   });
                   _onServerInputChanged();
                   _unFocus();
@@ -657,6 +676,112 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildFlorestaToggle() {
+    return Padding(
+      padding: const EdgeInsets.only(top: 36),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            'Floresta Server',
+            style: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
+          ),
+          Selector<ElectrumServerViewModel, NodeConnectionStatus>(
+            selector: (_, viewModel) => viewModel.nodeConnectionStatus,
+            builder: (context, nodeConnectionStatus, child) {
+              final isNodeConnecting = nodeConnectionStatus == NodeConnectionStatus.connecting;
+              return IgnorePointer(
+                ignoring: isNodeConnecting,
+                child: CoconutSwitch(
+                  isOn: _currentFlorestaState,
+                  onChanged: (value) {
+                    if (_currentFlorestaState != value) {
+                      vibrateLight();
+                      setState(() {
+                        _currentFlorestaState = value;
+                      });
+                      _onServerInputChanged();
+                    }
+                  },
+                  activeColor: isNodeConnecting ? CoconutColors.gray500 : null,
+                  trackColor: isNodeConnecting ? CoconutColors.gray750 : null,
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRpcPortTextField() {
+    return Selector<ElectrumServerViewModel, NodeConnectionStatus>(
+      selector: (_, viewModel) => viewModel.nodeConnectionStatus,
+      builder: (context, nodeConnectionStatus, child) {
+        return Padding(
+          padding: const EdgeInsets.only(top: 20),
+          child: Column(
+            children: [
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text('RPC Port',
+                  style: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
+                ),
+              ),
+              CoconutLayout.spacing_100h,
+              nodeConnectionStatus == NodeConnectionStatus.connecting
+                  ? Container(
+                    width: MediaQuery.sizeOf(context).width,
+                    height: 54,
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    margin: const EdgeInsets.only(bottom: 4),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: CoconutColors.gray600),
+                      borderRadius: BorderRadius.circular(12),
+                      color: Colors.transparent,
+                    ),
+                    child: Row(
+                      children: [
+                        Text(_rpcPortController.text, style: CoconutTypography.body2_14.setColor(CoconutColors.gray600)),
+                      ],
+                    ),
+                  )
+                  : CoconutTextField(
+                    controller: _rpcPortController,
+                    focusNode: rpcPortFocusNode,
+                    textInputAction: TextInputAction.done,
+                    onEditingComplete: _unFocus,
+                    height: 54,
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    textInputFormatter: [FilteringTextInputFormatter.digitsOnly],
+                    textInputType: TextInputType.number,
+                    suffix:
+                        _rpcPortController.text.isNotEmpty
+                            ? IconButton(
+                              iconSize: 14,
+                              padding: EdgeInsets.zero,
+                              onPressed: () {
+                                setState(() {
+                                  _rpcPortController.text = '';
+                                });
+                              },
+                              icon: SvgPicture.asset(
+                                'assets/svg/text-field-clear.svg',
+                                colorFilter: const ColorFilter.mode(CoconutColors.white, BlendMode.srcIn),
+                              ),
+                            )
+                            : null,
+                    onChanged: (text) {
+                      _onServerInputChanged();
+                    },
+                  ),
+            ],
+          ),
+        );
+      },
     );
   }
 

--- a/lib/services/floresta_rpc_client.dart
+++ b/lib/services/floresta_rpc_client.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:coconut_wallet/utils/logger.dart';
+
+class FlorestaRpcClient {
+  final String _host;
+  final int _port;
+  final bool _ssl;
+  late final http.Client _client;
+
+  String get _baseUrl {
+    final scheme = _ssl ? 'https' : 'http';
+    return '$scheme://$_host:$_port';
+  }
+
+  FlorestaRpcClient(this._host, this._port, this._ssl) {
+    _client = http.Client();
+  }
+
+  Future<Map<String, dynamic>> _call(
+    String method,
+    List<dynamic> params, {
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    final requestBody = {
+      'jsonrpc': '2.0',
+      'id': DateTime.now().microsecondsSinceEpoch,
+      'method': method,
+      'params': params,
+    };
+
+    try {
+      final response = await _client
+          .post(
+            Uri.parse(_baseUrl),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode(requestBody),
+          )
+          .timeout(timeout);
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        if (data.containsKey('error') && data['error'] != null) {
+          throw FlorestaRpcException('$method failed: ${data['error']}');
+        }
+        return data;
+      } else {
+        throw FlorestaRpcException('HTTP ${response.statusCode}: ${response.body}');
+      }
+    } catch (e) {
+      if (e is FlorestaRpcException) rethrow;
+      Logger.error('FlorestaRpcClient: $_baseUrl $method failed: $e');
+      throw FlorestaRpcException('$method: $e');
+    }
+  }
+
+  Future<void> loadDescriptor(String descriptor) async {
+    final checksum = descriptor.contains('#') ? descriptor.split('#').last : 'none';
+    Logger.log('FlorestaRpcClient: calling loaddescriptor on $_baseUrl');
+    Logger.log('FlorestaRpcClient: descriptor length=${descriptor.length}, checksum=$checksum');
+    await _call('loaddescriptor', [descriptor]);
+    Logger.log('FlorestaRpcClient: loaddescriptor registered successfully');
+  }
+
+  Future<List<Map<String, dynamic>>> listDescriptors() async {
+    final result = await _call('listdescriptors', []);
+    final descriptors = result['result'] as List<dynamic>? ?? [];
+    return descriptors.cast<Map<String, dynamic>>();
+  }
+
+  Future<void> rescan({int? startHeight}) async {
+    final params = <dynamic>[];
+    if (startHeight != null) {
+      params.add(startHeight);
+    }
+    await _call('rescan', params);
+    Logger.log('FlorestaRpcClient: rescan triggered');
+  }
+
+  Future<bool> checkConnection({Duration timeout = const Duration(seconds: 5)}) async {
+    try {
+      await _call('listdescriptors', [], timeout: timeout);
+      Logger.log('FlorestaRpcClient: RPC connection ok on $_baseUrl');
+      return true;
+    } catch (e) {
+      Logger.error('FlorestaRpcClient: RPC connection failed on $_baseUrl: $e');
+      return false;
+    }
+  }
+
+  void close() {
+    _client.close();
+  }
+}
+
+class FlorestaRpcException implements Exception {
+  final String message;
+  FlorestaRpcException(this.message);
+
+  @override
+  String toString() => 'FlorestaRpcException: $message';
+}


### PR DESCRIPTION
feat: add Floresta client support

## Summary
Add support for connecting to an external Floresta node via Electrum protocol and JSON-RPC. This allows coconut_wallet to use Floresta as a backend in regtest mode.

## What's included
- Floresta-compatible Electrum server connection
- Runtime descriptor registration via Floresta JSON-RPC (`loaddescriptor`)
- Blockchain rescan trigger via Floresta JSON-RPC (`rescan`)
- RPC connection status check

## Tested environment
- bitcoind v30.2
- utreexod v0.52.0
- floresta v0.9.1

## Tested features
- [x] TX pulling / balance sync
- [ ] TX broadcast (not yet implemented in this PR)

## Notes
- RBF/transaction builder tests pass
- Some pre-existing/flaky tests in `socket_manager_test` and electrum e2e tests may fail depending on environment
- No new unit tests added for Floresta RPC client yet
- 🚨 Warning: Floresta RPC currently has no authentication. Use only on a VPN or private network. 🚨

## References
- https://docs.getfloresta.sh/floresta_rpc/rpc/trait.FlorestaRPC.html
- https://github.com/getfloresta/Floresta
- https://github.com/utreexo/utreexod

## Future work
Built-in Floresta node support is tracked in #<epic_issue_number>.