### PR TITLE
의도치 않은 UTXO 잠김 현상

### DIFF
--- a/lib/providers/node_provider/utxo_sync_service.dart
+++ b/lib/providers/node_provider/utxo_sync_service.dart
@@ -59,7 +59,7 @@ class UtxoSyncService {
       );
       final transactionMap = {for (var realmTx in realmTransactions) realmTx.transactionHash: realmTx};
       final realmLockedUtxos = _utxoRepository.getUtxosByStatus(walletItem.id, UtxoStatus.locked);
-      final lockedUtxoMap = {for (final utxo in realmLockedUtxos) utxo.transactionHash: utxo};
+      final lockedUtxoMap = {for (final utxo in realmLockedUtxos) getUtxoId(utxo.transactionHash, utxo.index): utxo};
       return unspentResList
           // 이미 사용된 UTXO는 필터링하여 제외
           .map(
@@ -73,7 +73,7 @@ class UtxoSyncService {
               status: () {
                 if (e.height <= 0) return UtxoStatus.incoming;
 
-                final lockedUtxo = lockedUtxoMap[e.txHash];
+                final lockedUtxo = lockedUtxoMap[getUtxoId(e.txHash, e.txPos)];
                 if (lockedUtxo == null || lockedUtxo.status == UtxoStatus.unspent) {
                   return UtxoStatus.unspent;
                 } else {

--- a/test/providers/node_provider/utxo/utxo_sync_service_test.dart
+++ b/test/providers/node_provider/utxo/utxo_sync_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:coconut_wallet/model/node/script_status.dart';
 import 'package:coconut_wallet/model/utxo/utxo_state.dart';
 import 'package:coconut_wallet/model/wallet/singlesig_wallet_item.dart';
 import 'package:coconut_wallet/providers/node_provider/state/node_state_manager.dart';
@@ -7,8 +8,10 @@ import 'package:coconut_wallet/repository/realm/model/coconut_wallet_model.dart'
 import 'package:coconut_wallet/repository/realm/transaction_repository.dart';
 import 'package:coconut_wallet/repository/realm/utxo_repository.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
+import 'package:coconut_wallet/services/model/response/electrum_response_types.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
 import '../../../mock/transaction_mock.dart';
 import '../../../mock/wallet_mock.dart';
@@ -163,6 +166,7 @@ void main() {
         to: testWalletItem.walletBase.getAddress(0),
         timestamp: DateTime.now(),
         status: UtxoStatus.outgoing,
+        spentByTransactionHash: nonExistentTxHash,
       );
 
       await utxoRepository.addAllUtxos(testWalletId, [outgoingUtxo]);
@@ -285,6 +289,57 @@ void main() {
       for (final orphanedUtxo in orphanedUtxos) {
         expect(remainingUtxos.where((u) => u.utxoId == orphanedUtxo.utxoId).isEmpty, isTrue);
       }
+    });
+  });
+
+  group('fetchUtxoStateList 테스트', () {
+    test('같은 트랜잭션의 다른 output이 잠겨 있어도 잠근 적 없는 output은 unspent로 유지되는지 확인', () async {
+      // Given: 하나의 트랜잭션이 지갑 소유 output을 2개 생성 (수신 output index 0, 잔돈 output index 1)
+      const String sharedTxHash = 'shared_tx_hash_receive_and_change';
+
+      final confirmedTx = TransactionMock.createConfirmedTransactionRecord(
+        transactionHash: sharedTxHash,
+        blockHeight: 100,
+      );
+      await transactionRepository.addAllTransactions(testWalletId, [confirmedTx]);
+
+      // 수신 output(index 0)은 사용자가 수동으로 잠금 처리한 상태로 저장
+      final lockedReceiveUtxo = UtxoState(
+        transactionHash: sharedTxHash,
+        index: 0,
+        amount: 1000000,
+        derivationPath: "m/84'/0'/0'/0/0",
+        blockHeight: 100,
+        to: testWalletItem.walletBase.getAddress(0),
+        timestamp: DateTime.now(),
+        status: UtxoStatus.locked,
+      );
+      await utxoRepository.addAllUtxos(testWalletId, [lockedReceiveUtxo]);
+
+      // 잔돈 output(index 1)의 scriptStatus - 잠근 적 없음
+      final changeScriptStatus = ScriptStatus(
+        derivationPath: "m/84'/0'/0'/1/0",
+        address: testWalletItem.walletBase.getAddress(0, isChange: true),
+        index: 0,
+        isChange: true,
+        scriptPubKey: 'change_script_pub_key',
+        status: 'change_status_hash',
+        timestamp: DateTime.now(),
+      );
+
+      // electrum이 잔돈 주소에 대해 같은 트랜잭션의 output 1을 반환하도록 모킹
+      when(electrumService.getUnspentList(any, any)).thenAnswer((_) async {
+        return [ListUnspentRes(height: 100, txHash: sharedTxHash, txPos: 1, value: 500000)];
+      });
+
+      // When: 잔돈 주소에 대해 UTXO 상태를 재계산
+      final result = await utxoSyncService.fetchUtxoStateList(testWalletItem, changeScriptStatus);
+
+      // Then: 잔돈 UTXO는 locked로 전파되지 않고 unspent 상태를 유지해야 함
+      expect(result.length, 1);
+      expect(result.first.transactionHash, sharedTxHash);
+      expect(result.first.index, 1);
+      expect(result.first.status, UtxoStatus.unspent);
     });
   });
 }


### PR DESCRIPTION
## 1. 버그 리포트
- 8/6 코코넛 디스코드 서버
- 엄지왕님:  잠근 적 없는 잔돈 UTXO가 잠겨 있고, 홈 화면  잔액과 '모두 보내기' 금액이 다르게 보인다

## 2. 원인
- `UtxoSyncService.fetchUtxoStateList`에서 잠긴 UTXO 목록을 transactionHash만으로 매칭
- 같은 트랜잭션에 지갑 소유의 output이 2개 이상 있을 때(예: 수신 + 잔돈), 하나만 잠가도 나머지 utxo가 잘못 잠길 수 있음.

## 3. 작업 사항
- 잠긴 UTXO 목록을 transactionHash만으로 매칭하던 로직을 transactionHash+index(utxoId) 기준으로 수정
- 테스트 코드 추가 