### PR TITLE
bip39 단어집 개선

### DIFF
--- a/assets/i18n/de.i18n.yaml
+++ b/assets/i18n/de.i18n.yaml
@@ -1130,7 +1130,7 @@ errors:
 text_field:
   enter_fee_with_two_decimal_places: "Bis zu zwei Dezimalstellen erlaubt (sat/vB)"
   enter_fee_directly: "Manuell eingeben"
-  search_mnemonic_word: "Suche in Englisch oder Zahlen"
+  search_mnemonic_word: "Englische Buchstaben oder Zahlen"
 
 tooltip:
   recommended_fee1: "Empfohlene Gebühr konnte nicht abgerufen werden. Bitte geben Sie die Gebühr manuell ein."

--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -1210,7 +1210,7 @@ errors:
 text_field:
   enter_fee_with_two_decimal_places: "Up to two decimal places allowed (sat/vB)"
   enter_fee_directly: "Enter Manually"
-  search_mnemonic_word: "Search in English or numbers"
+  search_mnemonic_word: "English letters or numbers"
 
 tooltip:
   recommended_fee1: "Could not fetch recommended fee. Please enter fee manually."

--- a/assets/i18n/es.i18n.yaml
+++ b/assets/i18n/es.i18n.yaml
@@ -1203,7 +1203,7 @@ errors:
 text_field:
   enter_fee_with_two_decimal_places: "Hasta dos decimales permitidos (sat/vB)"
   enter_fee_directly: "Introducir manualmente"
-  search_mnemonic_word: "Buscar en inglés o números"
+  search_mnemonic_word: "Letras en inglés o números"
 
 tooltip:
   recommended_fee1: "No se puede obtener la comisión recomendada. Por favor, ingrese la comisión manualmente." 

--- a/assets/i18n/ja.i18n.yaml
+++ b/assets/i18n/ja.i18n.yaml
@@ -1201,7 +1201,7 @@ errors:
 text_field:
   enter_fee_with_two_decimal_places: "小数点以下2桁まで入力可能（sat/vB）"
   enter_fee_directly: "手動入力"
-  search_mnemonic_word: "英語で検索"
+  search_mnemonic_word: "英字または数字で検索"
 
 tooltip:
   recommended_fee1: "推奨手数料を取得できません。手数料を手動で入力してください。"

--- a/lib/screens/settings/tools/bip39_word_list_screen.dart
+++ b/lib/screens/settings/tools/bip39_word_list_screen.dart
@@ -13,10 +13,13 @@ List<TextSpan> highlightOccurrences(
   String query, {
   bool isIndex = false,
   Color? highlightColor,
+  bool tabularFigures = false,
 }) {
   final colors = context.coconutColors;
-  final normalStyle =
-      isIndex ? CoconutTypography.body1_16_Number.setColor(colors.mutedText) : TextStyle(color: colors.primaryText);
+  final normalStyle = (isIndex
+          ? CoconutTypography.body1_16_Number.setColor(colors.mutedText)
+          : TextStyle(color: colors.primaryText))
+      .copyWith(fontFeatures: tabularFigures ? const [FontFeature.tabularFigures()] : null);
   final resolvedHighlightColor = highlightColor ?? colors.success;
 
   if (query.isEmpty) {
@@ -215,7 +218,7 @@ class _Bip39ListScreenState extends State<Bip39ListScreen> {
         maxLength: 11,
         isLengthVisible: false,
         padding: const EdgeInsets.only(),
-        height: Sizes.size40,
+        height: Sizes.size48,
         prefix: IgnorePointer(
           ignoring: true,
           child: IconButton(
@@ -290,11 +293,14 @@ class _Bip39ListScreenState extends State<Bip39ListScreen> {
     final indexNum = data['index'] as int;
     final type = data['type'] as String?;
     final query = _searchController.text.toLowerCase();
+    final decimalStr = (indexNum - 1).toString();
     final binaryStr = (indexNum - 1).toRadixString(2).padLeft(11, '0');
+    final groupedBinaryStr = '${binaryStr.substring(0, 4)} ${binaryStr.substring(4, 8)} ${binaryStr.substring(8, 11)}';
 
     return Column(
       children: [
         ListTile(
+          contentPadding: const EdgeInsets.symmetric(horizontal: 24),
           title: RichText(
             text: TextSpan(
               children: highlightOccurrences(context, item, query),
@@ -305,12 +311,20 @@ class _Bip39ListScreenState extends State<Bip39ListScreen> {
             text: TextSpan(
               style: typography.caption.copyWith(color: colors.tertiaryText, fontSize: 16),
               children: [
-                const TextSpan(text: 'Binary: '),
                 ...highlightOccurrences(
                   context,
-                  binaryStr,
-                  type == 'numeric' ? binaryStr : (type == 'binary' ? query : ''),
+                  decimalStr,
+                  type == 'numeric' ? decimalStr : '',
                   isIndex: true,
+                  tabularFigures: true,
+                ),
+                const TextSpan(text: '  ·  '),
+                ...highlightOccurrences(
+                  context,
+                  groupedBinaryStr,
+                  type == 'numeric' ? groupedBinaryStr : (type == 'binary' ? query : ''),
+                  isIndex: true,
+                  tabularFigures: true,
                 ),
               ],
             ),


### PR DESCRIPTION
## 작업 항목
- 이진수를 4-4-3 자리로 그룹핑([X 한량님 요청](https://x.com/1happybtc/status/2085319285560541486?s=20)), 
  - 이진수 텍스트를 동일 너비로 정렬
- "Binary:" 라벨을 제거하고 십진수·이진수를 함께 표시 
  - 이유: 검색 결과에서 유사도가 높은 것이 먼저 나타남. 10 검색 시, 'access 0000 0001 010'이 최상단에 나타남. decimal 10인 access가 나타나는게 로직으로는 맞지만 사용자는 decimal '10'을 화면상에서 볼 수 없기 때문에 오동작으로 느낄 수 있음.
- 리스트 아이템 좌측 패딩 추가
- 어색한 검색 placeholder 문구(en/ja/es/de) 수정, 긴 문구 조정

## 테스트 
- [x] BIP39 단어 리스트 화면에서 알파벳/숫자/이진수 검색이 정상 동작하는지 확인
- [x] 각 언어(en/ko/ja/es/de)로 전환해 검색 placeholder가 잘리지 않는지 확인