### PR TITLE
[702] 거래 메모 이모지 입력 불가 오류

### DIFF
--- a/lib/screens/common/single_text_field_bottom_sheet.dart
+++ b/lib/screens/common/single_text_field_bottom_sheet.dart
@@ -2,6 +2,7 @@ import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/widgets/bottom_sheet/single_field_fixed_bottom_sheet_body.dart';
 import 'package:coconut_wallet/widgets/overlays/common_bottom_sheets.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -269,6 +270,8 @@ class _SingleTextFieldBottomSheetState extends State<SingleTextFieldBottomSheet>
   Widget build(BuildContext context) {
     final formatters = widget.textInputFormatters ?? _buildFormatters();
 
+    final bool isAndroid = defaultTargetPlatform == TargetPlatform.android;
+
     final clearIcon = IconButton(
       iconSize: 14,
       padding: EdgeInsets.zero,
@@ -299,7 +302,7 @@ class _SingleTextFieldBottomSheetState extends State<SingleTextFieldBottomSheet>
       isLengthVisible: widget.visibleTextLimit,
       maxLength: widget.maxLength ?? 30,
       maxLines: 1,
-      enableSuggestions: true,
+      enableSuggestions: isAndroid, // Required for Android emoji input
       backgroundColor: widget.fieldBackgroundColor,
       errorColor: widget.errorColor,
       placeholderColor: widget.placeholderColor,

--- a/lib/screens/common/single_text_field_bottom_sheet.dart
+++ b/lib/screens/common/single_text_field_bottom_sheet.dart
@@ -299,6 +299,8 @@ class _SingleTextFieldBottomSheetState extends State<SingleTextFieldBottomSheet>
       isLengthVisible: widget.visibleTextLimit,
       maxLength: widget.maxLength ?? 30,
       maxLines: 1,
+      autocorrect: true,
+      enableSuggestions: true,
       backgroundColor: widget.fieldBackgroundColor,
       errorColor: widget.errorColor,
       placeholderColor: widget.placeholderColor,

--- a/lib/screens/common/single_text_field_bottom_sheet.dart
+++ b/lib/screens/common/single_text_field_bottom_sheet.dart
@@ -299,7 +299,6 @@ class _SingleTextFieldBottomSheetState extends State<SingleTextFieldBottomSheet>
       isLengthVisible: widget.visibleTextLimit,
       maxLength: widget.maxLength ?? 30,
       maxLines: 1,
-      autocorrect: true,
       enableSuggestions: true,
       backgroundColor: widget.fieldBackgroundColor,
       errorColor: widget.errorColor,


### PR DESCRIPTION
#702 

## 오류 발생 원인
기존 CupertinoTextField에서 CoconutTextField로 바꾸는 리팩토링 과정에서
CupertinoTextField는 enableSuggestions 변수의 기본값이 true지만
CoconutTextField는 false로 설정되어 있어
리팩토링 이후 이모지 입력 불가하게 변경됨

## 변경 사항
single_text_field_bottom_sheet.dart에서 enableSuggestions 변수를 true로 설정