### PR TITLE
P2P 계산기 USD/EUR 소수점 입력 불가

### DIFF
--- a/lib/enums/fiat_enums.dart
+++ b/lib/enums/fiat_enums.dart
@@ -6,16 +6,27 @@ import 'package:coconut_wallet/localization/strings.g.dart';
 import '../utils/balance_format_util.dart';
 
 enum FiatCode {
-  KRW('KRW', 'South Korean Won', '₩'),
-  USD('USD', 'US Dollar', '\$'),
-  JPY('JPY', 'Japanese Yen', '¥'),
-  EUR('EUR', 'Euro', '€');
+  KRW('KRW', 'South Korean Won', '₩', 0),
+  USD('USD', 'US Dollar', '\$', 2),
+  JPY('JPY', 'Japanese Yen', '¥', 0),
+  EUR('EUR', 'Euro', '€', 2);
 
   final String code; // ISO 4217 코드
   final String fullName; // 통화 이름
   final String symbol;
+  final int decimalDigits; // ISO 4217 기준 소수 자리수 (예: KRW/JPY=0, USD/EUR=2)
 
-  const FiatCode(this.code, this.fullName, this.symbol);
+  const FiatCode(this.code, this.fullName, this.symbol, this.decimalDigits);
+
+  /// 1 whole unit를 최소단위(minor unit, 예: cent) 정수로 위해 필요한 배수 (10^decimalDigits)
+  /// 예: $1 = 100 cent -> decimalDigits = 2 (10^2 = 100)
+  int get minorUnitsPerWhole {
+    var result = 1;
+    for (var i = 0; i < decimalDigits; i++) {
+      result *= 10;
+    }
+    return result;
+  }
 
   // 메서드 추가 가능
   String description() {

--- a/lib/providers/view_model/utility/p2p_calculator_view_model.dart
+++ b/lib/providers/view_model/utility/p2p_calculator_view_model.dart
@@ -160,22 +160,26 @@ class P2PCalculatorViewModel extends ChangeNotifier {
   }
 
   /// Fiat → Sats 계산 (수수료 차감: × (1 - fee))
-  int calculateSatsFromFiat(int fiatAmount) {
+  /// [fiatMinorUnits]: 통화 최소단위(minor unit, 예: cent) 정수
+  int calculateSatsFromFiat(int fiatMinorUnits) {
     final price = _getBtcPrice();
     if (price == 0) return 0;
 
+    final minorUnitsPrice = price * _fiatCode.minorUnitsPerWhole;
     final discountMultiplier = 1.0 - (_feeRate / 100.0);
-    final btcAmount = (fiatAmount * discountMultiplier) / price;
+    final btcAmount = (fiatMinorUnits * discountMultiplier) / minorUnitsPrice;
     return (btcAmount * 100000000).round();
   }
 
   /// Sats → Fiat 계산 (수수료 추가: × (1 + fee))
+  /// 반환값은 통화 최소단위(minor unit, 예: cent) 정수
   int calculateFiatFromSats(int satsAmount) {
     final price = _getBtcPrice();
     if (price == 0) return 0;
+    final minorUnitsPrice = price * _fiatCode.minorUnitsPerWhole;
     final premiumMultiplier = 1.0 + (_feeRate / 100.0);
     final btcAmount = satsAmount / 100000000;
-    return (btcAmount * price * premiumMultiplier).round();
+    return (btcAmount * minorUnitsPrice * premiumMultiplier).round();
   }
 
   int _getBtcPrice() {
@@ -229,8 +233,8 @@ class P2PCalculatorViewModel extends ChangeNotifier {
         case FiatCode.EUR:
           inputValue = 50;
       }
-      // Fiat → Sats
-      final sats = calculateSatsFromFiat(inputValue);
+      // Fiat → Sats (inputValue는 whole unit 기준이므로 minor unit으로 변환)
+      final sats = calculateSatsFromFiat(inputValue * _fiatCode.minorUnitsPerWhole);
       return formatSatsResult(sats);
     } else {
       if (!_isNetworkOn) {
@@ -241,7 +245,7 @@ class P2PCalculatorViewModel extends ChangeNotifier {
       inputValue = 50000; // 50,000 sats = 0.0005 BTC
       // Sats → Fiat
       final fiat = calculateFiatFromSats(inputValue);
-      return fiat.toThousandsSeparatedString();
+      return formatFiatResult(fiat);
     }
   }
 
@@ -280,8 +284,9 @@ class P2PCalculatorViewModel extends ChangeNotifier {
     return result;
   }
 
-  String formatFiatResult(int fiat) {
-    return fiat.toThousandsSeparatedString();
+  /// [fiatMinorUnits]: 통화 최소단위(minor unit, 예: cent) 정수
+  String formatFiatResult(int fiatMinorUnits) {
+    return FiatUtil.formatMinorUnits(fiatMinorUnits, _fiatCode);
   }
 
   Future<void> onFiatUnitChange() async {

--- a/lib/screens/settings/tools/p2p_calculator_screen.dart
+++ b/lib/screens/settings/tools/p2p_calculator_screen.dart
@@ -180,11 +180,33 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     _updateResultOnPremiumChange();
   }
 
+  /// 현재 입력 필드가 소수점 입력을 허용해야 하는지 여부
+  /// - fiat: 통화의 소수 자리수(decimalDigits)가 0보다 클 때 (예: USD, EUR)
+  /// - btc: sats/BIP-177 기반이 아닌 BTC 단위일 때
+  bool get _amountInputAllowsDecimal {
+    if (_viewModel.inputAssetType == InputAssetType.fiat) {
+      return _viewModel.fiatCode.decimalDigits > 0;
+    }
+    return !_viewModel.currentUnit.isBasedOnSatoshi;
+  }
+
+  List<TextInputFormatter> _amountInputFormatters() {
+    if (_viewModel.inputAssetType == InputAssetType.fiat) {
+      final decimalDigits = _viewModel.fiatCode.decimalDigits;
+      return decimalDigits > 0
+          ? [FiatAmountInputFormatter(decimalPlaces: decimalDigits)]
+          : [FilteringTextInputFormatter.digitsOnly];
+    }
+    if (!_viewModel.currentUnit.isBasedOnSatoshi) {
+      return [const BtcAmountInputFormatter()];
+    }
+    return [FilteringTextInputFormatter.digitsOnly];
+  }
+
   void _handleAmountInputChanged(String value) {
     if (_isUpdatingController) return; // 무한 루프 방지
 
-    final isBtcInput = _viewModel.inputAssetType == InputAssetType.btc && !_viewModel.currentUnit.isBasedOnSatoshi;
-    final sanitized = _sanitizeInput(value, isBtcInput);
+    final sanitized = _sanitizeInput(value, _amountInputAllowsDecimal);
 
     if (sanitized.isEmpty) {
       _viewModel.setInputAmount(null);
@@ -200,7 +222,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     final shouldUpdateController = value != _inputController.text;
 
     if (_viewModel.inputAssetType == InputAssetType.fiat) {
-      _processFiatInput(sanitized);
+      _processFiatInput(sanitized, shouldUpdateController: shouldUpdateController);
     } else if (_viewModel.currentUnit.isBasedOnSatoshi) {
       _processSatsInput(sanitized);
     } else {
@@ -210,25 +232,53 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     setState(() {});
   }
 
-  void _processFiatInput(String sanitized) {
-    var value = sanitized.toIntSafe() ?? 0;
+  void _processFiatInput(String sanitized, {required bool shouldUpdateController}) {
+    final fiatCode = _viewModel.fiatCode;
+    var fiatText = filterNumericInput(sanitized, decimalPlaces: fiatCode.decimalDigits);
+    var minorUnits = _parseFiatTextToMinorUnits(fiatText);
 
     if (_viewModel.btcPrice != null && _viewModel.btcPrice! > 0) {
-      final btcFromFiat = value / _viewModel.btcPrice!;
+      final minorUnitsPrice = _viewModel.btcPrice! * fiatCode.minorUnitsPerWhole;
+      final btcFromFiat = minorUnits / minorUnitsPrice;
       if (btcFromFiat > _maxBtc) {
-        value = (_maxBtc * _viewModel.btcPrice!).round();
+        minorUnits = (_maxBtc * minorUnitsPrice).round();
+        fiatText = (minorUnits / fiatCode.minorUnitsPerWhole).toStringAsFixed(fiatCode.decimalDigits);
       }
     }
 
-    _viewModel.setInputAmount(value);
+    // decimalDigits==0인 통화(KRW/JPY)는 입력 필드에 digitsOnly 포매터만 붙어 있어
+    // 그룹 구분자(,)를 스스로 넣어주지 않으므로 매 입력마다 직접 그룹 포맷을 적용해야 한다.
+    // decimalDigits>0인 통화(USD/EUR)는 FiatAmountInputFormatter가 이미 타이핑 중에
+    // 그룹/소수점을 실시간으로 처리하므로, 프로그래매틱 갱신(Quick Add 등)일 때만 갱신한다.
+    if (fiatCode.decimalDigits == 0 || shouldUpdateController) {
+      final formatted = _formatFiatInputText(fiatText);
+      _isUpdatingController = true;
+      _inputController.value = TextEditingValue(
+        text: formatted,
+        selection: TextSelection.collapsed(offset: formatted.length),
+      );
+      _isUpdatingController = false;
+    }
 
-    final formatted = value.toThousandsSeparatedString();
-    _isUpdatingController = true;
-    _inputController.value = TextEditingValue(
-      text: formatted,
-      selection: TextSelection.collapsed(offset: formatted.length),
-    );
-    _isUpdatingController = false;
+    _viewModel.setInputAmount(minorUnits);
+  }
+
+  /// fiatText(예: "50.25")를 통화 최소단위(minor unit, 예: cent) 정수로 변환
+  int _parseFiatTextToMinorUnits(String fiatText) {
+    if (fiatText.isEmpty || fiatText == '.') return 0;
+    final value = fiatText.toDoubleSafe() ?? 0;
+    return (value * _viewModel.fiatCode.minorUnitsPerWhole).round();
+  }
+
+  String _formatFiatInputText(String fiatText) {
+    final decimalDigits = _viewModel.fiatCode.decimalDigits;
+    final displayText = _formatLocaleDecimalText(fiatText);
+    return FiatAmountInputFormatter(decimalPlaces: decimalDigits)
+        .formatEditUpdate(
+          const TextEditingValue(),
+          TextEditingValue(text: displayText, selection: TextSelection.collapsed(offset: displayText.length)),
+        )
+        .text;
   }
 
   void _processBtcInput(String sanitized, {required bool shouldUpdateController}) {
@@ -468,8 +518,8 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     _isUpdatingController = true;
 
     if (_viewModel.inputAssetType == InputAssetType.fiat) {
-      // BTC → Fiat로 전환: 정수 포맷
-      final formatted = result.toThousandsSeparatedString();
+      // BTC → Fiat로 전환: result는 통화 최소단위(minor unit) 정수
+      final formatted = _viewModel.formatFiatResult(result);
       _inputController.value = TextEditingValue(
         text: formatted,
         selection: TextSelection.collapsed(offset: formatted.length),
@@ -496,8 +546,8 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     _isUpdatingController = false;
   }
 
-  String _sanitizeInput(String value, bool isBtcInput) {
-    if (!isBtcInput) {
+  String _sanitizeInput(String value, bool allowDecimal) {
+    if (!allowDecimal) {
       return value.replaceAll(RegExp(r'[^0-9]'), '');
     } else {
       final normalizedValue = normalizeNumTextForNumParsing(value);
@@ -573,8 +623,8 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     final btcPriceStr = _viewModel.btcPrice?.toThousandsSeparatedString() ?? '-';
     final fiatAmountStr =
         _viewModel.inputAssetType == InputAssetType.fiat
-            ? input.toThousandsSeparatedString()
-            : result.toThousandsSeparatedString();
+            ? _viewModel.formatFiatResult(input)
+            : _viewModel.formatFiatResult(result);
     final btcAmountStr =
         _viewModel.inputAssetType == InputAssetType.fiat
             ? _viewModel.formatSatsResult(result)
@@ -583,12 +633,10 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     final premiumRateStr = '$premiumRateValueStr%';
 
     final premiumRate = _parsePremiumRate();
-    double premiumAmount;
-    if (_viewModel.inputAssetType == InputAssetType.fiat) {
-      premiumAmount = input * premiumRate / 100;
-    } else {
-      premiumAmount = result * premiumRate / 100;
-    }
+    // input/result는 통화 최소단위(minor unit) 정수이므로, whole unit(달러/원 등)으로 환산한 뒤 프리미엄을 계산한다.
+    final fiatMinorUnitsAmount = _viewModel.inputAssetType == InputAssetType.fiat ? input : result;
+    final fiatWholeUnitsAmount = fiatMinorUnitsAmount / _viewModel.fiatCode.minorUnitsPerWhole;
+    final double premiumAmount = fiatWholeUnitsAmount * premiumRate / 100;
 
     // premiumAmount를 BTC 가격으로 변환하여 sats로 표시
     final btcPrice = _viewModel.btcPrice ?? 0;
@@ -641,7 +689,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                                     ? _viewModel.fiatCode.code
                                     : _viewModel.currentUnit.symbol,
                                 _viewModel.inputAssetType == InputAssetType.fiat
-                                    ? input.toThousandsSeparatedString()
+                                    ? _viewModel.formatFiatResult(input)
                                     : _viewModel.formatSatsResult(input),
                                 canCopy: true,
                               ),
@@ -653,7 +701,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                                     : _viewModel.fiatCode.code,
                                 _viewModel.inputAssetType == InputAssetType.fiat
                                     ? _viewModel.formatSatsResult(result)
-                                    : result.toThousandsSeparatedString(),
+                                    : _viewModel.formatFiatResult(result),
                                 canCopy: true,
                               ),
                               const SizedBox(height: 24),
@@ -1084,6 +1132,14 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     final result = hasInput ? viewModel.calculate(viewModel.inputAmount!) : 0;
     final placeholder = viewModel.getPlaceholder(isInputCard: true);
     final isOffline = viewModel.isOfflineMode;
+    // 가격 조회가 불가능하면(오프라인 등) '-'로 표시
+    final isResultActive = hasInput && viewModel.isBtcPriceAvailable;
+    final resultText =
+        !viewModel.isBtcPriceAvailable
+            ? '-'
+            : hasInput
+            ? formatResultAmount(result)
+            : viewModel.getPlaceholder(isInputCard: false);
     final expandedHeight = (usableHeight) / 2 - kToolbarHeight;
     final cardHeight = isOffline ? expandedHeight : 175.0;
 
@@ -1111,15 +1167,15 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
             ? _buildOfflineCardWidget(
               enablePremiumInput: false,
               enableInput: false,
-              resultText: hasInput ? formatResultAmount(result) : viewModel.getPlaceholder(isInputCard: false),
-              isActive: hasInput,
+              resultText: resultText,
+              isActive: isResultActive,
               prefix: viewModel.resultCardPrefix,
               postfix: viewModel.resultCardPostfix,
               isFiatButtonVisible: false,
             )
             : _buildResultCardWidget(
-              isActive: hasInput,
-              resultText: hasInput ? formatResultAmount(result) : viewModel.getPlaceholder(isInputCard: false),
+              isActive: isResultActive,
+              resultText: resultText,
               prefix: viewModel.resultCardPrefix,
               postfix: viewModel.resultCardPostfix,
               onTap: null,
@@ -1177,16 +1233,14 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                       ? _buildOfflineCardWidget(
                         enablePremiumInput: true,
                         enableInput: true,
-                        resultText:
-                            hasInput ? formatResultAmount(result) : viewModel.getPlaceholder(isInputCard: false),
-                        isActive: hasInput,
+                        resultText: resultText,
+                        isActive: isResultActive,
                         prefix: viewModel.resultCardPrefix,
                         postfix: viewModel.resultCardPostfix,
                       )
                       : _buildResultCardWidget(
-                        isActive: hasInput,
-                        resultText:
-                            hasInput ? formatResultAmount(result) : viewModel.getPlaceholder(isInputCard: false),
+                        isActive: isResultActive,
+                        resultText: resultText,
                         prefix: viewModel.resultCardPrefix,
                         postfix: viewModel.resultCardPostfix,
                         onTap: shouldHandleUnitToggle ? _onBtcUnitToggle : null,
@@ -1300,13 +1354,10 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                             controller: controller,
                             focusNode: focusNode,
                             placeholderText: effectivePlaceholder,
-                            textInputFormatter:
-                                postfix == t.btc
-                                    ? [const BtcAmountInputFormatter()]
-                                    : [FilteringTextInputFormatter.digitsOnly],
+                            textInputFormatter: _amountInputFormatters(),
                             onChanged: _handleAmountInputChanged,
                             textInputType:
-                                postfix == t.btc
+                                _amountInputAllowsDecimal
                                     ? const TextInputType.numberWithOptions(signed: false, decimal: true)
                                     : TextInputType.number,
                             textInputAction: TextInputAction.done,
@@ -1595,9 +1646,14 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
       _updateResultOnPremiumChange();
     } else if (_inputFocusNode.hasFocus) {
       if (_viewModel.inputAssetType == InputAssetType.fiat) {
-        final currentValue = _inputController.text.toIntSafe() ?? 0;
-        final addValue = value.toIntSafe() ?? 0;
-        _handleAmountInputChanged((currentValue + addValue).toString());
+        final fiatCode = _viewModel.fiatCode;
+        final currentMinorUnits = _viewModel.inputAmount ?? 0;
+        final addMinorUnits = _parseFiatTextToMinorUnits(value); // value는 whole unit 기준 문자열 (예: "10000")
+        final nextMinorUnits = currentMinorUnits + addMinorUnits;
+        final nextWholeUnitsText = (nextMinorUnits / fiatCode.minorUnitsPerWhole).toStringAsFixed(
+          fiatCode.decimalDigits,
+        );
+        _handleAmountInputChanged(nextWholeUnitsText);
       } else if (_viewModel.currentUnit.isBasedOnSatoshi) {
         final currentValue = _inputController.text.toIntSafe() ?? 0;
         final addValue = value.toIntSafe() ?? 0;

--- a/lib/screens/settings/tools/p2p_calculator_screen.dart
+++ b/lib/screens/settings/tools/p2p_calculator_screen.dart
@@ -155,9 +155,31 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
           );
           _isUpdatingController = false;
         }
+      } else if (!_inputFocusNode.hasFocus && _viewModel.inputAssetType == InputAssetType.fiat) {
+        _stripTrailingZeroDecimalOnFocusLost();
       }
     }
     setState(() {});
+  }
+
+  /// 소수점 구분자 뒤 소수부가 비어있거나 전부 0이면(예: "50.", "50.0", "50.00")
+  /// 포커스 아웃 시 소수점 이하를 통째로 제거한다.
+  void _stripTrailingZeroDecimalOnFocusLost() {
+    final decimalSeparator = NumberFormatConfig.instance.decimalSeparator;
+    final text = _inputController.text;
+    final sepIndex = text.indexOf(decimalSeparator);
+    if (sepIndex == -1) return;
+
+    final decimalPart = text.substring(sepIndex + decimalSeparator.length);
+    if (decimalPart.isNotEmpty && (int.tryParse(decimalPart) ?? -1) != 0) return;
+
+    final trimmed = text.substring(0, sepIndex);
+    _isUpdatingController = true;
+    _inputController.value = TextEditingValue(
+      text: trimmed,
+      selection: TextSelection.collapsed(offset: trimmed.length),
+    );
+    _isUpdatingController = false;
   }
 
   void _formatPremiumOnFocusLost() {
@@ -263,22 +285,51 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     _viewModel.setInputAmount(minorUnits);
   }
 
-  /// fiatText(예: "50.25")를 통화 최소단위(minor unit, 예: cent) 정수로 변환
+  /// fiatText(예: "50.25", 항상 '.'을 소수점으로 쓰는 canonical 포맷)를 통화 최소단위(minor unit, 예: cent) 정수로 변환
+  /// - fiatText는 이미 filterNumericInput 등을 거쳐 로케일 구분자가 없는 canonical 포맷이므로
+  ///   toDoubleSafe()(로케일 구분자 기준 정규화)를 쓰면 '.'이 그룹 구분자로 오인되어(es/de 등) 값이 왜곡된다.
   int _parseFiatTextToMinorUnits(String fiatText) {
     if (fiatText.isEmpty || fiatText == '.') return 0;
-    final value = fiatText.toDoubleSafe() ?? 0;
+    final value = double.tryParse(fiatText) ?? 0;
     return (value * _viewModel.fiatCode.minorUnitsPerWhole).round();
   }
 
   String _formatFiatInputText(String fiatText) {
     final decimalDigits = _viewModel.fiatCode.decimalDigits;
-    final displayText = _formatLocaleDecimalText(fiatText);
+    final displayText = _formatLocaleDecimalText(_stripTrailingZeroDecimal(fiatText));
     return FiatAmountInputFormatter(decimalPlaces: decimalDigits)
         .formatEditUpdate(
           const TextEditingValue(),
           TextEditingValue(text: displayText, selection: TextSelection.collapsed(offset: displayText.length)),
         )
         .text;
+  }
+
+  /// 소수부가 전부 0이면(예: "10.00") 소수점 이하를 제거해 "10"으로 반환한다.
+  /// _formatFiatInputText는 프로그래매틱 갱신(Quick Add 등)에서만 호출되므로, 타이핑 중인 값은 영향받지 않는다.
+  String _stripTrailingZeroDecimal(String fiatText) {
+    final dotIndex = fiatText.indexOf('.');
+    if (dotIndex == -1) return fiatText;
+    final decimalPart = fiatText.substring(dotIndex + 1);
+    if (decimalPart.isEmpty || (int.tryParse(decimalPart) ?? 0) == 0) {
+      return fiatText.substring(0, dotIndex);
+    }
+    return fiatText;
+  }
+
+  /// [_viewModel.formatFiatResult]의 결과(로케일 포맷, 예: "50,00")에서 소수부가 전부 0이면
+  /// 소수점 이하를 제거한다. 결과/명세서(bill) 등 표시 전용 용도로만 사용한다.
+  String _formatFiatResultForDisplay(int fiatMinorUnits) {
+    final formatted = _viewModel.formatFiatResult(fiatMinorUnits);
+    final decimalSep = NumberFormatConfig.instance.decimalSeparator;
+    final sepIndex = formatted.indexOf(decimalSep);
+    if (sepIndex == -1) return formatted;
+
+    final decimalPart = formatted.substring(sepIndex + decimalSep.length);
+    if (decimalPart.isNotEmpty && (int.tryParse(decimalPart) ?? -1) == 0) {
+      return formatted.substring(0, sepIndex);
+    }
+    return formatted;
   }
 
   void _processBtcInput(String sanitized, {required bool shouldUpdateController}) {
@@ -519,7 +570,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
 
     if (_viewModel.inputAssetType == InputAssetType.fiat) {
       // BTC → Fiat로 전환: result는 통화 최소단위(minor unit) 정수
-      final formatted = _viewModel.formatFiatResult(result);
+      final formatted = _formatFiatResultForDisplay(result);
       _inputController.value = TextEditingValue(
         text: formatted,
         selection: TextSelection.collapsed(offset: formatted.length),
@@ -569,7 +620,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     if (_viewModel.inputAssetType == InputAssetType.fiat) {
       return _viewModel.formatSatsResult(result);
     } else {
-      return _viewModel.formatFiatResult(result);
+      return _formatFiatResultForDisplay(result);
     }
   }
 
@@ -623,8 +674,8 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     final btcPriceStr = _viewModel.btcPrice?.toThousandsSeparatedString() ?? '-';
     final fiatAmountStr =
         _viewModel.inputAssetType == InputAssetType.fiat
-            ? _viewModel.formatFiatResult(input)
-            : _viewModel.formatFiatResult(result);
+            ? _formatFiatResultForDisplay(input)
+            : _formatFiatResultForDisplay(result);
     final btcAmountStr =
         _viewModel.inputAssetType == InputAssetType.fiat
             ? _viewModel.formatSatsResult(result)
@@ -689,7 +740,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                                     ? _viewModel.fiatCode.code
                                     : _viewModel.currentUnit.symbol,
                                 _viewModel.inputAssetType == InputAssetType.fiat
-                                    ? _viewModel.formatFiatResult(input)
+                                    ? _formatFiatResultForDisplay(input)
                                     : _viewModel.formatSatsResult(input),
                                 canCopy: true,
                               ),
@@ -701,7 +752,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                                     : _viewModel.fiatCode.code,
                                 _viewModel.inputAssetType == InputAssetType.fiat
                                     ? _viewModel.formatSatsResult(result)
-                                    : _viewModel.formatFiatResult(result),
+                                    : _formatFiatResultForDisplay(result),
                                 canCopy: true,
                               ),
                               const SizedBox(height: 24),
@@ -756,7 +807,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
                         premiumSatsStr,
                         _viewModel.inputAssetType == InputAssetType.fiat ? result : input,
                       ),
-                      CoconutLayout.spacing_600h,
+                      CoconutLayout.spacing_500h,
                     ],
                   ),
                   Positioned(
@@ -785,25 +836,32 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
       padding: const EdgeInsets.symmetric(horizontal: 20.0),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Text(
-            label,
-            style: CoconutTypography.body3_12.copyWith(
-              height: 1.0,
-              letterSpacing: -0.12,
-              fontWeight: FontWeight.w500,
-              color: context.coconutColors.secondaryText,
+          Flexible(
+            child: Text(
+              label,
+              style: CoconutTypography.body3_12.copyWith(
+                height: 1.0,
+                letterSpacing: -0.12,
+                fontWeight: FontWeight.w500,
+                color: context.coconutColors.secondaryText,
+              ),
             ),
           ),
+          const SizedBox(width: 8),
           if (canCopy)
             _CopyableText(value: value)
           else
-            Text(
-              value,
-              style: CoconutTypography.body2_14_Number.copyWith(
-                color: context.coconutColors.primaryText,
-                height: valueLineHeight,
-                letterSpacing: -0.28,
+            Flexible(
+              child: Text(
+                value,
+                textAlign: TextAlign.right,
+                style: CoconutTypography.body2_14_Number.copyWith(
+                  color: context.coconutColors.primaryText,
+                  height: valueLineHeight,
+                  letterSpacing: -0.28,
+                ),
               ),
             ),
         ],
@@ -822,7 +880,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
     int satsAmount,
   ) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: Column(
         children: [
           CoconutUnderlinedButton(
@@ -1653,7 +1711,7 @@ class _P2PCalculatorScreenState extends State<P2PCalculatorScreen> with TickerPr
         final nextWholeUnitsText = (nextMinorUnits / fiatCode.minorUnitsPerWhole).toStringAsFixed(
           fiatCode.decimalDigits,
         );
-        _handleAmountInputChanged(nextWholeUnitsText);
+        _handleAmountInputChanged(_formatLocaleDecimalText(nextWholeUnitsText));
       } else if (_viewModel.currentUnit.isBasedOnSatoshi) {
         final currentValue = _inputController.text.toIntSafe() ?? 0;
         final addValue = value.toIntSafe() ?? 0;

--- a/lib/utils/fiat_util.dart
+++ b/lib/utils/fiat_util.dart
@@ -1,7 +1,28 @@
+import 'package:coconut_wallet/config/number_format_config.dart';
+import 'package:coconut_wallet/enums/fiat_enums.dart';
+import 'package:coconut_wallet/extensions/int_extensions.dart';
 import 'package:coconut_wallet/utils/balance_format_util.dart';
 
 class FiatUtil {
   static int calculateFiatAmount(int satoshiAmount, int exchangeRate) {
     return (UnitUtil.convertSatoshiToBitcoin(satoshiAmount) * exchangeRate).toInt();
+  }
+
+  /// 통화 최소단위(minor unit, 예: cent) 정수를 통화별 표시 형식의 문자열로 변환한다.
+  /// 예: USD 5025 -> "50.25", KRW 50000 -> "50,000"
+  static String formatMinorUnits(int minorUnits, FiatCode fiatCode) {
+    final decimalDigits = fiatCode.decimalDigits;
+    if (decimalDigits == 0) {
+      return minorUnits.toThousandsSeparatedString();
+    }
+
+    final divisor = fiatCode.minorUnitsPerWhole;
+    final isNegative = minorUnits < 0;
+    final absMinorUnits = minorUnits.abs();
+    final wholePart = absMinorUnits ~/ divisor;
+    final fractionPart = (absMinorUnits % divisor).toString().padLeft(decimalDigits, '0');
+    final sign = isNegative ? '-' : '';
+
+    return '$sign${wholePart.toThousandsSeparatedString()}${NumberFormatConfig.instance.decimalSeparator}$fractionPart';
   }
 }

--- a/lib/utils/numeric_input_formatters.dart
+++ b/lib/utils/numeric_input_formatters.dart
@@ -59,7 +59,10 @@ class BtcAmountInputFormatter extends TextInputFormatter {
         if (alreadyHasDecimal) return oldValue;
         // 소수점으로 대체
         final newText = newValue.text.substring(0, newValue.text.length - 1) + decimalSep;
-        final next = TextEditingValue(text: newText, selection: TextSelection.collapsed(offset: newText.length));
+        final next = TextEditingValue(
+          text: newText,
+          selection: TextSelection.collapsed(offset: newText.length),
+        );
         return formatEditUpdate(oldValue, next);
       }
 
@@ -68,7 +71,10 @@ class BtcAmountInputFormatter extends TextInputFormatter {
     }
 
     // groupingSeparator를 먼저 제거한 뒤 마침표/쉼표를 모두 .으로 통일
-    final text = newValue.text.replaceAll(groupingSep, '').replaceAll(',', '.').replaceAll(RegExp(r'[^0-9.]'), '');
+    final text = newValue.text
+        .replaceAll(groupingSep, '')
+        .replaceAll(',', '.')
+        .replaceAll(RegExp(r'[^0-9.]'), '');
     if (text.isEmpty) return newValue;
 
     final parts = text.split('.');
@@ -80,7 +86,11 @@ class BtcAmountInputFormatter extends TextInputFormatter {
     final btc = double.tryParse(text);
     if (btc != null && btc > maxBtc) return oldValue;
 
-    final formattedText = _formatBtcText(text, decimalSeparator: decimalSep, groupingSeparator: groupingSep);
+    final formattedText = _formatGroupedDecimalText(
+      text,
+      decimalSeparator: decimalSep,
+      groupingSeparator: groupingSep,
+    );
     final offset = _calculateSelectionOffset(
       originalText: newValue.text,
       formattedText: formattedText,
@@ -88,7 +98,74 @@ class BtcAmountInputFormatter extends TextInputFormatter {
       decimalSeparator: decimalSep,
       groupingSeparator: groupingSep,
     );
-    return TextEditingValue(text: formattedText, selection: TextSelection.collapsed(offset: offset));
+    return TextEditingValue(
+      text: formattedText,
+      selection: TextSelection.collapsed(offset: offset),
+    );
+  }
+}
+
+/// 법정화폐(fiat) 금액 입력용. 통화별 소수 자리수(decimalPlaces)만큼만 소수점 입력을 허용한다.
+/// decimalPlaces가 0이면 소수점 입력 자체를 거부한다. (예: KRW, JPY)
+class FiatAmountInputFormatter extends TextInputFormatter {
+  final int decimalPlaces;
+
+  const FiatAmountInputFormatter({required this.decimalPlaces});
+
+  String get _altSeparator => NumberFormatConfig.instance.decimalSeparator == '.' ? ',' : '.';
+
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    final decimalSep = NumberFormatConfig.instance.decimalSeparator;
+    final groupingSep = NumberFormatConfig.instance.groupingSeparator;
+    final inserted = _insertedText(oldValue, newValue);
+
+    if (inserted.isNotEmpty) {
+      if (!RegExp(r'^[0-9.,]+$').hasMatch(inserted)) return oldValue;
+
+      if (inserted == _altSeparator) {
+        final alreadyHasDecimal = oldValue.text.contains(decimalSep);
+        if (alreadyHasDecimal || decimalPlaces == 0) return oldValue;
+        final newText = newValue.text.substring(0, newValue.text.length - 1) + decimalSep;
+        final next = TextEditingValue(
+          text: newText,
+          selection: TextSelection.collapsed(offset: newText.length),
+        );
+        return formatEditUpdate(oldValue, next);
+      }
+
+      if (inserted == groupingSep) return oldValue;
+    }
+
+    final text = newValue.text
+        .replaceAll(groupingSep, '')
+        .replaceAll(',', '.')
+        .replaceAll(RegExp(r'[^0-9.]'), '');
+    if (text.isEmpty) return newValue;
+
+    final parts = text.split('.');
+    if (parts.length > 2) return oldValue;
+    if (decimalPlaces == 0 && parts.length > 1) return oldValue;
+
+    final decimalPart = parts.length > 1 ? parts[1] : '';
+    if (decimalPart.length > decimalPlaces) return oldValue;
+
+    final formattedText = _formatGroupedDecimalText(
+      text,
+      decimalSeparator: decimalSep,
+      groupingSeparator: groupingSep,
+    );
+    final offset = _calculateSelectionOffset(
+      originalText: newValue.text,
+      formattedText: formattedText,
+      baseOffset: newValue.selection.baseOffset,
+      decimalSeparator: decimalSep,
+      groupingSeparator: groupingSep,
+    );
+    return TextEditingValue(
+      text: formattedText,
+      selection: TextSelection.collapsed(offset: offset),
+    );
   }
 }
 
@@ -110,7 +187,10 @@ class RateInputFormatter extends TextInputFormatter {
       if (inserted == _altSep) {
         if (oldValue.text.contains(_decimalSep)) return oldValue;
         final newText = newValue.text.substring(0, newValue.text.length - 1) + _decimalSep;
-        final next = TextEditingValue(text: newText, selection: TextSelection.collapsed(offset: newText.length));
+        final next = TextEditingValue(
+          text: newText,
+          selection: TextSelection.collapsed(offset: newText.length),
+        );
         return formatEditUpdate(oldValue, next);
       }
     }
@@ -131,7 +211,10 @@ class RateInputFormatter extends TextInputFormatter {
     }
 
     final formatted = decimalPart != null ? '$integerPart$_decimalSep$decimalPart' : integerPart;
-    return TextEditingValue(text: formatted, selection: TextSelection.collapsed(offset: formatted.length));
+    return TextEditingValue(
+      text: formatted,
+      selection: TextSelection.collapsed(offset: formatted.length),
+    );
   }
 }
 
@@ -148,14 +231,20 @@ class SatoshiAmountInputFormatter extends TextInputFormatter {
     final sats = int.tryParse(text);
     if (sats != null && sats > maxSats) return oldValue;
 
-    final formattedText = formatIntWithGroupingSeparator(text, NumberFormatConfig.instance.groupingSeparator);
+    final formattedText = formatIntWithGroupingSeparator(
+      text,
+      NumberFormatConfig.instance.groupingSeparator,
+    );
     final offset = _calculateSelectionOffset(
       originalText: newValue.text,
       formattedText: formattedText,
       baseOffset: newValue.selection.baseOffset,
       groupingSeparator: NumberFormatConfig.instance.groupingSeparator,
     );
-    return TextEditingValue(text: formattedText, selection: TextSelection.collapsed(offset: offset));
+    return TextEditingValue(
+      text: formattedText,
+      selection: TextSelection.collapsed(offset: offset),
+    );
   }
 }
 
@@ -163,11 +252,18 @@ String _insertedText(TextEditingValue oldValue, TextEditingValue newValue) {
   if (newValue.text.length <= oldValue.text.length) return '';
 
   final start = oldValue.selection.baseOffset.clamp(0, oldValue.text.length);
-  final end = (start + (newValue.text.length - oldValue.text.length)).clamp(0, newValue.text.length);
+  final end = (start + (newValue.text.length - oldValue.text.length)).clamp(
+    0,
+    newValue.text.length,
+  );
   return newValue.text.substring(start, end);
 }
 
-String _formatBtcText(String text, {required String decimalSeparator, required String groupingSeparator}) {
+String _formatGroupedDecimalText(
+  String text, {
+  required String decimalSeparator,
+  required String groupingSeparator,
+}) {
   if (text == '.' || text == ',') return '0$decimalSeparator';
 
   final parts = text.replaceAll(',', '.').split('.');

--- a/test/utility/p2p_calculator_test.dart
+++ b/test/utility/p2p_calculator_test.dart
@@ -145,10 +145,10 @@ void main() {
       expect(viewModel.calculateSatsFromFiat(1), 1);
     });
 
-    test('[Fiat -> Sats] 오프라인 시 KRW 기본 가격(20,000,000) 사용', () {
+    test('[Fiat -> Sats] 오프라인 시 가격 조회 불가로 0 sats 반환', () {
       final viewModel = createViewModel(isNetworkOn: false);
-      // (1,000,000 × 0.99) / 20,000,000 × 100,000,000 = 4,950,000
-      expect(viewModel.calculateSatsFromFiat(1000000), 4950000);
+      // _getBtcPrice()는 오프라인일 때 폴백 가격 없이 0을 반환하므로 변환 결과도 0
+      expect(viewModel.calculateSatsFromFiat(1000000), 0);
     });
 
     test('[Fiat -> Sats] 수수료율 변경 후 동일 금액 재계산 시 결과 변경 확인', () {
@@ -246,10 +246,10 @@ void main() {
       expect(viewModel.calculateFiatFromSats(1), 1);
     });
 
-    test('[Sats -> Fiat] 오프라인 시 KRW 기본 가격(20,000,000) 사용', () {
+    test('[Sats -> Fiat] 오프라인 시 가격 조회 불가로 0원 반환', () {
       final viewModel = createViewModel(isNetworkOn: false);
-      // (1,000,000 / 100,000,000) * 20,000,000 * 1.01 = 202,000
-      expect(viewModel.calculateFiatFromSats(1000000), 202000);
+      // _getBtcPrice()는 오프라인일 때 폴백 가격 없이 0을 반환하므로 변환 결과도 0
+      expect(viewModel.calculateFiatFromSats(1000000), 0);
     });
 
     test('[Sats -> Fiat] 수수료율 변경 후 동일 금액 재계산 시 결과 변경 확인', () {
@@ -527,6 +527,51 @@ void main() {
         // (10,000 × 0.9999) / 140,000,000 × 100,000,000 = 7142.142857... → 7,142
         expect(viewModel.calculateSatsFromFiat(10000), 7142);
       });
+    });
+  });
+
+  group('통화별 소수 자리수(decimalDigits) 처리', () {
+    test('KRW(decimalDigits=0)는 minorUnitsPerWhole=1', () {
+      expect(FiatCode.KRW.minorUnitsPerWhole, 1);
+      expect(FiatCode.JPY.minorUnitsPerWhole, 1);
+    });
+
+    test('USD/EUR(decimalDigits=2)는 minorUnitsPerWhole=100', () {
+      expect(FiatCode.USD.minorUnitsPerWhole, 100);
+      expect(FiatCode.EUR.minorUnitsPerWhole, 100);
+    });
+
+    test('[USD] \$50.25 입력(센트 단위 5025)이 소수점 없이 처리되던 KRW와 달리 센트 단위까지 반영되어 Sats로 변환된다', () {
+      // btcPrice는 1 BTC당 whole unit(달러) 기준: $50,000/BTC
+      final viewModel = createViewModel(fiatCode: FiatCode.USD, btcPrice: 50000);
+      viewModel.setPremiumRate(0.0);
+
+      // $50.25 = 5025 cents
+      final satsFromCents = viewModel.calculateSatsFromFiat(5025);
+      // $50.00 = 5000 cents
+      final satsFromWholeDollars = viewModel.calculateSatsFromFiat(5000);
+
+      // 25센트 차이가 결과 sats에도 반영되어야 한다 (반올림 오차 허용)
+      expect(satsFromCents, greaterThan(satsFromWholeDollars));
+    });
+
+    test('[USD] Sats → Fiat 변환 결과가 센트 단위(minor unit) 정수로 반환된다', () {
+      final viewModel = createViewModel(fiatCode: FiatCode.USD, btcPrice: 50000);
+      viewModel.setPremiumRate(0.0);
+
+      // 100,000 sats = 0.001 BTC → $50.00 = 5000 cents
+      expect(viewModel.calculateFiatFromSats(100000), 5000);
+    });
+
+    test('[USD] formatFiatResult가 센트 단위 정수를 "50.25" 형태로 포맷한다', () {
+      final viewModel = createViewModel(fiatCode: FiatCode.USD, btcPrice: 50000);
+      expect(viewModel.formatFiatResult(5025), '50.25');
+      expect(viewModel.formatFiatResult(5000), '50.00');
+    });
+
+    test('[KRW] formatFiatResult는 기존과 동일하게 소수점 없이 포맷한다', () {
+      final viewModel = createViewModel();
+      expect(viewModel.formatFiatResult(50000), '50,000');
     });
   });
 

--- a/test/utils/numeric_input_formatters_test.dart
+++ b/test/utils/numeric_input_formatters_test.dart
@@ -319,6 +319,71 @@ void main() {
     });
   });
 
+  group('FiatAmountInputFormatter', () {
+    TextEditingValue format(String text, {required int decimalPlaces, String decimalSeparator = '.'}) {
+      NumberFormatConfig.instance.update(decimalSeparator == ',' ? AppLanguage.es.code : AppLanguage.en.code);
+      final formatter = FiatAmountInputFormatter(decimalPlaces: decimalPlaces);
+      return formatter.formatEditUpdate(
+        const TextEditingValue(),
+        TextEditingValue(text: text, selection: TextSelection.collapsed(offset: text.length)),
+      );
+    }
+
+    List<String> typeSequence(List<String> inputs, {required int decimalPlaces, String decimalSeparator = '.'}) {
+      NumberFormatConfig.instance.update(decimalSeparator == ',' ? AppLanguage.es.code : AppLanguage.en.code);
+      final formatter = FiatAmountInputFormatter(decimalPlaces: decimalPlaces);
+      var current = const TextEditingValue();
+      final results = <String>[];
+      for (final input in inputs) {
+        TextEditingValue next;
+        if (input == '<') {
+          if (current.text.isEmpty) {
+            next = current;
+          } else {
+            var newText = current.text.substring(0, current.text.length - 1);
+            next = TextEditingValue(text: newText, selection: TextSelection.collapsed(offset: newText.length));
+          }
+        } else {
+          final newText = current.text + input;
+          next = TextEditingValue(text: newText, selection: TextSelection.collapsed(offset: newText.length));
+        }
+        current = formatter.formatEditUpdate(current, next);
+        results.add(current.text);
+      }
+      return results;
+    }
+
+    test('USD처럼 decimalPlaces=2인 경우 소수점 입력 및 자리수 그룹핑을 허용한다', () {
+      final seq = typeSequence(['5', '0', '.', '2', '5'], decimalPlaces: 2);
+      expect(seq, ['5', '50', '50.', '50.2', '50.25']);
+    });
+
+    test('decimalPlaces=2를 초과하는 소수 자리 입력은 거부한다', () {
+      NumberFormatConfig.instance.update(AppLanguage.en.code);
+      const formatter = FiatAmountInputFormatter(decimalPlaces: 2);
+      const before = TextEditingValue(text: '50.25', selection: TextSelection.collapsed(offset: 5));
+      const addingDigit = TextEditingValue(text: '50.255', selection: TextSelection.collapsed(offset: 6));
+      expect(formatter.formatEditUpdate(before, addingDigit), before);
+    });
+
+    test('KRW처럼 decimalPlaces=0인 경우 소수점 입력 자체를 거부한다', () {
+      NumberFormatConfig.instance.update(AppLanguage.en.code);
+      const formatter = FiatAmountInputFormatter(decimalPlaces: 0);
+      const before = TextEditingValue(text: '50000', selection: TextSelection.collapsed(offset: 5));
+      const addingDot = TextEditingValue(text: '50000.', selection: TextSelection.collapsed(offset: 6));
+      expect(formatter.formatEditUpdate(before, addingDot), before);
+    });
+
+    test('천단위 구분자가 소수부와 함께 정상적으로 삽입된다 (en)', () {
+      expect(format('1234.5', decimalPlaces: 2).text, '1,234.5');
+    });
+
+    test('로케일이 comma-decimal인 경우 소수점 입력을 허용한다 (de)', () {
+      final seq = typeSequence(['5', '0', ',', '2', '5'], decimalPlaces: 2, decimalSeparator: ',');
+      expect(seq, ['5', '50', '50,', '50,2', '50,25']);
+    });
+  });
+
   group('SatoshiAmountInputFormatter', () {
     test('keeps cursor at the end when locale grouping separator is dot', () {
       NumberFormatConfig.instance.update(AppLanguage.es.code);


### PR DESCRIPTION
## 1. 수정 사항
- USD, EUR 소수점 입력 가능하도록 수정 
- 오프라인 상태 등으로 비트코인 가격을 가져오지 못하는 경우 '-' 을 대신 표기하도록(기존 0) 수정 
- 기존 테스트 수정: _getBtcPrice() 함수에서 오프라인 폴백으로 0을 반환하나 임의의 가격으로 환산하길 기대함. 로직 불일치로 수정
- 수정 사항에 대한 테스트 케이스 추가 

## 2. 테스트
- [x] USD, EUR: 소수점 두자리까지 입력 가능함.
- [x] KRW, JPY: 소수점 입력 불가능함.
- [x] 4-digit 이상 입력시 회계 포맷으로 정상 출력
- [x] 오프라인 상태에서 BTC 환산 값이 `- BTC` (before `0 BTC`)로 출력
