### PR TITLE
refactor(chain): extract ChainSource interface from ElectrumService

### DIFF
--- a/lib/providers/node_provider/balance_sync_service.dart
+++ b/lib/providers/node_provider/balance_sync_service.dart
@@ -4,26 +4,34 @@ import 'package:coconut_wallet/model/wallet/balance.dart';
 import 'package:coconut_wallet/model/wallet/wallet_item_base.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/repository/realm/wallet_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/enums/network_enums.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/providers/node_provider/state/state_manager_interface.dart';
 
 /// NodeProvider의 잔액 관련 기능을 담당하는 매니저 클래스
 class BalanceSyncService {
-  final ElectrumService _electrumService;
+  final ChainSource _chainSource;
   final StateManagerInterface _stateManager;
   final AddressRepository _addressRepository;
   final WalletRepository _walletRepository;
 
-  BalanceSyncService(this._electrumService, this._stateManager, this._addressRepository, this._walletRepository);
+  BalanceSyncService(
+    this._chainSource,
+    this._stateManager,
+    this._addressRepository,
+    this._walletRepository,
+  );
 
   /// 스크립트의 잔액을 조회하고 업데이트합니다.
   Future<void> fetchScriptBalance(WalletItemBase walletItem, ScriptStatus scriptStatus) async {
     // 동기화 시작 state 업데이트
     _stateManager.addWalletSyncState(walletItem.id, UpdateElement.balance);
 
-    final balanceResponse = await _electrumService.getBalance(walletItem.walletBase.addressType, scriptStatus.address);
+    final balanceResponse = await _chainSource.getBalance(
+      walletItem.walletBase.addressType,
+      scriptStatus.address,
+    );
 
     // GetBalanceRes에서 Balance 객체로 변환
     final addressBalance = Balance(balanceResponse.confirmed, balanceResponse.unconfirmed);
@@ -40,7 +48,10 @@ class BalanceSyncService {
   }
 
   /// 여러 스크립트의 잔액을 일괄적으로 조회하고 업데이트합니다.
-  Future<void> fetchScriptBalanceBatch(WalletItemBase walletItem, List<ScriptStatus> scriptStatuses) async {
+  Future<void> fetchScriptBalanceBatch(
+    WalletItemBase walletItem,
+    List<ScriptStatus> scriptStatuses,
+  ) async {
     if (scriptStatuses.isEmpty) {
       Logger.error('fetchScriptBalanceBatch: scriptStatus is empty');
       return;
@@ -53,10 +64,12 @@ class BalanceSyncService {
       List<UpdateAddressBalanceDto> balanceUpdates = [];
 
       const batchSize = 50; // 배치 사이즈 임의 설정
-      final isOnionHost = scriptStatuses.isNotEmpty && scriptStatuses.first.address.contains('.onion');
+      final isOnionHost =
+          scriptStatuses.isNotEmpty && scriptStatuses.first.address.contains('.onion');
 
       for (int i = 0; i < scriptStatuses.length; i += batchSize) {
-        final endIndex = (i + batchSize < scriptStatuses.length) ? i + batchSize : scriptStatuses.length;
+        final endIndex =
+            (i + batchSize < scriptStatuses.length) ? i + batchSize : scriptStatuses.length;
         final batch = scriptStatuses.sublist(i, endIndex);
 
         Logger.log(
@@ -66,7 +79,7 @@ class BalanceSyncService {
         // 배치 내에서 병렬 처리
         final batchFutures = batch.map((script) async {
           try {
-            final balanceResponse = await _electrumService.getBalance(
+            final balanceResponse = await _chainSource.getBalance(
               walletItem.walletBase.addressType,
               script.address,
             );
@@ -95,7 +108,7 @@ class BalanceSyncService {
       // 기존 방식
       // for (var script in scriptStatuses) {
       //   final balanceResponse =
-      //       await _electrumService.getBalance(walletItem.walletBase.addressType, script.address);
+      //       await _chainSource.getBalance(walletItem.walletBase.addressType, script.address);
 
       //   balanceUpdates.add(UpdateAddressBalanceDto(
       //     scriptStatus: script,
@@ -104,7 +117,10 @@ class BalanceSyncService {
       //   ));
       // }
 
-      final totalBalanceDiff = await _addressRepository.updateAddressBalanceBatch(walletItem.id, balanceUpdates);
+      final totalBalanceDiff = await _addressRepository.updateAddressBalanceBatch(
+        walletItem.id,
+        balanceUpdates,
+      );
 
       // 지갑 잔액에 변화량 반영
       await _walletRepository.accumulateWalletBalance(walletItem.id, totalBalanceDiff);

--- a/lib/providers/node_provider/isolate/isolate_controller.dart
+++ b/lib/providers/node_provider/isolate/isolate_controller.dart
@@ -5,7 +5,7 @@ import 'package:coconut_wallet/providers/node_provider/state/isolate_state_manag
 import 'package:coconut_wallet/providers/node_provider/network_service.dart';
 import 'package:coconut_wallet/providers/node_provider/subscription/subscription_service.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_record_service.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/result.dart';
 
@@ -13,13 +13,13 @@ class IsolateController {
   final SubscriptionService _subscriptionService;
   final NetworkService _networkManager;
   final IsolateStateManager _isolateStateManager;
-  final ElectrumService _electrumService;
+  final ChainSource _chainSource;
   final TransactionRecordService _transactionRecordService;
   IsolateController(
     this._subscriptionService,
     this._networkManager,
     this._isolateStateManager,
-    this._electrumService,
+    this._chainSource,
     this._transactionRecordService,
   );
 
@@ -74,12 +74,16 @@ class IsolateController {
           isolateToMainSendPort.send(await _networkManager.getRecommendedFees());
           break;
         case IsolateControllerCommand.getSocketConnectionStatus:
-          isolateToMainSendPort.send(Result.success(_electrumService.connectionStatus));
+          isolateToMainSendPort.send(Result.success(_chainSource.connectionStatus));
           break;
         case IsolateControllerCommand.getTransactionRecord:
           final txHash = params[1] as String;
-          Logger.log('IsolateController: getTransactionRecord executing in isolate (txHash: $txHash)');
-          isolateToMainSendPort.send(await _transactionRecordService.getTransactionRecord(params[0], params[1]));
+          Logger.log(
+            'IsolateController: getTransactionRecord executing in isolate (txHash: $txHash)',
+          );
+          isolateToMainSendPort.send(
+            await _transactionRecordService.getTransactionRecord(params[0], params[1]),
+          );
           break;
       }
     } catch (e, stack) {

--- a/lib/providers/node_provider/isolate/isolate_initializer.dart
+++ b/lib/providers/node_provider/isolate/isolate_initializer.dart
@@ -17,10 +17,10 @@ import 'package:coconut_wallet/repository/realm/transaction_draft_repository.dar
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/repository/realm/wallet_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 
 class IsolateInitializer {
-  static IsolateController entryInitialize(SendPort sendPort, ElectrumService electrumService) {
+  static IsolateController entryInitialize(SendPort sendPort, ChainSource chainSource) {
     // TODO: isSetPin, 핀 설정/해제할 때 isolate에서도 인지할 수 있는 로직 추가
     final realmManager = RealmManager();
     final addressRepository = AddressRepository(realmManager);
@@ -30,16 +30,16 @@ class IsolateInitializer {
     final transactionRepository = TransactionRepository(realmManager);
     final subscribeRepository = SubscriptionRepository(realmManager);
     // IsolateStateManager 초기화
-    final transactionRecordService = TransactionRecordService(electrumService, addressRepository);
+    final transactionRecordService = TransactionRecordService(chainSource, addressRepository);
     final isolateStateManager = IsolateStateManager(sendPort);
     final BalanceSyncService balanceSyncService = BalanceSyncService(
-      electrumService,
+      chainSource,
       isolateStateManager,
       addressRepository,
       walletRepository,
     );
     final UtxoSyncService utxoSyncService = UtxoSyncService(
-      electrumService,
+      chainSource,
       isolateStateManager,
       utxoRepository,
       transactionRepository,
@@ -47,14 +47,14 @@ class IsolateInitializer {
     );
     final ScriptCallbackService scriptCallbackService = ScriptCallbackService();
     final TransactionSyncService transactionSyncService = TransactionSyncService(
-      electrumService,
+      chainSource,
       transactionRepository,
       transactionRecordService,
       isolateStateManager,
       utxoRepository,
       scriptCallbackService,
     );
-    final NetworkService networkManager = NetworkService(electrumService, transactionRepository);
+    final NetworkService networkManager = NetworkService(chainSource, transactionRepository);
     final ScriptSyncService scriptSyncService = ScriptSyncService(
       isolateStateManager,
       balanceSyncService,
@@ -65,7 +65,7 @@ class IsolateInitializer {
     );
 
     final SubscriptionService subscriptionService = SubscriptionService(
-      electrumService,
+      chainSource,
       isolateStateManager,
       addressRepository,
       subscribeRepository,
@@ -76,12 +76,12 @@ class IsolateInitializer {
       subscriptionService,
       networkManager,
       isolateStateManager,
-      electrumService,
+      chainSource,
       transactionRecordService,
     );
 
     // 소켓 연결 종료 시 상태 콜백
-    electrumService.setOnConnectionLostCallback(() {
+    chainSource.setOnConnectionLostCallback(() {
       isolateStateManager.setNodeSyncStateToFailed();
     });
 

--- a/lib/providers/node_provider/isolate/isolate_manager.dart
+++ b/lib/providers/node_provider/isolate/isolate_manager.dart
@@ -10,6 +10,7 @@ import 'package:coconut_wallet/model/wallet/wallet_item_base.dart';
 import 'package:coconut_wallet/providers/node_provider/isolate/isolate_enum.dart';
 import 'package:coconut_wallet/providers/node_provider/isolate/isolate_initializer.dart';
 import 'package:coconut_wallet/model/node/isolate_state_message.dart';
+import 'package:coconut_wallet/services/electrum_chain_source.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
 import 'package:coconut_wallet/model/node/spawn_isolate_dto.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
@@ -54,7 +55,9 @@ class IsolateManager {
   void _createIsolateCompleter() {
     if (_isolateReady != null && !_isolateReady!.isCompleted && _isInitializing) {
       try {
-        _isolateReady!.completeError(Exception('IsolateManager: Previous initialization was cancelled'));
+        _isolateReady!.completeError(
+          Exception('IsolateManager: Previous initialization was cancelled'),
+        );
       } catch (e) {
         // 이미 완료된 경우 무시
       }
@@ -265,12 +268,15 @@ class IsolateManager {
     NetworkType.setNetworkType(data.networkType);
 
     final isolateFromMainReceivePort = ReceivePort('isolateFromMainReceivePort');
-    final electrumService = ElectrumService();
+    final chainSource = ElectrumChainSource(ElectrumService());
 
     try {
-      final isConnected = await electrumService.connect(data.host, data.port, ssl: data.ssl);
+      final isConnected = await chainSource.connect(data.host, data.port, ssl: data.ssl);
 
-      final isolateController = IsolateInitializer.entryInitialize(data.isolateToMainSendPort, electrumService);
+      final isolateController = IsolateInitializer.entryInitialize(
+        data.isolateToMainSendPort,
+        chainSource,
+      );
 
       if (!isConnected) {
         Logger.error("Isolate: Failed to connect to Electrum server");
@@ -330,7 +336,9 @@ class IsolateManager {
       case IsolateControllerCommand.getTransaction:
       case IsolateControllerCommand.getRecommendedFees:
         final timeout =
-            _host.contains('.onion') ? kIsolateSimpleResponseTimeoutForOnion : kIsolateSimpleResponseTimeout;
+            _host.contains('.onion')
+                ? kIsolateSimpleResponseTimeoutForOnion
+                : kIsolateSimpleResponseTimeout;
         return timeout;
     }
   }
@@ -352,7 +360,9 @@ class IsolateManager {
   /// Isolate 명령 실패 로그
   void _logCommandFailure(IsolateControllerCommand command, String failureStage, [Object? detail]) {
     if (detail != null) {
-      Logger.error('IsolateManager: command=${command.name} failureStage=$failureStage detail=$detail');
+      Logger.error(
+        'IsolateManager: command=${command.name} failureStage=$failureStage detail=$detail',
+      );
     } else {
       Logger.error('IsolateManager: command=${command.name} failureStage=$failureStage');
     }
@@ -441,7 +451,8 @@ class IsolateManager {
       Result<dynamic> result;
       try {
         final timeLimit = commandTimeoutOverride ?? _getTimeoutForCommand(messageType);
-        final isSocketConnectionStatusMessage = messageType == IsolateControllerCommand.getSocketConnectionStatus;
+        final isSocketConnectionStatusMessage =
+            messageType == IsolateControllerCommand.getSocketConnectionStatus;
 
         result = await mainFromIsolateReceivePort.first.timeout(
           timeLimit,
@@ -451,12 +462,18 @@ class IsolateManager {
                 'IsolateManager: getTransactionRecord timeout (txHash: ${params[1]}, limit: ${timeLimit.inMilliseconds}ms)',
               );
             } else {
-              Logger.error('IsolateManager: Command timeout: $messageType (${timeLimit.inMilliseconds}ms)');
+              Logger.error(
+                'IsolateManager: Command timeout: $messageType (${timeLimit.inMilliseconds}ms)',
+              );
             }
             if (isSocketConnectionStatusMessage) {
               return Result.success(SocketConnectionStatus.terminated);
             }
-            _logCommandFailure(messageType, 'isolate_response_timeout', '${timeLimit.inMilliseconds}ms');
+            _logCommandFailure(
+              messageType,
+              'isolate_response_timeout',
+              '${timeLimit.inMilliseconds}ms',
+            );
             return Result<T>.failure(ErrorCodes.nodeIsolateError);
           },
         );
@@ -543,7 +560,10 @@ class IsolateManager {
     Logger.log(
       'IsolateManager: getTransactionRecord called (txHash: $txHash, timeout: ${timeout?.inSeconds ?? "default"}s)',
     );
-    return _send(IsolateControllerCommand.getTransactionRecord, [walletItem, txHash], commandTimeoutOverride: timeout);
+    return _send(IsolateControllerCommand.getTransactionRecord, [
+      walletItem,
+      txHash,
+    ], commandTimeoutOverride: timeout);
   }
 
   /// isolate 연결만 종료하는 메서드
@@ -583,7 +603,9 @@ class IsolateManager {
       // isolateReady가 완료되지 않았다면 에러로 완료 처리
       if (_isolateReady != null && !_isolateReady!.isCompleted) {
         try {
-          _isolateReady!.completeError(Exception('Isolate was closed before initialization completed'));
+          _isolateReady!.completeError(
+            Exception('Isolate was closed before initialization completed'),
+          );
         } catch (e) {
           // 이미 완료된 경우 무시
         }

--- a/lib/providers/node_provider/network_service.dart
+++ b/lib/providers/node_provider/network_service.dart
@@ -4,22 +4,22 @@ import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/services/model/response/block_header.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/recommended_fee.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/utils/file_logger.dart';
 import 'package:coconut_wallet/utils/result.dart';
 
 /// NodeProvider의 네트워크 관련 기능을 담당하는 서비스 클래스
 /// ElectrumService의 네트워크 관련 기능을 직접 구현합니다.
 class NetworkService {
-  final ElectrumService _electrumService;
+  final ChainSource _chainSource;
   final TransactionRepository _transactionRepository;
 
-  NetworkService(this._electrumService, this._transactionRepository);
+  NetworkService(this._chainSource, this._transactionRepository);
 
   /// 네트워크 최소 수수료율을 조회합니다.
   Future<Result<int>> getNetworkMinimumFeeRate() async {
     try {
-      final feeHistogram = await _electrumService.getMempoolFeeHistogram();
+      final feeHistogram = await _chainSource.getMempoolFeeHistogram();
       if (feeHistogram.isEmpty) {
         return Result.success(1);
       }
@@ -40,7 +40,7 @@ class NetworkService {
   /// 최신 블록 정보를 조회합니다.
   Future<Result<BlockTimestamp>> getLatestBlock() async {
     try {
-      var result = await _electrumService.getCurrentBlock();
+      var result = await _chainSource.getCurrentBlock();
       var blockHeader = BlockHeader.parse(result.height, result.hex);
       return Result.success(
         BlockTimestamp(
@@ -58,7 +58,7 @@ class NetworkService {
     try {
       // 1. mempool.get_fee_histogram 호출
       //    결과는 [[fee, vsize], [fee, vsize], ...] 형태이며 fee 단위는 sat/vB.
-      final dynamic histogramResult = await _electrumService.getMempoolFeeHistogram();
+      final dynamic histogramResult = await _chainSource.getMempoolFeeHistogram();
       List<List<dynamic>> histogram = [];
       if (histogramResult is List) {
         for (var entry in histogramResult) {
@@ -76,16 +76,18 @@ class NetworkService {
       const int economyTarget = 10; // 경제적 확인 (10블록)
 
       // 각 목표에 대해 fee 추정값 호출 (BTC/kB 단위)
-      final dynamic feeFastRaw = await _electrumService.estimateFee(fastestTarget);
-      final dynamic feeHalfHourRaw = await _electrumService.estimateFee(halfHourTarget);
-      final dynamic feeHourRaw = await _electrumService.estimateFee(hourTarget);
-      final dynamic feeEconomyRaw = await _electrumService.estimateFee(economyTarget);
+      final dynamic feeFastRaw = await _chainSource.estimateFee(fastestTarget);
+      final dynamic feeHalfHourRaw = await _chainSource.estimateFee(halfHourTarget);
+      final dynamic feeHourRaw = await _chainSource.estimateFee(hourTarget);
+      final dynamic feeEconomyRaw = await _chainSource.estimateFee(economyTarget);
 
       // 반환값이 -1이면 충분한 정보가 없다는 뜻이므로 0으로 처리 (추후 대체)
       double feeFast = (feeFastRaw is int ? feeFastRaw.toDouble() : feeFastRaw) as double;
-      double feeHalfHour = (feeHalfHourRaw is int ? feeHalfHourRaw.toDouble() : feeHalfHourRaw) as double;
+      double feeHalfHour =
+          (feeHalfHourRaw is int ? feeHalfHourRaw.toDouble() : feeHalfHourRaw) as double;
       double feeHour = (feeHourRaw is int ? feeHourRaw.toDouble() : feeHourRaw) as double;
-      double feeEconomy = (feeEconomyRaw is int ? feeEconomyRaw.toDouble() : feeEconomyRaw) as double;
+      double feeEconomy =
+          (feeEconomyRaw is int ? feeEconomyRaw.toDouble() : feeEconomyRaw) as double;
       feeFast = feeFast > 0 ? feeFast : 0;
       feeHalfHour = feeHalfHour > 0 ? feeHalfHour : 0;
       feeHour = feeHour > 0 ? feeHour : 0;
@@ -110,7 +112,9 @@ class NetworkService {
       economyFee = economyFee > 0 ? economyFee : (minimumFee > 0 ? minimumFee : 1);
       minimumFee = minimumFee > 0 ? minimumFee : 1;
 
-      return Result.success(RecommendedFee(fastestFee, halfHourFee, hourFee, economyFee, minimumFee));
+      return Result.success(
+        RecommendedFee(fastestFee, halfHourFee, hourFee, economyFee, minimumFee),
+      );
     } catch (e) {
       return Result.failure(e is AppError ? e : ErrorCodes.nodeUnknown);
     }
@@ -125,7 +129,7 @@ class NetworkService {
   /// 트랜잭션을 브로드캐스트합니다.
   Future<Result<String>> broadcast(Transaction signedTx) async {
     try {
-      final txHash = await _electrumService.broadcast(signedTx.serialize());
+      final txHash = await _chainSource.broadcast(signedTx.serialize());
 
       return Result.success(txHash);
     } catch (e) {
@@ -137,7 +141,7 @@ class NetworkService {
   /// 특정 트랜잭션을 조회합니다.
   Future<Result<String>> getTransaction(String txHash) async {
     try {
-      final tx = await _electrumService.getTransaction(txHash);
+      final tx = await _chainSource.getTransaction(txHash);
       return Result.success(tx);
     } catch (e) {
       return Result.failure(e is AppError ? e : ErrorCodes.nodeUnknown);

--- a/lib/providers/node_provider/node_provider.dart
+++ b/lib/providers/node_provider/node_provider.dart
@@ -284,7 +284,9 @@ class NodeProvider extends ChangeNotifier {
   void _createNewCompleter() {
     if (_initCompleter != null && !_initCompleter!.isCompleted) {
       try {
-        _initCompleter!.completeError(Exception('NodeProvider: Previous initialization was cancelled'));
+        _initCompleter!.completeError(
+          Exception('NodeProvider: Previous initialization was cancelled'),
+        );
       } catch (e) {
         // 이미 완료된 경우 무시
       }
@@ -385,7 +387,8 @@ class NodeProvider extends ChangeNotifier {
   }
 
   Future<Result<bool>> subscribeWallets() async {
-    if (_walletLoadStateNotifier.value != WalletLoadState.loadCompleted || _connectivityProvider.isInternetOff) {
+    if (_walletLoadStateNotifier.value != WalletLoadState.loadCompleted ||
+        _connectivityProvider.isInternetOff) {
       return Result.success(false);
     }
     final walletItems = _walletItemListNotifier.value;
@@ -409,7 +412,9 @@ class NodeProvider extends ChangeNotifier {
   Future<Result<String>> broadcast(Transaction signedTx) async {
     final result = await _isolateManager.broadcast(signedTx);
     if (result.isFailure) {
-      Logger.error('NodeProvider.broadcast: failed code=${result.error.code} message=${result.error.message}');
+      Logger.error(
+        'NodeProvider.broadcast: failed code=${result.error.code} message=${result.error.message}',
+      );
       FileLogger.logBroadcast('NodeProvider failure code=${result.error.code}');
     }
     return result;
@@ -443,7 +448,9 @@ class NodeProvider extends ChangeNotifier {
     Logger.log('NodeProvider: getTransactionRecord called (txHash: $txHash)');
     final result = await _isolateManager.getTransactionRecord(walletItem, txHash, timeout: timeout);
     if (result.isFailure) {
-      Logger.error('NodeProvider.getTransactionRecord failed (txHash: $txHash) - error: ${result.error}');
+      Logger.error(
+        'NodeProvider.getTransactionRecord failed (txHash: $txHash) - error: ${result.error}',
+      );
     }
     return result;
   }

--- a/lib/providers/node_provider/state/isolate_state_manager.dart
+++ b/lib/providers/node_provider/state/isolate_state_manager.dart
@@ -62,7 +62,11 @@ class IsolateStateManager implements StateManagerInterface {
   }
 
   /// 업데이트 요소에 따른 상태 업데이트 및 상태 변경 여부 반환
-  bool _isUpdatedElementStatus(WalletUpdateInfo walletUpdateInfo, UpdateElement updateType, WalletSyncState newStatus) {
+  bool _isUpdatedElementStatus(
+    WalletUpdateInfo walletUpdateInfo,
+    UpdateElement updateType,
+    WalletSyncState newStatus,
+  ) {
     WalletSyncState prevStatus;
 
     switch (updateType) {
@@ -93,7 +97,9 @@ class IsolateStateManager implements StateManagerInterface {
 
     _registeredWallets[walletId] = WalletUpdateInfo(walletId);
     _walletUpdateCounter[walletId] = WalletUpdateCounter.initial();
-    _sendStateUpdateToMain(IsolateStateMessage(IsolateStateMethod.initWalletUpdateStatus, [walletId]));
+    _sendStateUpdateToMain(
+      IsolateStateMessage(IsolateStateMethod.initWalletUpdateStatus, [walletId]),
+    );
   }
 
   @override
@@ -110,7 +116,9 @@ class IsolateStateManager implements StateManagerInterface {
     _registeredWallets[walletId] = walletUpdateInfo;
 
     if (isChange) {
-      _sendStateUpdateToMain(IsolateStateMessage(IsolateStateMethod.addWalletSyncState, [walletId, updateType]));
+      _sendStateUpdateToMain(
+        IsolateStateMessage(IsolateStateMethod.addWalletSyncState, [walletId, updateType]),
+      );
     }
   }
 
@@ -131,13 +139,17 @@ class IsolateStateManager implements StateManagerInterface {
     _registeredWallets[walletId] = walletUpdateInfo;
 
     if (isChange) {
-      _sendStateUpdateToMain(IsolateStateMessage(IsolateStateMethod.addWalletCompletedState, [walletId, updateType]));
+      _sendStateUpdateToMain(
+        IsolateStateMessage(IsolateStateMethod.addWalletCompletedState, [walletId, updateType]),
+      );
     }
   }
 
   @override
   void addWalletCompletedAllStates(int walletId) {
-    _sendStateUpdateToMain(IsolateStateMessage(IsolateStateMethod.addWalletCompletedAllStates, [walletId]));
+    _sendStateUpdateToMain(
+      IsolateStateMessage(IsolateStateMethod.addWalletCompletedAllStates, [walletId]),
+    );
   }
 
   @override

--- a/lib/providers/node_provider/state/node_state_manager.dart
+++ b/lib/providers/node_provider/state/node_state_manager.dart
@@ -14,7 +14,10 @@ class NodeStateManager implements StateManagerInterface {
   final StreamController<NodeSyncState> _syncStateController;
   final StreamController<Map<int, WalletUpdateInfo>> _walletStateController;
 
-  NodeProviderState _state = const NodeProviderState(nodeSyncState: NodeSyncState.init, registeredWallets: {});
+  NodeProviderState _state = const NodeProviderState(
+    nodeSyncState: NodeSyncState.init,
+    registeredWallets: {},
+  );
   NodeProviderState get state => _state;
 
   NodeStateManager(this._notifyListeners, this._syncStateController, this._walletStateController);
@@ -31,7 +34,10 @@ class NodeStateManager implements StateManagerInterface {
     final prevState = _state;
 
     // 새 상태 생성
-    final newState = _state.copyWith(newConnectionState: newConnectionState, newUpdatedWallets: newUpdatedWallets);
+    final newState = _state.copyWith(
+      newConnectionState: newConnectionState,
+      newUpdatedWallets: newUpdatedWallets,
+    );
 
     // 상태 업데이트
     _state = newState;
@@ -90,7 +96,10 @@ class NodeStateManager implements StateManagerInterface {
 
   @override
   void initWalletUpdateStatus(int walletId) {
-    _setState(newUpdatedWallets: {..._state.registeredWallets, walletId: WalletUpdateInfo(walletId)}, notify: false);
+    _setState(
+      newUpdatedWallets: {..._state.registeredWallets, walletId: WalletUpdateInfo(walletId)},
+      notify: false,
+    );
   }
 
   /// 지갑의 동기화 상태 증가 및 상태 업데이트
@@ -156,7 +165,10 @@ class NodeStateManager implements StateManagerInterface {
         break;
     }
 
-    final Map<int, WalletUpdateInfo> newUpdatedWallets = {..._state.registeredWallets, walletId: walletUpdateInfo};
+    final Map<int, WalletUpdateInfo> newUpdatedWallets = {
+      ..._state.registeredWallets,
+      walletId: walletUpdateInfo,
+    };
 
     if (isAllWalletsCompleted(updatedWallets: newUpdatedWallets)) {
       newConnectionState = NodeSyncState.completed;
@@ -191,7 +203,10 @@ class NodeStateManager implements StateManagerInterface {
       );
     }
 
-    final Map<int, WalletUpdateInfo> newUpdatedWallets = {..._state.registeredWallets, walletId: updateInfo};
+    final Map<int, WalletUpdateInfo> newUpdatedWallets = {
+      ..._state.registeredWallets,
+      walletId: updateInfo,
+    };
 
     if (isAllWalletsCompleted(updatedWallets: newUpdatedWallets)) {
       newConnectionState = NodeSyncState.completed;

--- a/lib/providers/node_provider/subscription/script_callback_service.dart
+++ b/lib/providers/node_provider/subscription/script_callback_service.dart
@@ -11,7 +11,8 @@ class ScriptCallbackService {
 
   /// 스크립트별 트랜잭션 조회 후 fetchUtxos 콜백 함수
   /// key: ScriptKey, value: Function
-  final Map<String, List<Future<void> Function()>> _fetchUtxosCallback = <String, List<Future<void> Function()>>{};
+  final Map<String, List<Future<void> Function()>> _fetchUtxosCallback =
+      <String, List<Future<void> Function()>>{};
 
   /// 현재 처리 중인 트랜잭션 해시와 처리 시작 시간을 추적하기 위한 맵
   /// key: TxHashKey "walletId:txHash", value: ({DateTime startTime, bool isConfirmed, bool isCompleted})

--- a/lib/providers/node_provider/subscription/script_sync_service.dart
+++ b/lib/providers/node_provider/subscription/script_sync_service.dart
@@ -62,7 +62,10 @@ class ScriptSyncService {
       );
 
       // 기존 인덱스 저장 (변경 전)
-      final oldUsedIndex = dto.scriptStatus.isChange ? dto.walletItem.changeUsedIndex : dto.walletItem.receiveUsedIndex;
+      final oldUsedIndex =
+          dto.scriptStatus.isChange
+              ? dto.walletItem.changeUsedIndex
+              : dto.walletItem.receiveUsedIndex;
 
       // 지갑 인덱스 업데이트
       await _addressRepository.updateWalletUsedIndex(
@@ -86,8 +89,16 @@ class ScriptSyncService {
       await _balanceSyncService.fetchScriptBalance(dto.walletItem, dto.scriptStatus);
 
       // Transaction 동기화, 이벤트를 수신한 시점의 시간을 사용하기 위해 now 파라미터 전달
-      final txHashes = await _transactionSyncService.fetchScriptTransaction(dto.walletItem, dto.scriptStatus, now: now);
-      await _scriptCallbackService.registerTransactionDependency(dto.walletItem, dto.scriptStatus, txHashes);
+      final txHashes = await _transactionSyncService.fetchScriptTransaction(
+        dto.walletItem,
+        dto.scriptStatus,
+        now: now,
+      );
+      await _scriptCallbackService.registerTransactionDependency(
+        dto.walletItem,
+        dto.scriptStatus,
+        txHashes,
+      );
 
       // 새 스크립트 구독 여부 확인 및 처리
       if (_needSubscriptionUpdate(dto.walletItem, oldUsedIndex, dto.scriptStatus.isChange)) {
@@ -110,7 +121,9 @@ class ScriptSyncService {
   /// 필요한 경우 추가 스크립트를 구독합니다.
   bool _needSubscriptionUpdate(WalletItemBase walletItem, int oldUsedIndex, bool isChange) {
     // receive 또는 change 인덱스가 증가한 경우 추가 구독이 필요
-    return isChange ? walletItem.changeUsedIndex > oldUsedIndex : walletItem.receiveUsedIndex > oldUsedIndex;
+    return isChange
+        ? walletItem.changeUsedIndex > oldUsedIndex
+        : walletItem.receiveUsedIndex > oldUsedIndex;
   }
 
   /// 스크립트 상태 변경 배치 처리
@@ -127,7 +140,9 @@ class ScriptSyncService {
       await _balanceSyncService.fetchScriptBalanceBatch(walletItem, scriptStatuses);
       final balanceEndTime = DateTime.now();
       final balanceDuration = balanceEndTime.difference(balanceStartTime);
-      Logger.performance('Balance sync completed in ${balanceDuration.inMilliseconds}ms for ${walletItem.name}');
+      Logger.performance(
+        'Balance sync completed in ${balanceDuration.inMilliseconds}ms for ${walletItem.name}',
+      );
 
       // Transaction 병렬 처리
       _stateManager.addWalletSyncState(walletItem.id, UpdateElement.transaction);
@@ -135,11 +150,16 @@ class ScriptSyncService {
 
       const chunkSize = 20;
       for (int i = 0; i < scriptStatuses.length; i += chunkSize) {
-        final endIndex = (i + chunkSize < scriptStatuses.length) ? i + chunkSize : scriptStatuses.length;
+        final endIndex =
+            (i + chunkSize < scriptStatuses.length) ? i + chunkSize : scriptStatuses.length;
         final batch = scriptStatuses.sublist(i, endIndex);
         final transactionFutures = batch.map(
-          (status) =>
-              _transactionSyncService.fetchScriptTransaction(walletItem, status, inBatchProcess: true, now: now),
+          (status) => _transactionSyncService.fetchScriptTransaction(
+            walletItem,
+            status,
+            inBatchProcess: true,
+            now: now,
+          ),
         );
         await Future.wait(transactionFutures);
 
@@ -161,7 +181,9 @@ class ScriptSyncService {
       final utxoStartTime = DateTime.now();
 
       await Future.wait(
-        scriptStatuses.map((status) => _utxoSyncService.fetchScriptUtxo(walletItem, status, inBatchProcess: true)),
+        scriptStatuses.map(
+          (status) => _utxoSyncService.fetchScriptUtxo(walletItem, status, inBatchProcess: true),
+        ),
       );
 
       // 최초 지갑 구독 시 Outgoing Transaction이 있을 경우 UTXO가 생성되지 않을 경우 임의로 UTXO를 생성해야 함

--- a/lib/providers/node_provider/subscription/subscription_service.dart
+++ b/lib/providers/node_provider/subscription/subscription_service.dart
@@ -10,7 +10,7 @@ import 'package:coconut_wallet/providers/node_provider/state/state_manager_inter
 import 'package:coconut_wallet/providers/node_provider/subscription/script_sync_service.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/repository/realm/subscription_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/result.dart';
 
@@ -18,7 +18,7 @@ import '../../../utils/electrum_utils.dart';
 
 /// 스크립트 구독 처리를 담당하는 클래스
 class SubscriptionService {
-  final ElectrumService _electrumService;
+  final ChainSource _chainSource;
   final StateManagerInterface _stateManager;
   final AddressRepository _addressRepository;
   final SubscriptionRepository _subscriptionRepository;
@@ -32,7 +32,7 @@ class SubscriptionService {
   final Map<int, Completer<Result<bool>>> _subscriptionCompleters = {};
 
   SubscriptionService(
-    this._electrumService,
+    this._chainSource,
     this._stateManager,
     this._addressRepository,
     this._subscriptionRepository,
@@ -83,7 +83,10 @@ class SubscriptionService {
       _subscribeWallet(walletItem, true, _scriptStatusController),
     ]);
 
-    List<ScriptStatus> fetchedScriptStatuses = [...receiveResult.scriptStatuses, ...changeResult.scriptStatuses];
+    List<ScriptStatus> fetchedScriptStatuses = [
+      ...receiveResult.scriptStatuses,
+      ...changeResult.scriptStatuses,
+    ];
 
     // 지갑 최신화
     await _addressRepository.syncWalletWithSubscriptionData(
@@ -116,7 +119,10 @@ class SubscriptionService {
     _stateManager.addWalletCompletedState(walletItem.id, UpdateElement.subscription);
 
     // 변경 이력이 있는 지갑에 대해서만 balance, transaction, utxo 업데이트
-    await _scriptSyncService.syncBatchScriptStatusList(walletItem: walletItem, scriptStatuses: updatedScriptStatuses);
+    await _scriptSyncService.syncBatchScriptStatusList(
+      walletItem: walletItem,
+      scriptStatuses: updatedScriptStatuses,
+    );
 
     // 변경된 ScriptStatus DB에 저장
     _subscriptionRepository.updateScriptStatusList(walletItem.id, updatedScriptStatuses);
@@ -125,7 +131,10 @@ class SubscriptionService {
 
   /// 지갑의 스크립트 구독 해제
   Future<Result<bool>> unsubscribeWallet(WalletItemBase walletItem) async {
-    await Future.wait([_unsubscribeScript(walletItem, false), _unsubscribeScript(walletItem, true)]);
+    await Future.wait([
+      _unsubscribeScript(walletItem, false),
+      _unsubscribeScript(walletItem, true),
+    ]);
     walletItem.subscribedScriptMap.clear();
     Logger.log('UnsubscribeWallet: ${walletItem.name} - finished');
     return Result.success(true);
@@ -180,7 +189,8 @@ class SubscriptionService {
   }
 
   /// 주소 범위에 대한 구독 처리를 수행하는 공통 메서드
-  Future<({List<ScriptStatus> newScriptStatuses, int maxUsedIndex, int nextIndex})> _subscribeAddressRange(
+  Future<({List<ScriptStatus> newScriptStatuses, int maxUsedIndex, int nextIndex})>
+  _subscribeAddressRange(
     WalletItemBase walletItem,
     int startIndex,
     int endIndex,
@@ -203,7 +213,8 @@ class SubscriptionService {
 
     final results = await Future.wait(
       addresses.entries.map(
-        (entry) => _subscribeAddress(walletItem, entry.key, entry.value, isChange, scriptStatusController),
+        (entry) =>
+            _subscribeAddress(walletItem, entry.key, entry.value, isChange, scriptStatusController),
       ),
     );
 
@@ -227,7 +238,11 @@ class SubscriptionService {
       }
     }
 
-    return (newScriptStatuses: newScriptStatuses, maxUsedIndex: maxUsedIndex, nextIndex: startIndex + addresses.length);
+    return (
+      newScriptStatuses: newScriptStatuses,
+      maxUsedIndex: maxUsedIndex,
+      nextIndex: startIndex + addresses.length,
+    );
   }
 
   /// 단일 주소에 대한 구독 처리를 수행하는 메서드
@@ -239,7 +254,8 @@ class SubscriptionService {
     StreamController<SubscribeScriptStreamDto> scriptStatusController,
   ) async {
     final script = ElectrumUtil.getScriptForAddress(walletItem.walletBase.addressType, address);
-    final derivationPath = '${walletItem.walletBase.derivationPath}/${isChange ? 1 : 0}/$derivationIndex';
+    final derivationPath =
+        '${walletItem.walletBase.derivationPath}/${isChange ? 1 : 0}/$derivationIndex';
 
     // 이미 구독 중인 스크립트인지 확인
     final existingStatus = walletItem.subscribedScriptMap[script];
@@ -268,7 +284,7 @@ class SubscriptionService {
       _handleScriptUpdate(reversedScriptHash, scriptStatus, walletItem, scriptStatusController);
     }
 
-    final status = await _electrumService.subscribeScript(
+    final status = await _chainSource.subscribeScript(
       walletItem.walletBase.addressType,
       address,
       onUpdate: onUpdate,
@@ -314,7 +330,8 @@ class SubscriptionService {
     }
 
     // 인덱스가 더 크거나, 상태가 변경되었고 현재 인덱스와 같은 경우
-    if (scriptStatus.index > currentIndex || (statusChanged && scriptStatus.index >= currentIndex)) {
+    if (scriptStatus.index > currentIndex ||
+        (statusChanged && scriptStatus.index >= currentIndex)) {
       currentIndex = max(currentIndex, scriptStatus.index);
 
       if (scriptStatus.isChange) {
@@ -343,7 +360,9 @@ class SubscriptionService {
       timestamp: scriptStatus.timestamp,
     );
 
-    scriptStatusController.add(SubscribeScriptStreamDto(scriptStatus: scriptStatus, walletItem: walletItem));
+    scriptStatusController.add(
+      SubscribeScriptStreamDto(scriptStatus: scriptStatus, walletItem: walletItem),
+    );
   }
 
   /// 스캔 범위 확장을 위한 메서드
@@ -367,19 +386,32 @@ class SubscriptionService {
     }
 
     // 주소 범위에 대한 구독 처리 (기존 _subscribeAddressRange 메서드 재사용)
-    await _subscribeAddressRange(walletItem, startIndex, endIndex, isChange, scriptStatusController);
+    await _subscribeAddressRange(
+      walletItem,
+      startIndex,
+      endIndex,
+      isChange,
+      scriptStatusController,
+    );
   }
 
   /// 특정 유형(receive/change)의 스크립트 구독 해제
   Future<void> _unsubscribeScript(WalletItemBase walletItem, bool isChange) async {
     final addressScanLimit =
-        isChange ? walletItem.changeUsedIndex + _gapLimit + 1 : walletItem.receiveUsedIndex + _gapLimit + 1;
+        isChange
+            ? walletItem.changeUsedIndex + _gapLimit + 1
+            : walletItem.receiveUsedIndex + _gapLimit + 1;
 
-    Map<int, String> addresses = ElectrumUtil.prepareAddressesMap(walletItem.walletBase, 0, addressScanLimit, isChange);
+    Map<int, String> addresses = ElectrumUtil.prepareAddressesMap(
+      walletItem.walletBase,
+      0,
+      addressScanLimit,
+      isChange,
+    );
 
     await Future.wait(
       addresses.values.map((address) {
-        return _electrumService.unsubscribeScript(walletItem.walletBase.addressType, address);
+        return _chainSource.unsubscribeScript(walletItem.walletBase.addressType, address);
       }),
     );
   }

--- a/lib/providers/node_provider/transaction/cpfp_service.dart
+++ b/lib/providers/node_provider/transaction/cpfp_service.dart
@@ -5,18 +5,19 @@ import 'package:coconut_wallet/model/wallet/wallet_item_base.dart';
 import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 
-typedef CpfpInfo = ({String parentTransactionHash, double originalFee, List<Transaction> previousTransactions});
+typedef CpfpInfo =
+    ({String parentTransactionHash, double originalFee, List<Transaction> previousTransactions});
 
 /// CPFP(Child-Pays-For-Parent) 트랜잭션 처리를 담당하는 클래스
 class CpfpService {
   final TransactionRepository _transactionRepository;
   final UtxoRepository _utxoRepository;
-  final ElectrumService _electrumService;
+  final ChainSource _chainSource;
 
-  CpfpService(this._transactionRepository, this._utxoRepository, this._electrumService);
+  CpfpService(this._transactionRepository, this._utxoRepository, this._chainSource);
 
   /// 기존 CPFP 내역이 있는지 확인
   bool hasExistingCpfpHistory(int walletId, String txHash) {
@@ -37,10 +38,16 @@ class CpfpService {
     double originalFee = 0.0;
 
     for (final input in tx.inputs) {
-      final parentTxRecord = _transactionRepository.getTransactionRecord(walletId, input.transactionHash);
+      final parentTxRecord = _transactionRepository.getTransactionRecord(
+        walletId,
+        input.transactionHash,
+      );
 
       if (parentTxRecord != null && parentTxRecord.blockHeight == 0) {
-        final utxo = _utxoRepository.getUtxoState(walletId, getUtxoId(input.transactionHash, input.index));
+        final utxo = _utxoRepository.getUtxoState(
+          walletId,
+          getUtxoId(input.transactionHash, input.index),
+        );
         if (utxo != null) {
           isCpfp = true;
           parentTxHash = parentTxRecord.transactionHash;
@@ -51,8 +58,12 @@ class CpfpService {
     }
 
     if (isCpfp && parentTxHash != null) {
-      final prevTxs = await _electrumService.getPreviousTransactions(tx);
-      return (parentTransactionHash: parentTxHash, originalFee: originalFee, previousTransactions: prevTxs);
+      final prevTxs = await _chainSource.getPreviousTransactions(tx);
+      return (
+        parentTransactionHash: parentTxHash,
+        originalFee: originalFee,
+        previousTransactions: prevTxs,
+      );
     }
 
     return null;

--- a/lib/providers/node_provider/transaction/mempool_api_service.dart
+++ b/lib/providers/node_provider/transaction/mempool_api_service.dart
@@ -8,7 +8,9 @@ class MempoolApi {
   final Uri _baseUrl;
   final http.Client _client;
 
-  MempoolApi({http.Client? client}) : _client = client ?? http.Client(), _baseUrl = _resolveBaseUrl();
+  MempoolApi({http.Client? client})
+    : _client = client ?? http.Client(),
+      _baseUrl = _resolveBaseUrl();
 
   static Uri _resolveBaseUrl() {
     final networkType = NetworkType.currentNetworkType;
@@ -40,7 +42,10 @@ class MempoolApi {
     throw Exception('HTTP ${res.statusCode}: ${res.body}');
   }
 
-  Future<Map<String, dynamic>> fetchTx(String txid, {Duration timeout = const Duration(seconds: 15)}) async {
+  Future<Map<String, dynamic>> fetchTx(
+    String txid, {
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
     _validateTxid(txid);
 
     final uri = _uri('/api/tx/$txid');

--- a/lib/providers/node_provider/transaction/rbf_service.dart
+++ b/lib/providers/node_provider/transaction/rbf_service.dart
@@ -5,7 +5,7 @@ import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 
 typedef RbfInfo =
@@ -18,9 +18,9 @@ typedef RbfInfo =
 class RbfService {
   final TransactionRepository _transactionRepository;
   final UtxoRepository _utxoRepository;
-  final ElectrumService _electrumService;
+  final ChainSource _chainSource;
 
-  RbfService(this._transactionRepository, this._utxoRepository, this._electrumService);
+  RbfService(this._transactionRepository, this._utxoRepository, this._chainSource);
 
   /// RBF를 보내는 지갑 관점에서 이미 소비한 UTXO를 다시 소비하는지 확인
   Future<RbfInfo?> detectOutgoingRbfTransaction(int walletId, Transaction tx) async {
@@ -34,7 +34,10 @@ class RbfService {
     if (rbfInputInfo != null && rbfInputInfo.spentByTransactionHash != null) {
       final prevTxHash = rbfInputInfo.spentByTransactionHash!;
       // 원본 트랜잭션 해시 찾기
-      final originalTxHash = await findOriginalTransactionHash(walletId, rbfInputInfo.spentByTransactionHash!);
+      final originalTxHash = await findOriginalTransactionHash(
+        walletId,
+        rbfInputInfo.spentByTransactionHash!,
+      );
 
       return (originalTransactionHash: originalTxHash, previousTransactionHash: prevTxHash);
     }
@@ -74,7 +77,10 @@ class RbfService {
     }
 
     // 해당 UTXO를 이미 소비한 트랜잭션 조회
-    final spentTransaction = _transactionRepository.getTransactionRecord(walletId, utxo.spentByTransactionHash!);
+    final spentTransaction = _transactionRepository.getTransactionRecord(
+      walletId,
+      utxo.spentByTransactionHash!,
+    );
 
     // 미확인 상태인 트랜잭션만 RBF 대상
     return spentTransaction != null && spentTransaction.blockHeight < 1;
@@ -101,7 +107,8 @@ class RbfService {
         _utxoRepository.getUtxoStateList(walletId).where((utxo) => utxo.isPending).toList();
 
     // 현재 페칭 중인 트랜잭션은 제외
-    unconfirmedUtxoList = unconfirmedUtxoList.where((utxo) => utxo.transactionHash != tx.transactionHash).toList();
+    unconfirmedUtxoList =
+        unconfirmedUtxoList.where((utxo) => utxo.transactionHash != tx.transactionHash).toList();
 
     // 펜딩 중인 UTXO가 없으면 RBF 대상이 아님
     if (unconfirmedUtxoList.isEmpty) {
@@ -117,20 +124,32 @@ class RbfService {
 
       try {
         // 기존 트랜잭션 조회
-        final oldTx = Transaction.parse(await _electrumService.getTransaction(utxo.transactionHash));
+        final oldTx = Transaction.parse(await _chainSource.getTransaction(utxo.transactionHash));
 
         // 인풋이 겹치는지 확인
-        final oldTxInputs = oldTx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
-        final newTxInputs = tx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
+        final oldTxInputs =
+            oldTx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
+        final newTxInputs =
+            tx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
         final overlappingInputs = oldTxInputs.intersection(newTxInputs);
 
         // 겹치는 인풋이 있고 새 트랜잭션의 수수료율이 더 높다면 RBF로 간주
         if (overlappingInputs.isNotEmpty) {
-          final oldTxRecord = _transactionRepository.getTransactionRecord(walletId, oldTx.transactionHash);
-          final newTxRecord = _transactionRepository.getTransactionRecord(walletId, tx.transactionHash);
+          final oldTxRecord = _transactionRepository.getTransactionRecord(
+            walletId,
+            oldTx.transactionHash,
+          );
+          final newTxRecord = _transactionRepository.getTransactionRecord(
+            walletId,
+            tx.transactionHash,
+          );
 
-          if (oldTxRecord != null && newTxRecord != null && oldTxRecord.feeRate < newTxRecord.feeRate) {
-            Logger.log('[$walletId] 수신 RBF 감지: ${oldTx.transactionHash}이(가) ${tx.transactionHash}에 의해 대체됨');
+          if (oldTxRecord != null &&
+              newTxRecord != null &&
+              oldTxRecord.feeRate < newTxRecord.feeRate) {
+            Logger.log(
+              '[$walletId] 수신 RBF 감지: ${oldTx.transactionHash}이(가) ${tx.transactionHash}에 의해 대체됨',
+            );
             return oldTx.transactionHash;
           }
         }
@@ -174,10 +193,16 @@ class RbfService {
     List<RbfHistory> rbfHistoryDtos,
   ) async {
     // 원본 트랜잭션 조회
-    final originalTx = _transactionRepository.getTransactionRecord(walletId, rbfInfo.originalTransactionHash);
+    final originalTx = _transactionRepository.getTransactionRecord(
+      walletId,
+      rbfInfo.originalTransactionHash,
+    );
 
     if (originalTx != null) {
-      final existingRbfHistory = _transactionRepository.getRbfHistoryList(walletId, txRecord.transactionHash);
+      final existingRbfHistory = _transactionRepository.getRbfHistoryList(
+        walletId,
+        txRecord.transactionHash,
+      );
 
       // 최초로 RBF 내역을 등록하는 경우 원본 트랜잭션 내역도 등록
       if (existingRbfHistory.isEmpty) {

--- a/lib/providers/node_provider/transaction/transaction_record_service.dart
+++ b/lib/providers/node_provider/transaction/transaction_record_service.dart
@@ -7,16 +7,16 @@ import 'package:coconut_wallet/model/node/transaction_details.dart';
 import 'package:coconut_wallet/model/wallet/wallet_item_base.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_sync_service.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/utils/result.dart';
 
 class TransactionRecordService {
-  final ElectrumService _electrumService;
+  final ChainSource _chainSource;
   final AddressRepository _addressRepository;
 
-  TransactionRecordService(this._electrumService, this._addressRepository);
+  TransactionRecordService(this._chainSource, this._addressRepository);
 
   /// 트랜잭션 레코드를 생성합니다.
   Future<List<TransactionRecord>> createTransactionRecords(
@@ -51,7 +51,7 @@ class TransactionRecordService {
   }) async {
     now ??= DateTime.now();
 
-    final prevTxs = await _electrumService.getPreviousTransactions(tx, existingTxList: previousTxs);
+    final prevTxs = await _chainSource.getPreviousTransactions(tx, existingTxList: previousTxs);
     final txDetails = processTransactionDetails(tx, prevTxs, walletId);
 
     return TransactionRecord.fromTransactions(
@@ -68,7 +68,11 @@ class TransactionRecordService {
   }
 
   /// 트랜잭션의 입출력 상세 정보를 처리합니다.
-  TransactionDetails processTransactionDetails(Transaction tx, List<Transaction> previousTxs, int walletId) {
+  TransactionDetails processTransactionDetails(
+    Transaction tx,
+    List<Transaction> previousTxs,
+    int walletId,
+  ) {
     List<TransactionAddress> inputAddressList = [];
     int selfInputCount = 0;
     int selfOutputCount = 0;
@@ -82,7 +86,9 @@ class TransactionRecordService {
       // 이전 트랜잭션에서 해당 입력에 대응하는 출력 찾기
       Transaction? previousTx;
       try {
-        previousTx = previousTxs.firstWhere((prevTx) => prevTx.transactionHash == input.transactionHash);
+        previousTx = previousTxs.firstWhere(
+          (prevTx) => prevTx.transactionHash == input.transactionHash,
+        );
       } catch (_) {
         continue;
       }
@@ -92,7 +98,10 @@ class TransactionRecordService {
       }
 
       final previousOutput = previousTx.outputs[input.index];
-      final inputAddress = TransactionAddress(previousOutput.scriptPubKey.getAddress(), previousOutput.amount);
+      final inputAddress = TransactionAddress(
+        previousOutput.scriptPubKey.getAddress(),
+        previousOutput.amount,
+      );
       inputAddressList.add(inputAddress);
 
       fee += inputAddress.amount;
@@ -142,7 +151,12 @@ class TransactionRecordService {
     );
   }
 
-  TransactionType determineTransactionType(int selfInputCount, int selfOutputCount, int inputCount, int outputCount) {
+  TransactionType determineTransactionType(
+    int selfInputCount,
+    int selfOutputCount,
+    int inputCount,
+    int outputCount,
+  ) {
     if (selfInputCount == 0) {
       return TransactionType.received;
     }
@@ -159,12 +173,17 @@ class TransactionRecordService {
   }
 
   /// 트랜잭션 레코드를 조회합니다.
-  Future<Result<TransactionRecord>> getTransactionRecord(WalletItemBase walletItem, String txHash) async {
-    Logger.log('TransactionRecordService: getTransactionRecord called (txHash: $txHash, walletId: ${walletItem.id})');
+  Future<Result<TransactionRecord>> getTransactionRecord(
+    WalletItemBase walletItem,
+    String txHash,
+  ) async {
+    Logger.log(
+      'TransactionRecordService: getTransactionRecord called (txHash: $txHash, walletId: ${walletItem.id})',
+    );
     try {
-      final txRaw = await _electrumService.getTransaction(txHash);
+      final txRaw = await _chainSource.getTransaction(txHash);
       final tx = Transaction.parse(txRaw);
-      final previousTxs = await _electrumService.getPreviousTransactions(tx);
+      final previousTxs = await _chainSource.getPreviousTransactions(tx);
       final txDetails = processTransactionDetails(tx, previousTxs, walletItem.id);
       final blockTimestamp = await getTxHeight(
         walletItem.id,
@@ -203,7 +222,7 @@ class TransactionRecordService {
     TransactionDetails txDetails,
   ) async {
     final address = _findWalletRelatedAddress(walletId, txDetails);
-    final history = await _electrumService.getHistory(addressType, address);
+    final history = await _chainSource.getHistory(addressType, address);
 
     if (history.isEmpty) {
       return BlockTimestamp(0, DateTime.now());
@@ -215,7 +234,7 @@ class TransactionRecordService {
       return BlockTimestamp(0, DateTime.now());
     }
 
-    return await _electrumService.getBlockTimestamp(height);
+    return await _chainSource.getBlockTimestamp(height);
   }
 
   /// 지갑과 관련된 주소를 찾습니다.
@@ -272,7 +291,11 @@ class TransactionRecordService {
       final blockTimestamp = fetchedTransactionDetails.blockTimestampMap[blockHeight];
 
       // 이전 트랜잭션들을 맵에서 조회
-      final prevTxs = tx.inputs.map((input) => previousTxsMap[input.transactionHash]).whereType<Transaction>().toList();
+      final prevTxs =
+          tx.inputs
+              .map((input) => previousTxsMap[input.transactionHash])
+              .whereType<Transaction>()
+              .toList();
 
       final txDetails = processTransactionDetails(tx, prevTxs, walletId);
 
@@ -307,7 +330,7 @@ class TransactionRecordService {
     for (final chunk in chunks) {
       final futures = chunk.map((txHash) async {
         try {
-          final txHex = await _electrumService.getTransaction(txHash);
+          final txHex = await _chainSource.getTransaction(txHash);
           final tx = Transaction.parse(txHex);
           return MapEntry(txHash, tx);
         } catch (e) {

--- a/lib/providers/node_provider/transaction/transaction_sync_service.dart
+++ b/lib/providers/node_provider/transaction/transaction_sync_service.dart
@@ -10,7 +10,7 @@ import 'package:coconut_wallet/providers/node_provider/transaction/rbf_service.d
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_record_service.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/fetch_transaction_response.dart';
 import 'package:coconut_wallet/utils/logger.dart';
@@ -32,7 +32,7 @@ typedef RbfCpfpDetectionResult =
 
 /// 트랜잭션 조회를 담당하는 클래스
 class TransactionSyncService {
-  final ElectrumService _electrumService;
+  final ChainSource _chainSource;
   final TransactionRepository _transactionRepository;
   final TransactionRecordService _transactionRecordService;
   final StateManagerInterface _stateManager;
@@ -42,14 +42,14 @@ class TransactionSyncService {
   final ScriptCallbackService _scriptCallbackService;
 
   TransactionSyncService(
-    this._electrumService,
+    this._chainSource,
     this._transactionRepository,
     this._transactionRecordService,
     this._stateManager,
     this._utxoRepository,
     this._scriptCallbackService,
-  ) : _rbfService = RbfService(_transactionRepository, _utxoRepository, _electrumService),
-      _cpfpService = CpfpService(_transactionRepository, _utxoRepository, _electrumService);
+  ) : _rbfService = RbfService(_transactionRepository, _utxoRepository, _chainSource),
+      _cpfpService = CpfpService(_transactionRepository, _utxoRepository, _chainSource);
 
   /// 특정 스크립트의 트랜잭션을 조회하고 DB에 업데이트합니다.
   Future<List<String>> fetchScriptTransaction(
@@ -87,7 +87,11 @@ class TransactionSyncService {
         txFetchResults.where((tx) => tx.height > 0).map((tx) => tx.transactionHash).toSet();
 
     // 2. 처리 대상 트랜잭션 식별 및 등록
-    final Set<String> newTxHashes = _registerProcessableTransactions(walletId, txFetchResults, _scriptCallbackService);
+    final Set<String> newTxHashes = _registerProcessableTransactions(
+      walletId,
+      txFetchResults,
+      _scriptCallbackService,
+    );
 
     if (newTxHashes.isEmpty) {
       await _finalizeTransactionFetch(walletId, newTxHashes, inBatchProcess);
@@ -98,15 +102,12 @@ class TransactionSyncService {
     final FetchedTransactionDetails fetchedTransactionDetails = await _fetchTransactionDetails(
       newTxHashes,
       txFetchResults,
-      _electrumService,
+      _chainSource,
     );
 
     // 4. 트랜잭션 레코드 생성 및 저장
-    final List<TransactionRecord> txRecords = await _transactionRecordService.createTransactionRecords(
-      walletId,
-      fetchedTransactionDetails,
-      now: now,
-    );
+    final List<TransactionRecord> txRecords = await _transactionRecordService
+        .createTransactionRecords(walletId, fetchedTransactionDetails, now: now);
     await _transactionRepository.addAllTransactions(walletItem.id, txRecords);
 
     // 5. UTXO 상태 업데이트 및 RBF/CPFP 처리
@@ -121,7 +122,10 @@ class TransactionSyncService {
     await _saveRbfAndCpfpHistory(walletItem, txRecords, rbfCpfpResult);
 
     // 7. 대체된 언컨펌 트랜잭션 삭제
-    await _cleanupOrphanedUnconfirmedTransactions(walletId, fetchedTransactionDetails.fetchedTransactions);
+    await _cleanupOrphanedUnconfirmedTransactions(
+      walletId,
+      fetchedTransactionDetails.fetchedTransactions,
+    );
 
     // 8. 마무리 단계
     await _finalizeTransactionFetch(walletId, newTxHashes, inBatchProcess);
@@ -149,7 +153,11 @@ class TransactionSyncService {
         txHashKey: getTxHashKey(walletId, txFetchResult.transactionHash),
         isConfirmed: isConfirmed,
       )) {
-        scriptCallbackManager.registerTransactionProcessing(walletId, txFetchResult.transactionHash, isConfirmed);
+        scriptCallbackManager.registerTransactionProcessing(
+          walletId,
+          txFetchResult.transactionHash,
+          isConfirmed,
+        );
         newTxHashes.add(txFetchResult.transactionHash);
       }
     }
@@ -160,18 +168,21 @@ class TransactionSyncService {
   Future<FetchedTransactionDetails> _fetchTransactionDetails(
     Set<String> newTxHashes,
     List<FetchTransactionResponse> allTxFetchResults,
-    ElectrumService electrumService,
+    ChainSource chainSource,
   ) async {
-    final filteredTxFetchResults = allTxFetchResults.where((tx) => newTxHashes.contains(tx.transactionHash)).toList();
+    final filteredTxFetchResults =
+        allTxFetchResults.where((tx) => newTxHashes.contains(tx.transactionHash)).toList();
 
     final txBlockHeightMap = Map<String, int>.fromEntries(
-      filteredTxFetchResults.where((tx) => tx.height > 0).map((tx) => MapEntry(tx.transactionHash, tx.height)),
+      filteredTxFetchResults
+          .where((tx) => tx.height > 0)
+          .map((tx) => MapEntry(tx.transactionHash, tx.height)),
     );
 
     final blockTimestampMap =
         txBlockHeightMap.isEmpty
             ? <int, BlockTimestamp>{}
-            : await electrumService.fetchBlocksByHeight(txBlockHeightMap.values.toSet());
+            : await chainSource.fetchBlocksByHeight(txBlockHeightMap.values.toSet());
 
     final fetchedTransactions = await fetchTransactions(newTxHashes);
 
@@ -201,7 +212,10 @@ class TransactionSyncService {
           outgoingingRbfInfoMap[fetchedTx.transactionHash] = outgoingRbfInfo;
         }
 
-        final replacedTxHashByIncomingRbf = await _rbfService.detectIncomingRbfTransaction(walletId, fetchedTx);
+        final replacedTxHashByIncomingRbf = await _rbfService.detectIncomingRbfTransaction(
+          walletId,
+          fetchedTx,
+        );
         if (replacedTxHashByIncomingRbf != null) {
           replacedTxHashSetByIncomingRbf.add(replacedTxHashByIncomingRbf);
         }
@@ -266,12 +280,20 @@ class TransactionSyncService {
     }
 
     if (rbfCpfpResult.cpfpInfoMap.isNotEmpty) {
-      await _cpfpService.saveCpfpHistoryMap(walletItem, rbfCpfpResult.cpfpInfoMap, txRecordMap, walletId);
+      await _cpfpService.saveCpfpHistoryMap(
+        walletItem,
+        rbfCpfpResult.cpfpInfoMap,
+        txRecordMap,
+        walletId,
+      );
     }
   }
 
   /// 7. 대체된 언컨펌 트랜잭션 삭제
-  Future<void> _cleanupOrphanedUnconfirmedTransactions(int walletId, List<Transaction> newTxs) async {
+  Future<void> _cleanupOrphanedUnconfirmedTransactions(
+    int walletId,
+    List<Transaction> newTxs,
+  ) async {
     final unconfirmedTxs = _transactionRepository.getUnconfirmedTransactionRecordList(walletId);
     final toDeleteTxs = <String>[];
 
@@ -279,25 +301,32 @@ class TransactionSyncService {
       Transaction? unconfirmedTx;
       try {
         unconfirmedTx = Transaction.parse(
-          await _electrumService.getTransaction(localUnconfirmedTxRecord.transactionHash),
+          await _chainSource.getTransaction(localUnconfirmedTxRecord.transactionHash),
         );
       } catch (e) {
         // 언컨펌 트랜잭션을 다시 조회해서 실패한 경우 대체된 것으로 간주
-        Logger.log('Transaction ${localUnconfirmedTxRecord.transactionHash} not found, marking for deletion.');
+        Logger.log(
+          'Transaction ${localUnconfirmedTxRecord.transactionHash} not found, marking for deletion.',
+        );
         toDeleteTxs.add(localUnconfirmedTxRecord.transactionHash);
         continue;
       }
 
       // 새로운 트랜잭션들을 순회하면서 인풋이 겹치는 것이 있는지 확인
-      final unconfirmedInputs = unconfirmedTx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
+      final unconfirmedInputs =
+          unconfirmedTx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
       for (final newTx in newTxs) {
-        final newTxInputs = newTx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
+        final newTxInputs =
+            newTx.inputs.map((input) => '${input.transactionHash}:${input.index}').toSet();
         final overlappingInputs = unconfirmedInputs.intersection(newTxInputs);
 
         // 겹치는 인풋이 있으면서 새 트랜잭션의 수수료율이 더 높다면 로컬의 언컨펌 트랜잭션은 대체된 것으로 간주
         if (overlappingInputs.isNotEmpty) {
           if (unconfirmedTx.transactionHash != newTx.transactionHash) {
-            final newTxRecord = _transactionRepository.getTransactionRecord(walletId, newTx.transactionHash);
+            final newTxRecord = _transactionRepository.getTransactionRecord(
+              walletId,
+              newTx.transactionHash,
+            );
 
             if (newTxRecord != null && localUnconfirmedTxRecord.feeRate < newTxRecord.feeRate) {
               toDeleteTxs.add(localUnconfirmedTxRecord.transactionHash);
@@ -322,7 +351,11 @@ class TransactionSyncService {
   }
 
   /// 8. 마무리 단계: 상태 업데이트 및 완료 등록
-  Future<void> _finalizeTransactionFetch(int walletId, Set<String> newTxHashes, bool inBatchProcess) async {
+  Future<void> _finalizeTransactionFetch(
+    int walletId,
+    Set<String> newTxHashes,
+    bool inBatchProcess,
+  ) async {
     if (!inBatchProcess) {
       _stateManager.addWalletCompletedState(walletId, UpdateElement.transaction);
     }
@@ -338,7 +371,7 @@ class TransactionSyncService {
     Set<String> knownTransactionHashes,
   ) async {
     try {
-      final historyList = await _electrumService.getHistory(addressType, scriptStatus.address);
+      final historyList = await _chainSource.getHistory(addressType, scriptStatus.address);
 
       if (historyList.isEmpty) {
         return [];
@@ -372,7 +405,7 @@ class TransactionSyncService {
 
     final futures = transactionHashes.map((txHash) async {
       try {
-        final txHex = await _electrumService.getTransaction(txHash);
+        final txHex = await _chainSource.getTransaction(txHash);
         return Transaction.parse(txHex);
       } catch (e) {
         Logger.error('Failed to fetch transaction $txHash: $e');
@@ -397,7 +430,9 @@ class TransactionSyncService {
     final Map<ScriptStatus, List<String>> results = {};
 
     Logger.performance('=== BATCH PERFORMANCE ANALYSIS ===');
-    Logger.performance('Starting batch transaction fetch for ${scriptStatuses.length} scripts (wallet: $walletId)');
+    Logger.performance(
+      'Starting batch transaction fetch for ${scriptStatuses.length} scripts (wallet: $walletId)',
+    );
 
     try {
       // 1. 초기화 및 준비 단계
@@ -408,7 +443,9 @@ class TransactionSyncService {
 
       // 2. 모든 스크립트의 히스토리 조회 (병렬)
       final historyStartTime = DateTime.now();
-      final knownTransactionHashes = _transactionRepository.getConfirmedTransactionHashSet(walletId);
+      final knownTransactionHashes = _transactionRepository.getConfirmedTransactionHashSet(
+        walletId,
+      );
       final dbReadDuration = DateTime.now().difference(historyStartTime);
       Logger.performance('DB read (knownTransactionHashes): ${dbReadDuration.inMilliseconds}ms');
 
@@ -436,7 +473,9 @@ class TransactionSyncService {
       }
       final collectionDuration = DateTime.now().difference(collectionStartTime);
       Logger.performance('Data collection: ${collectionDuration.inMilliseconds}ms');
-      Logger.performance('Found ${allTxHashes.length} total transactions across ${scriptStatuses.length} scripts');
+      Logger.performance(
+        'Found ${allTxHashes.length} total transactions across ${scriptStatuses.length} scripts',
+      );
 
       if (allTxHashes.isEmpty) {
         await _finalizeTransactionFetch(walletId, {}, inBatchProcess);
@@ -445,7 +484,11 @@ class TransactionSyncService {
 
       // 4. 처리 대상 트랜잭션 식별
       final identifyStartTime = DateTime.now();
-      final newTxHashes = _registerProcessableTransactionsBatch(walletId, allTxFetchResults, _scriptCallbackService);
+      final newTxHashes = _registerProcessableTransactionsBatch(
+        walletId,
+        allTxFetchResults,
+        _scriptCallbackService,
+      );
       final identifyDuration = DateTime.now().difference(identifyStartTime);
       Logger.performance('Transaction identification: ${identifyDuration.inMilliseconds}ms');
       Logger.performance('Identified ${newTxHashes.length} new transactions to process');
@@ -460,7 +503,7 @@ class TransactionSyncService {
       final fetchedTransactionDetails = await _fetchTransactionDetailsBatch(
         newTxHashes,
         allTxFetchResults,
-        _electrumService,
+        _chainSource,
       );
       final detailsDuration = DateTime.now().difference(detailsStartTime);
       Logger.performance(
@@ -506,7 +549,10 @@ class TransactionSyncService {
 
       // 9. 대체된 언컨펌 트랜잭션 삭제
       final cleanupStartTime = DateTime.now();
-      await _cleanupOrphanedUnconfirmedTransactions(walletId, fetchedTransactionDetails.fetchedTransactions);
+      await _cleanupOrphanedUnconfirmedTransactions(
+        walletId,
+        fetchedTransactionDetails.fetchedTransactions,
+      );
       final cleanupDuration = DateTime.now().difference(cleanupStartTime);
       Logger.performance('Cleanup orphaned transactions: ${cleanupDuration.inMilliseconds}ms');
 
@@ -558,7 +604,7 @@ class TransactionSyncService {
 
     // 병렬로 히스토리 조회
     final futures = scriptStatuses.map((scriptStatus) async {
-      final historyList = await _electrumService.getHistory(addressType, scriptStatus.address);
+      final historyList = await _chainSource.getHistory(addressType, scriptStatus.address);
       return MapEntry(scriptStatus, historyList);
     });
 
@@ -604,7 +650,9 @@ class TransactionSyncService {
       final scriptStatus = entry.key;
       final historyList = entry.value;
 
-      final filteredHistoryList = historyList.where((history) => newTxHashes.contains(history.txHash));
+      final filteredHistoryList = historyList.where(
+        (history) => newTxHashes.contains(history.txHash),
+      );
 
       results[scriptStatus] =
           filteredHistoryList
@@ -639,7 +687,7 @@ class TransactionSyncService {
     for (final chunk in chunks) {
       final futures = chunk.map((txHash) async {
         try {
-          final txHex = await _electrumService.getTransaction(txHash);
+          final txHex = await _chainSource.getTransaction(txHash);
           return Transaction.parse(txHex);
         } catch (e) {
           Logger.error('Failed to fetch transaction $txHash: $e');
@@ -655,14 +703,16 @@ class TransactionSyncService {
   }
 
   /// 중복 제거된 블록 높이들을 한 번에 조회
-  Future<Map<int, BlockTimestamp>> fetchBlockTimestampsBatch(Map<String, int> txBlockHeightMap) async {
+  Future<Map<int, BlockTimestamp>> fetchBlockTimestampsBatch(
+    Map<String, int> txBlockHeightMap,
+  ) async {
     final uniqueBlockHeights = txBlockHeightMap.values.toSet();
 
     if (uniqueBlockHeights.isEmpty) {
       return <int, BlockTimestamp>{};
     }
 
-    return await _electrumService.fetchBlocksByHeight(uniqueBlockHeights);
+    return await _chainSource.fetchBlocksByHeight(uniqueBlockHeights);
   }
 
   /// 4. 처리 대상 트랜잭션 식별 (배치 버전)
@@ -679,7 +729,11 @@ class TransactionSyncService {
         txHashKey: getTxHashKey(walletId, txFetchResult.transactionHash),
         isConfirmed: isConfirmed,
       )) {
-        scriptCallbackManager.registerTransactionProcessing(walletId, txFetchResult.transactionHash, isConfirmed);
+        scriptCallbackManager.registerTransactionProcessing(
+          walletId,
+          txFetchResult.transactionHash,
+          isConfirmed,
+        );
         newTxHashes.add(txFetchResult.transactionHash);
       }
     }
@@ -691,19 +745,24 @@ class TransactionSyncService {
   Future<FetchedTransactionDetails> _fetchTransactionDetailsBatch(
     Set<String> newTxHashes,
     List<FetchTransactionResponse> allTxFetchResults,
-    ElectrumService electrumService,
+    ChainSource chainSource,
   ) async {
     // 새로운 트랜잭션만 필터링
-    final filteredTxFetchResults = allTxFetchResults.where((tx) => newTxHashes.contains(tx.transactionHash)).toList();
+    final filteredTxFetchResults =
+        allTxFetchResults.where((tx) => newTxHashes.contains(tx.transactionHash)).toList();
 
     // 블록 높이 맵 생성 (컨펌된 트랜잭션만)
     final txBlockHeightMap = Map<String, int>.fromEntries(
-      filteredTxFetchResults.where((tx) => tx.height > 0).map((tx) => MapEntry(tx.transactionHash, tx.height)),
+      filteredTxFetchResults
+          .where((tx) => tx.height > 0)
+          .map((tx) => MapEntry(tx.transactionHash, tx.height)),
     );
 
     // 블록 타임스탬프 조회 (병렬 처리)
     final blockTimestampMap =
-        txBlockHeightMap.isEmpty ? <int, BlockTimestamp>{} : await fetchBlockTimestampsBatch(txBlockHeightMap);
+        txBlockHeightMap.isEmpty
+            ? <int, BlockTimestamp>{}
+            : await fetchBlockTimestampsBatch(txBlockHeightMap);
 
     // 트랜잭션 상세 정보 조회 (병렬 처리)
     final fetchedTransactions = await fetchTransactionsBatch(newTxHashes);

--- a/lib/providers/node_provider/utxo_sync_service.dart
+++ b/lib/providers/node_provider/utxo_sync_service.dart
@@ -5,7 +5,7 @@ import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/wallet_item_base.dart';
 import 'package:coconut_wallet/repository/realm/service/realm_id_service.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 import 'package:coconut_wallet/providers/node_provider/state/state_manager_interface.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
@@ -13,14 +13,14 @@ import 'package:coconut_wallet/repository/realm/address_repository.dart';
 
 /// NodeProvider의 UTXO 관련 기능을 담당하는 서비스 클래스
 class UtxoSyncService {
-  final ElectrumService _electrumService;
+  final ChainSource _chainSource;
   final StateManagerInterface _stateManager;
   final UtxoRepository _utxoRepository;
   final TransactionRepository _transactionRepository;
   final AddressRepository _addressRepository;
 
   UtxoSyncService(
-    this._electrumService,
+    this._chainSource,
     this._stateManager,
     this._utxoRepository,
     this._transactionRepository,
@@ -46,9 +46,12 @@ class UtxoSyncService {
   }
 
   /// 스크립트에 대한 UTXO 목록을 가져옵니다.
-  Future<List<UtxoState>> fetchUtxoStateList(WalletItemBase walletItem, ScriptStatus scriptStatus) async {
+  Future<List<UtxoState>> fetchUtxoStateList(
+    WalletItemBase walletItem,
+    ScriptStatus scriptStatus,
+  ) async {
     try {
-      final unspentResList = await _electrumService.getUnspentList(
+      final unspentResList = await _chainSource.getUnspentList(
         walletItem.walletBase.addressType,
         scriptStatus.address,
       );
@@ -57,7 +60,9 @@ class UtxoSyncService {
         walletItem.id,
         unspentResList.map((unspentRes) => unspentRes.txHash).toSet(),
       );
-      final transactionMap = {for (var realmTx in realmTransactions) realmTx.transactionHash: realmTx};
+      final transactionMap = {
+        for (var realmTx in realmTransactions) realmTx.transactionHash: realmTx,
+      };
       final realmLockedUtxos = _utxoRepository.getUtxosByStatus(walletItem.id, UtxoStatus.locked);
       final lockedUtxoMap = {for (final utxo in realmLockedUtxos) utxo.transactionHash: utxo};
       return unspentResList
@@ -85,7 +90,9 @@ class UtxoSyncService {
           )
           .toList();
     } catch (e, stackTrace) {
-      Logger.error('Failed to get UTXO list - [${scriptStatus.derivationPath}-${scriptStatus.address}}] $e');
+      Logger.error(
+        'Failed to get UTXO list - [${scriptStatus.derivationPath}-${scriptStatus.address}}] $e',
+      );
       Logger.error('Stack trace: $stackTrace');
       return [];
     }
@@ -109,9 +116,13 @@ class UtxoSyncService {
   Future<void> createOutgoingUtxos(WalletItemBase walletItem) async {
     try {
       // 1. 언컨펌 출금 트랜잭션 목록 조회
-      final unconfirmedTransactions = _transactionRepository.getUnconfirmedTransactionRecordList(walletItem.id);
+      final unconfirmedTransactions = _transactionRepository.getUnconfirmedTransactionRecordList(
+        walletItem.id,
+      );
       final sentTransactions =
-          unconfirmedTransactions.where((tx) => tx.transactionType == TransactionType.sent).toList();
+          unconfirmedTransactions
+              .where((tx) => tx.transactionType == TransactionType.sent)
+              .toList();
 
       // 언컨펌 sent 트랜잭션이 없으면 처리 필요 없음
       if (sentTransactions.isEmpty) {
@@ -126,11 +137,11 @@ class UtxoSyncService {
 
       // 3. 각 트랜잭션에 대해 트랜잭션 상세 정보 조회
       for (final txRecord in sentTransactions) {
-        final txHex = await _electrumService.getTransaction(txRecord.transactionHash);
+        final txHex = await _chainSource.getTransaction(txRecord.transactionHash);
         final transaction = Transaction.parse(txHex);
 
         // 4. 이전 트랜잭션 조회 (트랜잭션의 입력으로 사용된 트랜잭션)
-        final previousTxs = await _electrumService.getPreviousTransactions(transaction);
+        final previousTxs = await _chainSource.getPreviousTransactions(transaction);
 
         if (previousTxs.isEmpty) {
           continue; // 이전 트랜잭션을 찾을 수 없으면 처리 불가
@@ -147,7 +158,9 @@ class UtxoSyncService {
 
           Transaction? previousTx;
           try {
-            previousTx = previousTxs.firstWhere((prevTx) => prevTx.transactionHash == input.transactionHash);
+            previousTx = previousTxs.firstWhere(
+              (prevTx) => prevTx.transactionHash == input.transactionHash,
+            );
           } catch (_) {
             continue;
           }
@@ -189,12 +202,16 @@ class UtxoSyncService {
 
   /// orphaned UTXO를 정리합니다.
   Future<void> cleanupOrphanedUtxos(WalletItemBase walletItem) async {
-    final pendingUtxos = _utxoRepository.getUtxoStateList(walletItem.id).where((utxo) => utxo.isPending).toList();
+    final pendingUtxos =
+        _utxoRepository.getUtxoStateList(walletItem.id).where((utxo) => utxo.isPending).toList();
 
     final orphanUtxoSet = <UtxoState>{};
     for (final utxo in pendingUtxos) {
       if (utxo.status == UtxoStatus.outgoing && utxo.spentByTransactionHash != null) {
-        final tx = _transactionRepository.getTransactionRecord(walletItem.id, utxo.spentByTransactionHash!);
+        final tx = _transactionRepository.getTransactionRecord(
+          walletItem.id,
+          utxo.spentByTransactionHash!,
+        );
         if (tx == null || tx.blockHeight > 0) {
           orphanUtxoSet.add(utxo);
         }
@@ -207,7 +224,10 @@ class UtxoSyncService {
     }
 
     if (orphanUtxoSet.isNotEmpty) {
-      await _utxoRepository.deleteUtxoList(walletItem.id, orphanUtxoSet.map((utxo) => utxo.utxoId).toList());
+      await _utxoRepository.deleteUtxoList(
+        walletItem.id,
+        orphanUtxoSet.map((utxo) => utxo.utxoId).toList(),
+      );
     }
   }
 }

--- a/lib/services/chain_source.dart
+++ b/lib/services/chain_source.dart
@@ -1,0 +1,44 @@
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/enums/network_enums.dart';
+import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
+import 'package:coconut_wallet/services/model/response/electrum_response_types.dart';
+
+abstract class ChainSource {
+  //1. connect & close
+  Future<bool> connect(String host, int port, {bool ssl = true});
+  Future<void> close();
+  void setOnConnectionLostCallback(void Function() callback);
+  SocketConnectionStatus get connectionStatus;
+
+  //2. block / chain
+  Future<BlockHeaderSubscribe> getCurrentBlock();
+  Future<BlockTimestamp> getBlockTimestamp(int height);
+  Future<Map<int, BlockTimestamp>> fetchBlocksByHeight(Set<int> heights);
+
+  //3. script query
+  Future<GetBalanceRes> getBalance(AddressType addressType, String address);
+  Future<List<GetTxHistoryRes>> getHistory(AddressType addressType, String address);
+  Future<List<ListUnspentRes>> getUnspentList(AddressType addressType, String address);
+  Future<String?> subscribeScript(
+    AddressType addressType,
+    String address, {
+    required Function(String, String?) onUpdate,
+  });
+  Future<bool> unsubscribeScript(AddressType addressType, String address);
+
+  //4. transaction
+  Future<String> getTransaction(
+    String txHash, {
+    bool? verbose,
+    Duration timeout = const Duration(seconds: 5),
+  });
+  Future<List<Transaction>> getPreviousTransactions(
+    Transaction transaction, {
+    List<Transaction>? existingTxList,
+  });
+  Future<String> broadcast(String rawTransaction);
+
+  //5. fee
+  Future<num> estimateFee(int targetConfirmation);
+  Future<List<List<num>>> getMempoolFeeHistogram();
+}

--- a/lib/services/electrum_chain_source.dart
+++ b/lib/services/electrum_chain_source.dart
@@ -1,0 +1,114 @@
+import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
+
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/enums/network_enums.dart';
+import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
+import 'package:coconut_wallet/services/model/response/electrum_response_types.dart';
+
+class ElectrumChainSource implements ChainSource {
+  final ElectrumService _electrum;
+
+  ElectrumChainSource(this._electrum);
+
+  //1. connect & close
+  @override
+  Future<bool> connect(String host, int port, {bool ssl = true}) {
+    return _electrum.connect(host, port, ssl: ssl);
+  }
+
+  @override
+  Future<void> close() {
+    return _electrum.close();
+  }
+
+  @override
+  void setOnConnectionLostCallback(void Function() callback) {
+    _electrum.setOnConnectionLostCallback(callback);
+  }
+
+  @override
+  SocketConnectionStatus get connectionStatus {
+    return _electrum.connectionStatus;
+  }
+
+  //2.block  / chain
+  @override
+  Future<BlockHeaderSubscribe> getCurrentBlock() {
+    return _electrum.getCurrentBlock();
+  }
+
+  @override
+  Future<BlockTimestamp> getBlockTimestamp(int height) {
+    return _electrum.getBlockTimestamp(height);
+  }
+
+  @override
+  Future<Map<int, BlockTimestamp>> fetchBlocksByHeight(Set<int> heights) {
+    return _electrum.fetchBlocksByHeight(heights);
+  }
+
+  //3. script query
+  @override
+  Future<GetBalanceRes> getBalance(AddressType addressType, String address) {
+    return _electrum.getBalance(addressType, address);
+  }
+
+  @override
+  Future<List<GetTxHistoryRes>> getHistory(AddressType addressType, String address) {
+    return _electrum.getHistory(addressType, address);
+  }
+
+  @override
+  Future<List<ListUnspentRes>> getUnspentList(AddressType addressType, String address) {
+    return _electrum.getUnspentList(addressType, address);
+  }
+
+  @override
+  Future<String?> subscribeScript(
+    AddressType addressType,
+    String address, {
+    required Function(String, String?) onUpdate,
+  }) {
+    return _electrum.subscribeScript(addressType, address, onUpdate: onUpdate);
+  }
+
+  @override
+  Future<bool> unsubscribeScript(AddressType addressType, String address) {
+    return _electrum.unsubscribeScript(addressType, address);
+  }
+
+  //4. transaction
+  @override
+  Future<String> getTransaction(
+    String txHash, {
+    bool? verbose,
+    Duration timeout = const Duration(seconds: 5),
+  }) {
+    return _electrum.getTransaction(txHash, verbose: verbose, timeout: timeout);
+  }
+
+  @override
+  Future<List<Transaction>> getPreviousTransactions(
+    Transaction transaction, {
+    List<Transaction>? existingTxList,
+  }) {
+    return _electrum.getPreviousTransactions(transaction, existingTxList: existingTxList);
+  }
+
+  @override
+  Future<String> broadcast(String rawTransaction) {
+    return _electrum.broadcast(rawTransaction);
+  }
+
+  //5. fee
+  @override
+  Future<num> estimateFee(int targetConfirmation) {
+    return _electrum.estimateFee(targetConfirmation);
+  }
+
+  @override
+  Future<List<List<num>>> getMempoolFeeHistogram() {
+    return _electrum.getMempoolFeeHistogram();
+  }
+}

--- a/test/mock/script_sync_service_mock.dart
+++ b/test/mock/script_sync_service_mock.dart
@@ -23,7 +23,7 @@ import '../repository/realm/test_realm_manager.dart';
 
 class ScriptSyncServiceMock {
   static int callSubscribeWalletCount = 0;
-  static late MockElectrumService electrumService;
+  static late MockChainSource chainSource;
   static late NodeStateManager stateManager;
   static TestRealmManager? realmManager;
   static late UtxoRepository utxoRepository;
@@ -55,7 +55,7 @@ class ScriptSyncServiceMock {
   static void init() {
     NetworkType.setNetworkType(NetworkType.regtest);
     callSubscribeWalletCount = 0;
-    electrumService = MockElectrumService();
+    chainSource = MockChainSource();
     stateManager = NodeStateManager(
       () {},
       StreamController<NodeSyncState>.broadcast(),
@@ -79,19 +79,19 @@ class ScriptSyncServiceMock {
 
     // 의존성 순서를 고려한 매니저 초기화
     utxoSyncService = UtxoSyncService(
-      electrumService,
+      chainSource,
       stateManager,
       utxoRepository,
       transactionRepository,
       addressRepository,
     );
 
-    transactionRecordService = TransactionRecordService(electrumService, addressRepository);
+    transactionRecordService = TransactionRecordService(chainSource, addressRepository);
 
-    balanceSyncService = BalanceSyncService(electrumService, stateManager, addressRepository, walletRepository);
+    balanceSyncService = BalanceSyncService(chainSource, stateManager, addressRepository, walletRepository);
 
     transactionSyncService = TransactionSyncService(
-      electrumService,
+      chainSource,
       transactionRepository,
       transactionRecordService,
       stateManager,

--- a/test/providers/node_provider/subscription/script_sync_service/setup.dart
+++ b/test/providers/node_provider/subscription/script_sync_service/setup.dart
@@ -45,25 +45,25 @@ class _ScriptSyncTestSetup {
   }
 
   static void setupMockElectrumService(_ScriptSyncTestData testData) {
-    final electrumService = ScriptSyncServiceMock.electrumService;
+    final chainSource = ScriptSyncServiceMock.chainSource;
 
-    when(electrumService.getHistory(any, any)).thenAnswer(
+    when(chainSource.getHistory(any, any)).thenAnswer(
       (_) async => [GetTxHistoryRes(height: _TestConstants.blockHeight, txHash: testData.mockTx.transactionHash)],
     );
 
     when(
-      electrumService.getTransaction(testData.mockTx.transactionHash),
+      chainSource.getTransaction(testData.mockTx.transactionHash),
     ).thenAnswer((_) async => testData.mockTx.serialize());
 
     when(
-      electrumService.getBalance(any, any),
+      chainSource.getBalance(any, any),
     ).thenAnswer((_) async => GetBalanceRes(confirmed: 0, unconfirmed: _TestConstants.transactionAmount));
 
     when(
-      electrumService.fetchBlocksByHeight({_TestConstants.blockHeight}),
+      chainSource.fetchBlocksByHeight({_TestConstants.blockHeight}),
     ).thenAnswer((_) async => {_TestConstants.blockHeight: BlockTimestamp(_TestConstants.blockHeight, DateTime.now())});
 
-    when(electrumService.getUnspentList(any, any)).thenAnswer((_) async {
+    when(chainSource.getUnspentList(any, any)).thenAnswer((_) async {
       return [
         ListUnspentRes(
           height: 0,
@@ -74,7 +74,7 @@ class _ScriptSyncTestSetup {
       ];
     });
 
-    when(electrumService.getPreviousTransactions(any, existingTxList: anyNamed('existingTxList'))).thenAnswer((
+    when(chainSource.getPreviousTransactions(any, existingTxList: anyNamed('existingTxList'))).thenAnswer((
       invocation,
     ) async {
       final transaction = invocation.positionalArguments[0] as Transaction;
@@ -109,9 +109,9 @@ class _ScriptSyncTestSetup {
         to: testData.walletA.walletBase.getAddress(_TestConstants.addressIndex),
       ),
     ]);
-    final electrumService = ScriptSyncServiceMock.electrumService;
+    final chainSource = ScriptSyncServiceMock.chainSource;
 
-    when(electrumService.fetchBlocksByHeight(any)).thenAnswer((invocation) async {
+    when(chainSource.fetchBlocksByHeight(any)).thenAnswer((invocation) async {
       final blockHeights = invocation.positionalArguments[0] as Set<int>;
       final result = <int, BlockTimestamp>{};
 
@@ -123,7 +123,7 @@ class _ScriptSyncTestSetup {
     });
 
     // 모든 트랜잭션에 대한 모킹 - transactionHash로 매칭
-    when(electrumService.getPreviousTransactions(any, existingTxList: anyNamed('existingTxList'))).thenAnswer((
+    when(chainSource.getPreviousTransactions(any, existingTxList: anyNamed('existingTxList'))).thenAnswer((
       invocation,
     ) async {
       final transaction = invocation.positionalArguments[0] as Transaction;
@@ -142,28 +142,28 @@ class _ScriptSyncTestSetup {
 
     // 개별 트랜잭션 직렬화 모킹
     when(
-      electrumService.getTransaction(testData.previousMockTx.transactionHash),
+      chainSource.getTransaction(testData.previousMockTx.transactionHash),
     ).thenAnswer((_) async => testData.previousMockTx.serialize());
 
     when(
-      electrumService.getTransaction(testData.mockTx.transactionHash),
+      chainSource.getTransaction(testData.mockTx.transactionHash),
     ).thenAnswer((_) async => testData.mockTx.serialize());
 
     if (testData.cpfpTx != null) {
       when(
-        electrumService.getTransaction(testData.cpfpTx!.transactionHash),
+        chainSource.getTransaction(testData.cpfpTx!.transactionHash),
       ).thenAnswer((_) async => testData.cpfpTx!.serialize());
     }
     if (testData.rbfTx != null) {
       when(
-        electrumService.getTransaction(testData.rbfTx!.transactionHash),
+        chainSource.getTransaction(testData.rbfTx!.transactionHash),
       ).thenAnswer((_) async => testData.rbfTx!.serialize());
     }
 
     // 기본 응답 설정
-    when(electrumService.getHistory(any, any)).thenAnswer((_) async => []);
-    when(electrumService.getBalance(any, any)).thenAnswer((_) async => GetBalanceRes(confirmed: 0, unconfirmed: 0));
-    when(electrumService.getUnspentList(any, any)).thenAnswer((_) async => []);
+    when(chainSource.getHistory(any, any)).thenAnswer((_) async => []);
+    when(chainSource.getBalance(any, any)).thenAnswer((_) async => GetBalanceRes(confirmed: 0, unconfirmed: 0));
+    when(chainSource.getUnspentList(any, any)).thenAnswer((_) async => []);
 
     // 초기 트랜잭션 추가
     final addressA = testData.walletA.walletBase.getAddress(_TestConstants.addressIndex);
@@ -176,12 +176,12 @@ class _ScriptSyncTestSetup {
     final txHistoryRes = GetTxHistoryRes(height: 0, txHash: testData.mockTx.transactionHash);
 
     when(
-      electrumService.getBalance(any, addressB),
+      chainSource.getBalance(any, addressB),
     ).thenAnswer((_) async => GetBalanceRes(confirmed: 0, unconfirmed: _TestConstants.transactionAmount));
-    when(electrumService.getHistory(any, addressA)).thenAnswer((_) async => [prevTxHistoryRes, txHistoryRes]);
-    when(electrumService.getHistory(any, addressB)).thenAnswer((_) async => [txHistoryRes]);
+    when(chainSource.getHistory(any, addressA)).thenAnswer((_) async => [prevTxHistoryRes, txHistoryRes]);
+    when(chainSource.getHistory(any, addressB)).thenAnswer((_) async => [txHistoryRes]);
 
-    when(electrumService.getUnspentList(any, addressB)).thenAnswer(
+    when(chainSource.getUnspentList(any, addressB)).thenAnswer(
       (_) async => [
         ListUnspentRes(
           height: 0,
@@ -194,7 +194,7 @@ class _ScriptSyncTestSetup {
   }
 
   static Future<void> setupCpfpEnvironment(_ScriptSyncTestData testData) async {
-    final electrumService = ScriptSyncServiceMock.electrumService;
+    final chainSource = ScriptSyncServiceMock.chainSource;
 
     final addressB = testData.walletB.walletBase.getAddress(_TestConstants.addressIndex);
     final changeAddressB = testData.walletB.walletBase.getAddress(_TestConstants.addressIndex, isChange: true);
@@ -209,28 +209,28 @@ class _ScriptSyncTestSetup {
       value: _TestConstants.transactionAmount - _TestConstants.cpfpFeeAmount,
     );
 
-    when(electrumService.getHistory(any, addressB)).thenAnswer((_) async => [txHistoryRes, cpfpTxHistoryRes]);
-    when(electrumService.getHistory(any, changeAddressB)).thenAnswer((_) async => [cpfpTxHistoryRes]);
+    when(chainSource.getHistory(any, addressB)).thenAnswer((_) async => [txHistoryRes, cpfpTxHistoryRes]);
+    when(chainSource.getHistory(any, changeAddressB)).thenAnswer((_) async => [cpfpTxHistoryRes]);
 
     when(
-      electrumService.getTransaction(testData.cpfpTx!.transactionHash),
+      chainSource.getTransaction(testData.cpfpTx!.transactionHash),
     ).thenAnswer((_) async => testData.cpfpTx!.serialize());
 
     when(
-      electrumService.getBalance(any, addressB),
+      chainSource.getBalance(any, addressB),
     ).thenAnswer((_) async => GetBalanceRes(confirmed: 0, unconfirmed: 0));
 
-    when(electrumService.getBalance(any, changeAddressB)).thenAnswer(
+    when(chainSource.getBalance(any, changeAddressB)).thenAnswer(
       (_) async =>
           GetBalanceRes(confirmed: 0, unconfirmed: _TestConstants.transactionAmount - _TestConstants.cpfpFeeAmount),
     );
 
-    when(electrumService.getUnspentList(any, addressB)).thenAnswer((_) async => []);
-    when(electrumService.getUnspentList(any, changeAddressB)).thenAnswer((_) async => [cpfpUnspentRes]);
+    when(chainSource.getUnspentList(any, addressB)).thenAnswer((_) async => []);
+    when(chainSource.getUnspentList(any, changeAddressB)).thenAnswer((_) async => [cpfpUnspentRes]);
   }
 
   static Future<void> setupRbfEnvironment(_ScriptSyncTestData testData) async {
-    final electrumService = ScriptSyncServiceMock.electrumService;
+    final chainSource = ScriptSyncServiceMock.chainSource;
 
     final addressA = testData.walletA.walletBase.getAddress(_TestConstants.addressIndex);
     final addressB = testData.walletB.walletBase.getAddress(_TestConstants.addressIndex);
@@ -238,15 +238,15 @@ class _ScriptSyncTestSetup {
     final rbfTxHistoryRes = GetTxHistoryRes(height: 0, txHash: testData.rbfTx!.transactionHash);
     final txHistoryRes = GetTxHistoryRes(height: 0, txHash: testData.mockTx.transactionHash);
 
-    when(electrumService.getHistory(any, addressA)).thenAnswer((_) async => [txHistoryRes, rbfTxHistoryRes]);
-    when(electrumService.getHistory(any, addressB)).thenAnswer((_) async => [rbfTxHistoryRes]);
+    when(chainSource.getHistory(any, addressA)).thenAnswer((_) async => [txHistoryRes, rbfTxHistoryRes]);
+    when(chainSource.getHistory(any, addressB)).thenAnswer((_) async => [rbfTxHistoryRes]);
 
     when(
-      electrumService.getTransaction(testData.rbfTx!.transactionHash),
+      chainSource.getTransaction(testData.rbfTx!.transactionHash),
     ).thenAnswer((_) async => testData.rbfTx!.serialize());
 
     when(
-      electrumService.getBalance(any, addressA),
+      chainSource.getBalance(any, addressA),
     ).thenAnswer((_) async => GetBalanceRes(confirmed: 0, unconfirmed: 0));
 
     final rbfUnspentRes = ListUnspentRes(
@@ -256,6 +256,6 @@ class _ScriptSyncTestSetup {
       value: _TestConstants.transactionAmount - _TestConstants.rbfFeeAmount,
     );
 
-    when(electrumService.getUnspentList(any, addressB)).thenAnswer((_) async => [rbfUnspentRes]);
+    when(chainSource.getUnspentList(any, addressB)).thenAnswer((_) async => [rbfUnspentRes]);
   }
 }

--- a/test/providers/node_provider/transaction/cpfp_service_test.dart
+++ b/test/providers/node_provider/transaction/cpfp_service_test.dart
@@ -9,7 +9,7 @@ import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/repository/realm/wallet_repository.dart';
 import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -21,14 +21,14 @@ import '../../../repository/realm/test_realm_manager.dart';
 import '../../../services/shared_prefs_service_test.mocks.dart';
 import 'rbf_service_test.mocks.dart';
 
-@GenerateMocks([ElectrumService])
+@GenerateMocks([ChainSource])
 void main() {
   group('CpfpService', () {
     TestRealmManager? realmManager;
     late TransactionRepository transactionRepository;
     late WalletRepository walletRepository;
     late UtxoRepository utxoRepository;
-    late MockElectrumService electrumService;
+    late MockChainSource electrumService;
     late CpfpService cpfpService;
 
     const int walletId = 1;
@@ -56,7 +56,7 @@ void main() {
       transactionRepository = TransactionRepository(realmManager!);
       utxoRepository = UtxoRepository(realmManager!);
       walletRepository = WalletRepository(realmManager!, TransactionDraftRepository(realmManager!));
-      electrumService = MockElectrumService();
+      electrumService = MockChainSource();
       cpfpService = CpfpService(transactionRepository, utxoRepository, electrumService);
       walletRepository.addSinglesigWallet(
         WatchOnlyWallet(

--- a/test/providers/node_provider/transaction/rbf_service_test.dart
+++ b/test/providers/node_provider/transaction/rbf_service_test.dart
@@ -11,7 +11,7 @@ import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/repository/realm/wallet_repository.dart';
 import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -24,7 +24,7 @@ import '../../../services/shared_prefs_service_test.mocks.dart';
 import 'rbf_service_test.mocks.dart';
 
 // 테스트에 필요한 모킹 클래스 생성
-@GenerateMocks([ElectrumService])
+@GenerateMocks([ChainSource])
 void main() {
   group('RbfService', () {
     TestRealmManager? realmManager;
@@ -32,7 +32,7 @@ void main() {
     late WalletRepository walletRepository;
     late AddressRepository addressRepository;
     late UtxoRepository utxoRepository;
-    late MockElectrumService electrumService;
+    late MockChainSource electrumService;
     late RbfService rbfService;
 
     const int walletId = 1;
@@ -85,7 +85,7 @@ void main() {
         ),
       );
       await addressRepository.ensureAddressesInit(walletItemBase: walletItem);
-      electrumService = MockElectrumService();
+      electrumService = MockChainSource();
       rbfService = RbfService(transactionRepository, utxoRepository, electrumService);
     });
 

--- a/test/providers/node_provider/transaction/transaction_record_service_test.dart
+++ b/test/providers/node_provider/transaction/transaction_record_service_test.dart
@@ -5,7 +5,7 @@ import 'package:coconut_wallet/model/wallet/transaction_record.dart';
 import 'package:coconut_wallet/providers/node_provider/transaction/transaction_record_service.dart';
 import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/electrum_response_types.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,13 +17,13 @@ import '../../../mock/wallet_mock.dart';
 import '../../../repository/realm/test_realm_manager.dart';
 
 // 모킹할 클래스 목록
-@GenerateMocks([ElectrumService])
+@GenerateMocks([ChainSource])
 import 'transaction_record_service_test.mocks.dart';
 
 void main() {
   late TestRealmManager realmManager;
   late AddressRepository addressRepository;
-  late MockElectrumService electrumService;
+  late MockChainSource electrumService;
   late TransactionRecordService transactionRecordService;
 
   const int testWalletId = 1;
@@ -37,7 +37,7 @@ void main() {
   setUp(() async {
     realmManager = await setupTestRealmManager();
     addressRepository = AddressRepository(realmManager);
-    electrumService = MockElectrumService();
+    electrumService = MockChainSource();
 
     transactionRecordService = TransactionRecordService(electrumService, addressRepository);
 

--- a/test/providers/node_provider/transaction/transaction_sync_service_test.dart
+++ b/test/providers/node_provider/transaction/transaction_sync_service_test.dart
@@ -11,7 +11,7 @@ import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/electrum_response_types.dart';
 import 'package:coconut_wallet/services/model/response/fetch_transaction_response.dart';
@@ -26,13 +26,13 @@ import '../../../mock/wallet_mock.dart';
 import '../../../repository/realm/test_realm_manager.dart';
 
 // 모킹할 클래스 목록
-@GenerateMocks([ElectrumService, NodeStateManager, WalletProvider])
+@GenerateMocks([ChainSource, NodeStateManager, WalletProvider])
 import 'transaction_sync_service_test.mocks.dart';
 
 void main() {
   late TestRealmManager realmManager;
   late TransactionRepository transactionRepository;
-  late MockElectrumService electrumService;
+  late MockChainSource electrumService;
   late MockNodeStateManager stateManager;
   late UtxoRepository utxoRepository;
   late AddressRepository addressRepository;
@@ -48,7 +48,7 @@ void main() {
     realmManager = await setupTestRealmManager();
     transactionRepository = TransactionRepository(realmManager);
     addressRepository = AddressRepository(realmManager);
-    electrumService = MockElectrumService();
+    electrumService = MockChainSource();
     stateManager = MockNodeStateManager();
     utxoRepository = UtxoRepository(realmManager);
     walletProvider = MockWalletProvider();

--- a/test/providers/node_provider/utxo/utxo_sync_service_test.dart
+++ b/test/providers/node_provider/utxo/utxo_sync_service_test.dart
@@ -6,7 +6,7 @@ import 'package:coconut_wallet/repository/realm/address_repository.dart';
 import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart';
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
-import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/chain_source.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 
@@ -15,7 +15,7 @@ import '../../../mock/wallet_mock.dart';
 import '../../../repository/realm/test_realm_manager.dart';
 
 // 모킹할 클래스 목록
-@GenerateMocks([ElectrumService, NodeStateManager])
+@GenerateMocks([ChainSource, NodeStateManager])
 import 'utxo_sync_service_test.mocks.dart';
 
 void main() {
@@ -23,7 +23,7 @@ void main() {
   late TransactionRepository transactionRepository;
   late UtxoRepository utxoRepository;
   late AddressRepository addressRepository;
-  late MockElectrumService electrumService;
+  late MockChainSource electrumService;
   late MockNodeStateManager stateManager;
   late UtxoSyncService utxoSyncService;
 
@@ -35,7 +35,7 @@ void main() {
     transactionRepository = TransactionRepository(realmManager);
     addressRepository = AddressRepository(realmManager);
     utxoRepository = UtxoRepository(realmManager);
-    electrumService = MockElectrumService();
+    electrumService = MockChainSource();
     stateManager = MockNodeStateManager();
 
     utxoSyncService = UtxoSyncService(


### PR DESCRIPTION
## 요약
ChainSource 추상 클래스 뒤에 체인 데이터 액세스를 분리하여
나중에 다른 소스(예: Floresta)를 추가할 수 있도록 합니다. 동작상의 변경 사항은 전혀 없습니다.

## 변경
- `lib/services/chain_source.dart`에 `ChainSource` 인터페이스(메서드 17개) 추가
- `lib/services/electrum_chain_source.dart`에 `ElectrumChainSource` 어댑터 추가
- 9개의 서비스와 `IsolateInitializer`/`IsolateManager`가 `ChainSource`에 의존하도록 변경
- `ChainSource`에 대한 테스트 mocks 재생성

## 테스트
- [x] `dart analyze` clean (새로운 오류 0개)
- [x] `fvm flutter test test/providers/node_provider/` 기존에 있던 i18n 오류만 발생함 (node_provider 관련 오류 없음)

## 체크리스트
- [x] `develop` 브랜치를 기반으로 함
- [x] 새로운 패키지가 추가되지 않음
- [x] `dart format . --set-exit-if-changed --line-length=100` 명령어가 성공적으로 실행됨
- [x] 커밋이 `refactor(chain):` 형식을 따름


## 참고

closes #734 

Deepseek V4의 도움을 받아 작성되었습니다.

