### PR TITLE
[705] WalletItemCard 리팩토링

### DIFF
--- a/lib/screens/home/wallet_home_screen.dart
+++ b/lib/screens/home/wallet_home_screen.dart
@@ -1017,6 +1017,15 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
           currentUnit: currentUnit,
           iconGradientColors: signers != null ? ColorUtil.getGradientColors(signers) : taprootStyle?.iconGradientColors,
           entryPoint: kEntryPointWalletHome,
+          onPressed: () {
+            Navigator.pushNamed(context, '/wallet-detail', arguments: {'id': id, 'entryPoint': kEntryPointWalletHome});
+          },
+          rightWidget: SvgPicture.asset(
+            'assets/svg/arrow-right.svg',
+            width: 6,
+            height: 10,
+            colorFilter: const ColorFilter.mode(CoconutColors.gray400, BlendMode.srcIn),
+          ),
         );
       },
     );

--- a/lib/screens/home/wallet_home_screen.dart
+++ b/lib/screens/home/wallet_home_screen.dart
@@ -995,7 +995,6 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
           isBalanceHidden: isBalanceHidden,
           fakeBalance: fakeBalance,
           currentUnit: currentUnit,
-          entryPoint: kEntryPointWalletHome,
           onPressed: () {
             Navigator.pushNamed(
               context,

--- a/lib/screens/home/wallet_home_screen.dart
+++ b/lib/screens/home/wallet_home_screen.dart
@@ -39,10 +39,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
-import 'package:coconut_wallet/model/wallet/multisig_signer.dart';
-import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
-import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_home_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/screens/settings/settings_screen.dart';
@@ -985,19 +982,6 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
     int? fakeBalance,
     bool isLastItem,
   ) {
-    final WalletListItemBase(
-      id: id,
-      name: name,
-      iconIndex: iconIndex,
-      colorIndex: colorIndex,
-      walletImportSource: walletImportSource,
-    ) = walletItem;
-    List<MultisigSigner>? signers;
-    if (walletItem.walletType == WalletType.multiSignature) {
-      signers = (walletItem as MultisigWalletListItem).signers;
-    }
-    final taprootStyle = TaprootCardStyle.from(walletItem);
-
     return Selector2<PreferenceProvider, WalletHomeViewModel, Tuple2<BitcoinUnit, bool>>(
       selector: (_, preferenceProvider, viewModel) => Tuple2(preferenceProvider.currentUnit, viewModel.isBalanceHidden),
       builder: (context, data, child) {
@@ -1005,20 +989,19 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> with TickerProvider
         final isBalanceHidden = data.item2;
         return WalletItemCard(
           key: key,
-          id: id,
-          name: name,
+          walletItem: walletItem,
           animatedBalanceData: animatedBalanceData,
-          iconIndex: iconIndex,
-          colorIndex: colorIndex,
           isLastItem: isLastItem,
           isBalanceHidden: isBalanceHidden,
           fakeBalance: fakeBalance,
-          walletImportSource: walletImportSource,
           currentUnit: currentUnit,
-          iconGradientColors: signers != null ? ColorUtil.getGradientColors(signers) : taprootStyle?.iconGradientColors,
           entryPoint: kEntryPointWalletHome,
           onPressed: () {
-            Navigator.pushNamed(context, '/wallet-detail', arguments: {'id': id, 'entryPoint': kEntryPointWalletHome});
+            Navigator.pushNamed(
+              context,
+              '/wallet-detail',
+              arguments: {'id': walletItem.id, 'entryPoint': kEntryPointWalletHome},
+            );
           },
           rightWidget: SvgPicture.asset(
             'assets/svg/arrow-right.svg',

--- a/lib/screens/home/wallet_list_screen.dart
+++ b/lib/screens/home/wallet_list_screen.dart
@@ -625,6 +625,9 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
           onTapStar: (pair) {
             // pair: (bool isFavorite, int walletId)
             vibrateExtraLight();
+            if (isEditMode) {
+              return;
+            }
             _viewModel.toggleTempFavorite(pair.$2);
           },
           index: index,
@@ -638,6 +641,15 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
               child: WalletItemSettingBottomSheet(id: id),
             );
           },
+          onPressed: () {
+            Navigator.pushNamed(context, '/wallet-detail', arguments: {'id': id, 'entryPoint': kEntryPointWalletList});
+          },
+          rightWidget: SvgPicture.asset(
+            'assets/svg/arrow-right.svg',
+            width: 6,
+            height: 10,
+            colorFilter: const ColorFilter.mode(CoconutColors.gray400, BlendMode.srcIn),
+          ),
         );
       },
     );

--- a/lib/screens/home/wallet_list_screen.dart
+++ b/lib/screens/home/wallet_list_screen.dart
@@ -25,11 +25,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:provider/provider.dart';
-import 'package:coconut_wallet/enums/wallet_enums.dart';
-import 'package:coconut_wallet/model/wallet/multisig_signer.dart';
-import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
-import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/providers/view_model/home/wallet_list_view_model.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
 import 'package:coconut_wallet/widgets/card/wallet_item_card.dart';
@@ -225,7 +221,6 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
   Widget _buildEditModeHeader() {
     SvgPicture starIcon = SvgPicture.asset('assets/svg/star-small.svg', width: 16, height: 16);
     SvgPicture hamburgerIcon = SvgPicture.asset('assets/svg/hamburger.svg', width: 16, height: 16);
-    SvgPicture deleteIcon = SvgPicture.asset('assets/svg/delete.svg', width: 16, height: 16);
     return Container(
       width: MediaQuery.sizeOf(context).width,
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -586,44 +581,26 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
     bool isFavorite, {
     int? index,
   }) {
-    final WalletListItemBase(
-      id: id,
-      name: name,
-      iconIndex: iconIndex,
-      colorIndex: colorIndex,
-      walletImportSource: walletImportSource,
-    ) = walletItem;
-    List<MultisigSigner>? signers;
-    if (walletItem.walletType == WalletType.multiSignature) {
-      signers = (walletItem as MultisigWalletListItem).signers;
-    }
-    final taprootStyle = TaprootCardStyle.from(walletItem);
     return Selector<PreferenceProvider, Tuple2<BitcoinUnit, List<int>>>(
       selector: (_, viewModel) => Tuple2(viewModel.currentUnit, viewModel.excludedFromTotalBalanceWalletIds),
       builder: (context, data, child) {
         final currentUnit = data.item1;
-        bool isExludedFromTotalBalance = data.item2.contains(id);
+        bool isExludedFromTotalBalance = data.item2.contains(walletItem.id);
 
         return WalletItemCard(
           key: key,
-          id: id,
-          name: name,
+          walletItem: walletItem,
           animatedBalanceData: animatedBalanceData,
-          iconIndex: iconIndex,
-          colorIndex: colorIndex,
           isLastItem: isLastItem,
           isBalanceHidden: false,
-          walletImportSource: walletImportSource,
           currentUnit: currentUnit,
           backgroundColor: CoconutColors.black,
-          iconGradientColors: signers != null ? ColorUtil.getGradientColors(signers) : taprootStyle?.iconGradientColors,
           isPrimaryWallet: isFirstItem,
           isExcludeFromTotalBalance: isExludedFromTotalBalance,
           isEditMode: isEditMode,
           isFavorite: isFavorite,
-          isStarVisible: isFavorite || _viewModel.tempFavoriteWalletIds.length < kMaxStarLenght, // 즐겨찾기 제한 만큼 설정
+          isStarVisible: isFavorite || _viewModel.tempFavoriteWalletIds.length < kMaxStarLenght,
           onTapStar: (pair) {
-            // pair: (bool isFavorite, int walletId)
             vibrateExtraLight();
             if (isEditMode) {
               return;
@@ -638,11 +615,15 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
               title: '',
               titlePadding: EdgeInsets.zero,
               context: context,
-              child: WalletItemSettingBottomSheet(id: id),
+              child: WalletItemSettingBottomSheet(id: walletItem.id),
             );
           },
           onPressed: () {
-            Navigator.pushNamed(context, '/wallet-detail', arguments: {'id': id, 'entryPoint': kEntryPointWalletList});
+            Navigator.pushNamed(
+              context,
+              '/wallet-detail',
+              arguments: {'id': walletItem.id, 'entryPoint': kEntryPointWalletList},
+            );
           },
           rightWidget: SvgPicture.asset(
             'assets/svg/arrow-right.svg',

--- a/lib/screens/home/wallet_list_screen.dart
+++ b/lib/screens/home/wallet_list_screen.dart
@@ -585,7 +585,7 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
       selector: (_, viewModel) => Tuple2(viewModel.currentUnit, viewModel.excludedFromTotalBalanceWalletIds),
       builder: (context, data, child) {
         final currentUnit = data.item1;
-        bool isExludedFromTotalBalance = data.item2.contains(walletItem.id);
+        bool isExcludedFromTotalBalance = data.item2.contains(walletItem.id);
 
         return WalletItemCard(
           key: key,
@@ -596,19 +596,15 @@ class _WalletListScreenState extends State<WalletListScreen> with TickerProvider
           currentUnit: currentUnit,
           backgroundColor: CoconutColors.black,
           isPrimaryWallet: isFirstItem,
-          isExcludeFromTotalBalance: isExludedFromTotalBalance,
+          isExcludeFromTotalBalance: isExcludedFromTotalBalance,
           isEditMode: isEditMode,
           isFavorite: isFavorite,
           isStarVisible: isFavorite || _viewModel.tempFavoriteWalletIds.length < kMaxStarLenght,
           onTapStar: (pair) {
             vibrateExtraLight();
-            if (isEditMode) {
-              return;
-            }
             _viewModel.toggleTempFavorite(pair.$2);
           },
           index: index,
-          entryPoint: kEntryPointWalletList,
           onLongPressed: () {
             vibrateExtraLight();
             CommonBottomSheets.showBottomSheet(

--- a/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
+++ b/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
@@ -1,18 +1,13 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
-import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/balance.dart';
-import 'package:coconut_wallet/model/wallet/multisig_signer.dart';
-import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
 import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
 import 'package:coconut_wallet/providers/preferences/preference_provider.dart';
 import 'package:coconut_wallet/providers/wallet_provider.dart';
-import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/utils/wallet_util.dart';
-import 'package:coconut_wallet/widgets/button/shrink_animation_button.dart';
-import 'package:coconut_wallet/widgets/icon/wallet_icon_small.dart';
+import 'package:coconut_wallet/widgets/card/wallet_item_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
@@ -46,56 +41,6 @@ int _getUnspentUtxoSum(List<UtxoState> utxos) {
     }
     return accu;
   });
-}
-
-Widget _buildWalletRow({
-  required WalletListItemBase walletBase,
-  required BitcoinUnit currentUnit,
-  required int? balance,
-  required bool showCheckIcon,
-  required bool isChecked,
-}) {
-  String amountText = currentUnit.displayBitcoinAmount(balance ?? 0, withUnit: true);
-  List<MultisigSigner>? signer;
-  if (walletBase.walletType == WalletType.multiSignature) {
-    signer = (walletBase as MultisigWalletListItem).signers;
-  }
-  return Row(
-    children: [
-      Expanded(
-        child: Row(
-          children: [
-            SizedBox(
-              width: Sizes.size32,
-              height: Sizes.size32,
-              child: WalletIconSmall(
-                walletImportSource: walletBase.walletImportSource,
-                iconIndex: walletBase.iconIndex,
-                colorIndex: walletBase.colorIndex,
-                gradientColors: signer != null ? ColorUtil.getGradientColors(signer) : null,
-              ),
-            ),
-            CoconutLayout.spacing_300w,
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(amountText, style: CoconutTypography.body2_14_Number),
-                  Text(
-                    walletBase.name,
-                    style: CoconutTypography.body3_12.setColor(CoconutColors.gray400),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-      if (showCheckIcon && isChecked) ...{SvgPicture.asset('assets/svg/check.svg')},
-    ],
-  );
 }
 
 class SelectWalletBottomSheet extends StatefulWidget {
@@ -145,23 +90,22 @@ class _SelectWalletBottomSheetState extends State<SelectWalletBottomSheet> {
                 child: Column(
                   children: List.generate(_walletList.length, (index) {
                     int walletId = _walletList[index].id;
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: Sizes.size24, left: 14, right: 22),
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.translucent,
-                        onTap: () {
-                          _selectedWalletId = walletId;
-                          setState(() {});
-                        },
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: Sizes.size8),
-                          child: _buildWalletItem(
-                            _walletList[index],
-                            _walletBalanceMap[walletId],
-                            _selectedWalletId == walletId,
-                          ),
-                        ),
+                    bool isChecked = _selectedWalletId == walletId;
+                    return WalletItemCard(
+                      id: walletId,
+                      name: _walletList[index].name,
+                      animatedBalanceData: AnimatedBalanceData(
+                        _walletBalanceMap[walletId] ?? 0,
+                        _walletBalanceMap[walletId] ?? 0,
                       ),
+                      iconIndex: _walletList[index].iconIndex,
+                      colorIndex: _walletList[index].colorIndex,
+                      isLastItem: index == _walletList.length - 1,
+                      currentUnit: widget.currentUnit,
+                      entryPoint: '',
+                      backgroundColor: CoconutColors.black,
+                      rightWidget: isChecked ? SvgPicture.asset('assets/svg/check.svg') : Container(),
+                      onPressed: () => setState(() => _selectedWalletId = walletId),
                     );
                   }),
                 ),
@@ -216,16 +160,6 @@ class _SelectWalletBottomSheetState extends State<SelectWalletBottomSheet> {
       case BalanceMode.onlyUnspent:
         return _buildBalanceMapOnlyUnspent(context, _walletList);
     }
-  }
-
-  Widget _buildWalletItem(WalletListItemBase walletBase, int? balance, bool isChecked) {
-    return _buildWalletRow(
-      walletBase: walletBase,
-      currentUnit: widget.currentUnit,
-      balance: balance,
-      showCheckIcon: true,
-      isChecked: isChecked,
-    );
   }
 }
 
@@ -301,17 +235,26 @@ class _P2PSelectWalletBottomSheetState extends State<P2PSelectWalletBottomSheet>
                 child: Column(
                   children: List.generate(_walletList.length, (index) {
                     int walletId = _walletList[index].id;
-                    return ShrinkAnimationButton(
-                      defaultColor: CoconutColors.black,
-                      pressedColor: CoconutColors.gray850,
-                      borderRadius: 12,
-                      onPressed: () {
-                        widget.onWalletSelected(walletId);
-                      },
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(vertical: Sizes.size12, horizontal: 22),
-                        child: _buildWalletItem(_walletList[index], _walletBalanceMap[walletId]),
+                    return WalletItemCard(
+                      id: walletId,
+                      name: _walletList[index].name,
+                      animatedBalanceData: AnimatedBalanceData(
+                        _walletBalanceMap[walletId] ?? 0,
+                        _walletBalanceMap[walletId] ?? 0,
                       ),
+                      iconIndex: _walletList[index].iconIndex,
+                      colorIndex: _walletList[index].colorIndex,
+                      isLastItem: index == _walletList.length - 1,
+                      currentUnit: widget.currentUnit,
+                      entryPoint: '',
+                      backgroundColor: CoconutColors.black,
+                      rightWidget: SvgPicture.asset(
+                        'assets/svg/arrow-right.svg',
+                        width: 6,
+                        height: 10,
+                        colorFilter: const ColorFilter.mode(CoconutColors.gray400, BlendMode.srcIn),
+                      ),
+                      onPressed: () => widget.onWalletSelected(walletId),
                     );
                   }),
                 ),
@@ -321,16 +264,6 @@ class _P2PSelectWalletBottomSheetState extends State<P2PSelectWalletBottomSheet>
           ],
         ),
       ),
-    );
-  }
-
-  Widget _buildWalletItem(WalletListItemBase walletBase, int? balance) {
-    return _buildWalletRow(
-      walletBase: walletBase,
-      currentUnit: widget.currentUnit,
-      balance: balance,
-      showCheckIcon: false,
-      isChecked: false,
     );
   }
 }

--- a/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
+++ b/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
@@ -90,16 +90,14 @@ class _SelectWalletBottomSheetState extends State<SelectWalletBottomSheet> {
                 child: Column(
                   children: List.generate(_walletList.length, (index) {
                     int walletId = _walletList[index].id;
+                    final wallet = _walletList[index];
                     bool isChecked = _selectedWalletId == walletId;
                     return WalletItemCard(
-                      id: walletId,
-                      name: _walletList[index].name,
+                      walletItem: wallet,
                       animatedBalanceData: AnimatedBalanceData(
                         _walletBalanceMap[walletId] ?? 0,
                         _walletBalanceMap[walletId] ?? 0,
                       ),
-                      iconIndex: _walletList[index].iconIndex,
-                      colorIndex: _walletList[index].colorIndex,
                       isLastItem: index == _walletList.length - 1,
                       currentUnit: widget.currentUnit,
                       entryPoint: '',
@@ -235,15 +233,13 @@ class _P2PSelectWalletBottomSheetState extends State<P2PSelectWalletBottomSheet>
                 child: Column(
                   children: List.generate(_walletList.length, (index) {
                     int walletId = _walletList[index].id;
+                    final wallet = _walletList[index];
                     return WalletItemCard(
-                      id: walletId,
-                      name: _walletList[index].name,
+                      walletItem: wallet,
                       animatedBalanceData: AnimatedBalanceData(
                         _walletBalanceMap[walletId] ?? 0,
                         _walletBalanceMap[walletId] ?? 0,
                       ),
-                      iconIndex: _walletList[index].iconIndex,
-                      colorIndex: _walletList[index].colorIndex,
                       isLastItem: index == _walletList.length - 1,
                       currentUnit: widget.currentUnit,
                       entryPoint: '',

--- a/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
+++ b/lib/screens/send/refactor/select_wallet_bottom_sheet.dart
@@ -100,7 +100,6 @@ class _SelectWalletBottomSheetState extends State<SelectWalletBottomSheet> {
                       ),
                       isLastItem: index == _walletList.length - 1,
                       currentUnit: widget.currentUnit,
-                      entryPoint: '',
                       backgroundColor: CoconutColors.black,
                       rightWidget: isChecked ? SvgPicture.asset('assets/svg/check.svg') : Container(),
                       onPressed: () => setState(() => _selectedWalletId = walletId),
@@ -242,14 +241,8 @@ class _P2PSelectWalletBottomSheetState extends State<P2PSelectWalletBottomSheet>
                       ),
                       isLastItem: index == _walletList.length - 1,
                       currentUnit: widget.currentUnit,
-                      entryPoint: '',
                       backgroundColor: CoconutColors.black,
-                      rightWidget: SvgPicture.asset(
-                        'assets/svg/arrow-right.svg',
-                        width: 6,
-                        height: 10,
-                        colorFilter: const ColorFilter.mode(CoconutColors.gray400, BlendMode.srcIn),
-                      ),
+                      rightWidget: Container(),
                       onPressed: () => widget.onWalletSelected(walletId),
                     );
                   }),

--- a/lib/widgets/card/wallet_item_card.dart
+++ b/lib/widgets/card/wallet_item_card.dart
@@ -28,7 +28,6 @@ class WalletItemCard extends StatelessWidget {
   final bool isStarVisible;
   final ValueChanged<(bool, int)>? onTapStar;
   final int? index;
-  final String entryPoint;
   final VoidCallback? onLongPressed;
   final Widget rightWidget;
   final VoidCallback onPressed;
@@ -38,7 +37,6 @@ class WalletItemCard extends StatelessWidget {
     required this.walletItem,
     required this.animatedBalanceData,
     required this.currentUnit,
-    required this.entryPoint,
     required this.isLastItem,
     this.isBalanceHidden = false,
     this.fakeBalance,

--- a/lib/widgets/card/wallet_item_card.dart
+++ b/lib/widgets/card/wallet_item_card.dart
@@ -33,6 +33,8 @@ class WalletItemCard extends StatelessWidget {
   final int? index;
   final String entryPoint;
   final VoidCallback? onLongPressed;
+  final Widget rightWidget;
+  final VoidCallback onPressed;
 
   const WalletItemCard({
     super.key,
@@ -58,6 +60,8 @@ class WalletItemCard extends StatelessWidget {
     this.onTapStar,
     this.index,
     this.onLongPressed,
+    required this.rightWidget,
+    required this.onPressed,
   });
 
   @override
@@ -79,9 +83,7 @@ class WalletItemCard extends StatelessWidget {
       defaultColor: backgroundColor ?? CoconutColors.gray800,
       pressedColor: pressedColor ?? CoconutColors.gray750,
       borderRadius: 12,
-      onPressed: () {
-        Navigator.pushNamed(context, '/wallet-detail', arguments: {'id': id, 'entryPoint': entryPoint});
-      },
+      onPressed: onPressed,
       onLongPress: () {
         onLongPressed?.call();
       },
@@ -227,12 +229,7 @@ class WalletItemCard extends StatelessWidget {
                   ),
                 ),
               )
-              : SvgPicture.asset(
-                'assets/svg/arrow-right.svg',
-                width: 6,
-                height: 10,
-                colorFilter: const ColorFilter.mode(CoconutColors.gray400, BlendMode.srcIn),
-              ),
+              : rightWidget,
         ],
       ),
     );

--- a/lib/widgets/card/wallet_item_card.dart
+++ b/lib/widgets/card/wallet_item_card.dart
@@ -2,7 +2,10 @@ import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_wallet/enums/fiat_enums.dart';
 import 'package:coconut_wallet/enums/wallet_enums.dart';
 import 'package:coconut_wallet/localization/strings.g.dart';
+import 'package:coconut_wallet/model/wallet/multisig_wallet_list_item.dart';
 import 'package:coconut_wallet/model/wallet/balance.dart';
+import 'package:coconut_wallet/model/wallet/wallet_list_item_base.dart';
+import 'package:coconut_wallet/utils/colors_util.dart';
 import 'package:coconut_wallet/widgets/animated_balance.dart';
 import 'package:coconut_wallet/widgets/icon/wallet_icon_small.dart';
 import 'package:flutter/material.dart';
@@ -10,20 +13,14 @@ import 'package:coconut_wallet/widgets/button/shrink_animation_button.dart';
 import 'package:flutter_svg/svg.dart';
 
 class WalletItemCard extends StatelessWidget {
-  /// External Wallet인 경우 iconIndex = colorIndex = null
-  final int id;
+  final WalletListItemBase walletItem;
   final AnimatedBalanceData animatedBalanceData;
-  final String name;
-  final int iconIndex;
-  final int colorIndex;
   final bool isLastItem;
   final bool isBalanceHidden;
   final int? fakeBalance;
-  final WalletImportSource walletImportSource;
   final BitcoinUnit currentUnit;
   final Color? backgroundColor;
   final Color? pressedColor;
-  final List<Color>? iconGradientColors;
   final bool? isPrimaryWallet;
   final bool? isExcludeFromTotalBalance;
   final bool isEditMode;
@@ -38,20 +35,15 @@ class WalletItemCard extends StatelessWidget {
 
   const WalletItemCard({
     super.key,
-    required this.id,
+    required this.walletItem,
     required this.animatedBalanceData,
-    required this.name,
     required this.currentUnit,
     required this.entryPoint,
-    this.iconIndex = 0,
-    this.colorIndex = 0,
     required this.isLastItem,
     this.isBalanceHidden = false,
     this.fakeBalance,
-    this.walletImportSource = WalletImportSource.coconutVault,
     this.backgroundColor,
     this.pressedColor,
-    this.iconGradientColors,
     this.isPrimaryWallet,
     this.isExcludeFromTotalBalance,
     this.isEditMode = false,
@@ -66,6 +58,15 @@ class WalletItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    List<Color>? iconGradientColors;
+    if (walletItem.walletType == WalletType.multiSignature) {
+      final signers = (walletItem as MultisigWalletListItem).signers;
+      iconGradientColors = ColorUtil.getGradientColors(signers);
+    } else if (walletItem.walletType == WalletType.taproot) {
+      final taprootStyle = TaprootCardStyle.from(walletItem);
+      iconGradientColors = taprootStyle?.iconGradientColors;
+    }
+
     final displayedFakeBalance = currentUnit.displayBitcoinAmount(fakeBalance);
     if (isEditMode) {
       return _buildWalletItemContent(
@@ -77,6 +78,7 @@ class WalletItemCard extends StatelessWidget {
           }
         },
         index: index,
+        iconGradientColors: iconGradientColors,
       );
     }
     final row = ShrinkAnimationButton(
@@ -87,7 +89,7 @@ class WalletItemCard extends StatelessWidget {
       onLongPress: () {
         onLongPressed?.call();
       },
-      child: _buildWalletItemContent(displayedFakeBalance),
+      child: _buildWalletItemContent(displayedFakeBalance, iconGradientColors: iconGradientColors),
     );
 
     if (isLastItem) {
@@ -101,10 +103,11 @@ class WalletItemCard extends StatelessWidget {
     String displayFakeBalance, {
     bool isEditMode = false,
     ValueChanged<(bool, int)>? onTapStar,
+    List<Color>? iconGradientColors,
     int? index,
   }) {
     final walletDescriptionParts = <String>[
-      name,
+      walletItem.name,
       if (isPrimaryWallet == true) t.wallet_list.primary_wallet,
       if (isExcludeFromTotalBalance == true) t.wallet_list.exclude_from_total_amount,
     ];
@@ -120,7 +123,7 @@ class WalletItemCard extends StatelessWidget {
                 behavior: HitTestBehavior.translucent,
                 onTap: () {
                   if (!isStarVisible) return;
-                  onTapStar?.call((!isFavorite, id));
+                  onTapStar?.call((!isFavorite, walletItem.id));
                 },
                 child: Padding(
                   padding: const EdgeInsets.all(8.0),
@@ -129,9 +132,9 @@ class WalletItemCard extends StatelessWidget {
               ),
             ),
           WalletIconSmall(
-            walletImportSource: walletImportSource,
-            iconIndex: iconIndex,
-            colorIndex: colorIndex,
+            walletImportSource: walletItem.walletImportSource,
+            iconIndex: walletItem.iconIndex,
+            colorIndex: walletItem.colorIndex,
             gradientColors: iconGradientColors,
           ),
           CoconutLayout.spacing_200w,


### PR DESCRIPTION
#705 

보내기 화면에서 지갑 선택, 계산기 화면에서 보내기 시 지갑 선택하는 경우의 바텀 시트에서
지갑 색상 적용되지 않는 버그를 수정하기 위해 리팩토링 진행하였습니다. 

## 변동 사항
WalletItemCard 리팩토링
- wallet_item_card에 rightWidget, onPressed 변수 추가
- 홈화면과 리스트 화면에 변수 적용
- 지갑 선택 바텀 시트에 WalletItemCard 적용
- iconGradientColors 지갑 색상이 wallet_item_card 내부에서 적용되도록 수정
   -> 지갑 정보(walletListItemBase)를 wallet_item_card에서 불러오는 방식

### 특이사항
머지 시 CCOS와 충돌 발생할 수 있음