### PR TITLE
Electrum 서버 인증서 검사 로직 개선

### DIFF
--- a/assets/i18n/de.i18n.yaml
+++ b/assets/i18n/de.i18n.yaml
@@ -757,9 +757,13 @@ settings_screen:
       network_mismatch: "Verbindung nicht möglich – falsches Netzwerk"
       connecting: "Verbinde..."
       connected: "Verbunden"
+      untrusted_certificate: "Nicht vertrauenswürdiges Zertifikat"
     popup:
       delete_server_info: "Serverinformationen löschen"
       delete_server_info_description: "Sind Sie sicher, dass Sie die gespeicherten Serverinformationen löschen möchten?"
+      untrusted_certificate_title: "Zertifikat nicht vertrauenswürdig"
+      untrusted_certificate_description: "Dieser Server verwendet kein Zertifikat, das von einer vertrauenswürdigen Zertifizierungsstelle (CA) signiert wurde. Fahren Sie nur fort, wenn Sie diesen Server selbst betreiben und der untenstehende Fingerabdruck korrekt ist. Andernfalls stellen Sie keine Verbindung her.\n\nZertifikat-Fingerabdruck (SHA-256)\n$fingerprint"
+      trust_and_continue: "Vertrauen & Fortfahren"
   block_explorer:
     default_explorer: "Standard-Explorer"
     custom_explorer: "Benutzerdefinierter Explorer"
@@ -1238,6 +1242,7 @@ errors:
   storage_write_error: "Fehler beim Speichern der Daten im Speicher."
   network_error: "Keine Verbindung zum Netzwerk möglich. Bitte überprüfen Sie Ihren Verbindungsstatus."
   node_connection_error: "Verbindung zum Bitcoin-Knoten fehlgeschlagen."
+  untrusted_certificate_error: "Dem Zertifikat des Servers konnte nicht vertraut werden."
   fetch_wallet_error: "Wallet konnte nicht abgerufen werden."
   wallet_sync_failed_error: "Wallet-Informationen konnten nicht aus dem Netzwerk geladen werden"
   fetch_balance_error: "Guthaben konnte nicht abgerufen werden."

--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -826,9 +826,13 @@ settings_screen:
       network_mismatch: "Can't connect — different network"
       connecting: "Connecting..."
       connected: "Connected"
+      untrusted_certificate: "Untrusted certificate"
     popup:
       delete_server_info: "Delete Server Info"
       delete_server_info_description: "Are you sure you want to delete the saved server information?"
+      untrusted_certificate_title: "Certificate Not Trusted"
+      untrusted_certificate_description: "This server does not use a certificate signed by a trusted certificate authority (CA). Only continue if you personally operate this server and the fingerprint below is correct. Otherwise, do not connect.\n\nCertificate Fingerprint (SHA-256)\n$fingerprint"
+      trust_and_continue: "Trust & Continue"
   block_explorer:
     default_explorer: "Default Explorer"
     custom_explorer: "Custom Explorer"
@@ -1307,6 +1311,7 @@ errors:
   storage_write_error: "Failed to save data to storage."
   network_error: "Cannot connect to network. Please check your connection status."
   node_connection_error: "Failed to connect to Bitcoin node."
+  untrusted_certificate_error: "The server's certificate could not be trusted."
   fetch_wallet_error: "Failed to fetch wallet."
   wallet_sync_failed_error: "Failed to load wallet information from network"
   fetch_balance_error: "Failed to fetch balance."

--- a/assets/i18n/es.i18n.yaml
+++ b/assets/i18n/es.i18n.yaml
@@ -817,9 +817,13 @@ settings_screen:
       network_mismatch: "No se puede conectar: red incompatible"
       connecting: "Conectando..."
       connected: "Conectado"
+      untrusted_certificate: "Certificado no confiable"
     popup:
       delete_server_info: "Eliminar información del servidor"
       delete_server_info_description: "¿Estás seguro de querer eliminar la información del servidor guardada?"
+      untrusted_certificate_title: "Certificado no confiable"
+      untrusted_certificate_description: "Este servidor no utiliza un certificado firmado por una autoridad de certificación (CA) de confianza. Continúa solo si tú mismo operas este servidor y la huella digital a continuación es correcta. De lo contrario, no te conectes.\n\nHuella digital del certificado (SHA-256)\n$fingerprint"
+      trust_and_continue: "Confiar y continuar"
   block_explorer:
     default_explorer: "Explorador predeterminado"
     custom_explorer: "Explorador personalizado"
@@ -1298,7 +1302,8 @@ errors:
   storage_write_error: "Fallo al guardar datos en el almacenamiento."
   network_error: "No se puede conectar a la red. Por favor, verifique su estado de conexión."
   node_connection_error: "Fallo al conectar a la red Bitcoin."
-  fetch_wallet_error: "Fallo al obtener la billetera." 
+  untrusted_certificate_error: "No se pudo confiar en el certificado del servidor."
+  fetch_wallet_error: "Fallo al obtener la billetera."
   wallet_sync_failed_error: "Fallo al cargar la información de la billetera desde la red" 
   fetch_balance_error: "Fallo al obtener el saldo."
   fetch_transaction_list_error: "Fallo al obtener el historial de transacciones."

--- a/assets/i18n/ja.i18n.yaml
+++ b/assets/i18n/ja.i18n.yaml
@@ -813,9 +813,13 @@ settings_screen:
       network_mismatch: "ネットワークが異なるため接続できません"
       connecting: "接続中..."
       connected: "接続済み"
+      untrusted_certificate: "信頼できない証明書です"
     popup:
       delete_server_info: "サーバー情報を削除"
       delete_server_info_description: "保存されたサーバー情報を削除してもよろしいですか？"
+      untrusted_certificate_title: "証明書を信頼できません"
+      untrusted_certificate_description: "このサーバーは信頼できる認証局（CA）によって署名された証明書を使用していません。ご自身でこのサーバーを運用しており、下記のフィンガープリントが正しい場合のみ続行してください。そうでない場合は接続しないでください。\n\n証明書フィンガープリント（SHA-256）\n$fingerprint"
+      trust_and_continue: "信頼して続行"
   block_explorer:
     default_explorer: "デフォルトエクスプローラー"
     custom_explorer: "カスタムエクスプローラー"
@@ -1295,6 +1299,7 @@ errors:
   storage_write_error: "ストレージへのデータ保存に失敗しました。"
   network_error: "ネットワークに接続できません。接続状態を確認してください。"
   node_connection_error: "ビットコインノードへの接続に失敗しました。"
+  untrusted_certificate_error: "サーバーの証明書を信頼できませんでした。"
   fetch_wallet_error: "ウォレットの取得に失敗しました。"
   wallet_sync_failed_error: "ネットワークからウォレット情報の読み込みに失敗"
   fetch_balance_error: "残高の取得に失敗しました。"

--- a/assets/i18n/ko.i18n.yaml
+++ b/assets/i18n/ko.i18n.yaml
@@ -829,9 +829,13 @@ settings_screen:
       network_mismatch: "네트워크가 달라 연결할 수 없어요"
       connecting: "연결 중입니다"
       connected: "연결되었습니다"
+      untrusted_certificate: "신뢰할 수 없는 인증서예요"
     popup:
       delete_server_info: "서버 정보 삭제"
       delete_server_info_description: "저장된 서버 정보를 삭제하시겠어요?"
+      untrusted_certificate_title: "인증서를 신뢰할 수 없어요"
+      untrusted_certificate_description: "이 서버는 신뢰할 수 있는 인증기관(CA)의 인증서를 사용하지 않아요. 본인이 직접 운영하는 서버가 맞고 아래 지문이 정확하다면 신뢰하고 계속할 수 있어요. 그렇지 않다면 연결하지 마세요.\n\n인증서 지문 (SHA-256)\n$fingerprint"
+      trust_and_continue: "신뢰하고 계속"
   block_explorer:
     default_explorer: "기본 익스플로러"
     custom_explorer: "직접 입력"
@@ -1313,6 +1317,7 @@ errors:
   storage_write_error: "저장소에 데이터를 저장하는데 실패했습니다."
   network_error: "네트워크에 연결할 수 없어요. 연결 상태를 확인해 주세요."
   node_connection_error: "비트코인 노드와 연결하는데 실패했습니다."
+  untrusted_certificate_error: "서버 인증서를 신뢰할 수 없습니다."
   fetch_wallet_error: "지갑을 가져오는데 실패했습니다."
   wallet_sync_failed_error: "네트워크에서 지갑 정보 불러오기 실패"
   fetch_balance_error: "잔액 조회를 실패했습니다."

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -7,6 +7,7 @@ import 'package:coconut_wallet/constants/dotenv_keys.dart';
 import 'package:coconut_wallet/firebase_options.dart';
 import 'package:coconut_wallet/constants/shared_pref_keys.dart';
 import 'package:coconut_wallet/design_system/theme/coconut_theme_data.dart';
+import 'package:coconut_wallet/providers/preferences/electrum_server_provider.dart';
 import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
 import 'package:coconut_wallet/utils/app_icon_util.dart';
 import 'package:coconut_wallet/utils/file_logger.dart';
@@ -27,6 +28,8 @@ class AppBootstrap {
     await configureSystemUi();
 
     await _loadEnvironment();
+    // 기본 서버 매칭(findMatching)이 NetworkType에 의존하므로 _loadEnvironment() 이후에 호출해야 한다.
+    await ElectrumServerProvider().migrateLegacyCustomServerStorage();
     await _initializeFirebase();
     await FileLogger.initialize();
     await _updateAppIconIfNeeded();

--- a/lib/constants/shared_pref_keys.dart
+++ b/lib/constants/shared_pref_keys.dart
@@ -63,6 +63,7 @@ class SharedPrefKeys {
   static const String kCustomElectrumHost = 'CUSTOM_ELECTRUM_HOST';
   static const String kCustomElectrumPort = 'CUSTOM_ELECTRUM_PORT';
   static const String kCustomElectrumIsSsl = 'CUSTOM_ELECTRUM_IS_SSL';
+  static const String kCustomElectrumCertFingerprint = 'CUSTOM_ELECTRUM_CERT_FINGERPRINT';
   static const String kUserServers = 'USER_SERVERS';
   static const String kBaselineGenesisHash = 'BASELINE_GENESIS_HASH';
 

--- a/lib/enums/electrum_enums.dart
+++ b/lib/enums/electrum_enums.dart
@@ -1,3 +1,4 @@
+import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_wallet/model/node/electrum_server.dart';
 
 enum DefaultElectrumServer {
@@ -7,15 +8,63 @@ enum DefaultElectrumServer {
     1,
     false, // isRegtest
   ),
-  fulrum(ElectrumServer('fulcrum2.not.fyi', 51002, true), 'FULRUM', 2, false),
+  // self-signed 인증서를 쓰는 개인/커뮤니티 운영 서버들은 2026-09-02 기준 확인한 지문을 고정한다.
+  // 서버 운영자가 인증서를 재발급하면 연결이 끊기므로, 그 경우 새 지문으로 갱신해야 한다.
+  fulrum(
+    ElectrumServer(
+      'fulcrum2.not.fyi',
+      51002,
+      true,
+      pinnedCertFingerprint:
+          '16:0D:3E:0C:AD:F1:D1:D3:52:70:7E:9D:50:41:25:E1:8F:A2:E8:75:E1:11:AC:0D:56:FC:43:E9:26:2F:8D:3E',
+    ),
+    'FULRUM',
+    2,
+    false,
+  ),
   nunchuk(ElectrumServer('mainnet.nunchuk.io', 51001, false), 'NUNCHUK', 3, false),
   acinq(ElectrumServer('electrum.acinq.co', 50002, true), 'ACINQ', 4, false),
-  foundationdevices(ElectrumServer('mainnet.foundationdevices.com', 50002, true), 'FOUNDATIONDEVICES', 5, false),
-  bluewallet(ElectrumServer('electrum1.bluewallet.io', 443, true), 'BLUEWALLET', 6, false),
-  lukechilds(ElectrumServer('bitcoin.lukechilds.co', 50002, true), 'LUKECHILDS', 7, false),
-  bitaroo(ElectrumServer('electrum.bitaroo.net', 50002, true), 'BITAROO', 8, false),
-  jochenhoenicke(ElectrumServer('electrum.jochen-hoenicke.de', 50006, true), 'JOCHENHOENICKE', 9, false),
-  emzy(ElectrumServer('electrum.emzy.de', 50002, true), 'EMZY', 10, false),
+  // 기존 mainnet.foundationdevices.com / electrum1.bluewallet.io 는 CA 인증서의 CN이 도메인과 달라 표준 검증에 실패
+  // 실제 응답하는 인증서 도메인으로 접속 주소 업데이트
+  foundationdevices(ElectrumServer('mainnet-0.foundation.xyz', 50002, true), 'FOUNDATIONDEVICES', 5, false),
+  bluewallet(ElectrumServer('electrum2.bluewallet.io', 443, true), 'BLUEWALLET', 6, false),
+  lukechilds(
+    ElectrumServer(
+      'bitcoin.lukechilds.co',
+      50002,
+      true,
+      pinnedCertFingerprint:
+          '4B:CD:74:8E:B9:34:A1:16:FD:6E:8D:08:D3:21:AC:2B:BE:03:50:E1:56:B6:21:92:9C:CA:55:18:BC:A7:36:4F',
+    ),
+    'LUKECHILDS',
+    7,
+    false,
+  ),
+  bitaroo(
+    ElectrumServer(
+      'electrum.bitaroo.net',
+      50002,
+      true,
+      pinnedCertFingerprint:
+          '4B:7E:A6:8D:5E:91:D8:7C:E0:DF:86:62:07:98:25:41:0A:58:59:C1:5E:AE:AB:3C:31:84:B5:E0:BE:B2:6B:D3',
+    ),
+    'BITAROO',
+    8,
+    false,
+  ),
+  // 인증서 만료: 2026-10-11. 만료/갱신 시 새 지문으로 교체 필요
+  emzy(
+    ElectrumServer(
+      'electrum.emzy.de',
+      50002,
+      true,
+      pinnedCertFingerprint:
+          'B2:5D:A2:92:9C:0F:65:E0:16:CF:EC:2A:24:66:1F:FC:58:7F:DD:D8:32:F5:0A:ED:26:E0:5A:2E:DE:4C:DF:34',
+    ),
+    'EMZY',
+    10,
+    false,
+  ),
   blockstream(ElectrumServer('blockstream.info', 700, true), 'BLOCKSTREAM', 11, false),
 
   // Testnet
@@ -43,6 +92,24 @@ enum DefaultElectrumServer {
       (e) => e.serverName == serverType,
       orElse: () => DefaultElectrumServer.coconut,
     );
+  }
+
+  /// 현재 네트워크 타입(mainnet/testnet/regtest) 기준으로 host/port/ssl이 정확히 일치하는
+  /// 기본 서버 항목을 찾는다. 없으면 null(=사용자가 지정한 진짜 커스텀 서버).
+  static DefaultElectrumServer? findMatching(String host, int port, bool ssl) {
+    final networkType = NetworkType.currentNetworkType;
+    for (final e in DefaultElectrumServer.values) {
+      final matchesFlavor =
+          networkType == NetworkType.regtest
+              ? e.isRegtest
+              : networkType == NetworkType.testnet
+              ? e.isTestnet
+              : (!e.isRegtest && !e.isTestnet);
+      if (matchesFlavor && e.server.host == host && e.server.port == port && e.server.ssl == ssl) {
+        return e;
+      }
+    }
+    return null;
   }
 
   /// Flavor에 따른 서버 리스트 반환

--- a/lib/enums/node_connection_status.dart
+++ b/lib/enums/node_connection_status.dart
@@ -5,4 +5,5 @@ enum NodeConnectionStatus {
   failed, // 연결할 수 없습니다!
   networkMismatch, // 네트워크가 달라 연결할 수 없어요
   waiting, // 대기중
+  untrustedCertificate, // 서버 인증서를 신뢰할 수 없어 사용자 확인이 필요합니다 (커스텀 서버 전용)
 }

--- a/lib/model/error/app_error.dart
+++ b/lib/model/error/app_error.dart
@@ -33,6 +33,7 @@ class ErrorCodes {
   static AppError nodeIsolateError = AppError('1301', t.errors.node_unknown);
   static AppError broadcastError = AppError('1302', t.errors.broadcast_error);
   static AppError chainMismatchError = AppError('1303', t.errors.chain_mismatch_error);
+  static AppError untrustedCertificateError = AppError('1304', t.errors.untrusted_certificate_error);
   static AppError broadcastErrorWithMessage(String message) => ErrorCodes.withMessage(broadcastError, message);
   static AppError invalidTransactionDraftId = AppError('1400', t.errors.transaction_draft.invalid_id);
   static AppError transactionDraftAlreadyExists = AppError(

--- a/lib/model/node/electrum_server.dart
+++ b/lib/model/node/electrum_server.dart
@@ -3,9 +3,29 @@ class ElectrumServer {
   final int port;
   final bool ssl;
 
-  const ElectrumServer(this.host, this.port, this.ssl);
+  /// 사용자가 명시적으로 신뢰를 승인한 인증서의 SHA-256 지문
+  /// 기본 제공 서버는 항상 null이며, OS 표준 인증서 검증만 적용된다.
+  /// 커스텀(자체 호스팅) 서버에서 인증서 검증이 실패했을 때만 사용자가 지문을 확인하고 승인한 경우에 채워지며,
+  /// 이후 연결에서는 이 지문과 정확히 일치하는 인증서만 허용된다.
+  final String? pinnedCertFingerprint;
 
-  factory ElectrumServer.custom(String host, int port, bool ssl) {
-    return ElectrumServer(host, port, host.contains('.onion') ? false : ssl);
+  const ElectrumServer(this.host, this.port, this.ssl, {this.pinnedCertFingerprint});
+
+  factory ElectrumServer.custom(String host, int port, bool ssl, {String? pinnedCertFingerprint}) {
+    return ElectrumServer(
+      host,
+      port,
+      host.contains('.onion') ? false : ssl,
+      pinnedCertFingerprint: pinnedCertFingerprint,
+    );
+  }
+
+  ElectrumServer copyWith({String? host, int? port, bool? ssl, String? pinnedCertFingerprint}) {
+    return ElectrumServer(
+      host ?? this.host,
+      port ?? this.port,
+      ssl ?? this.ssl,
+      pinnedCertFingerprint: pinnedCertFingerprint ?? this.pinnedCertFingerprint,
+    );
   }
 }

--- a/lib/model/node/spawn_isolate_dto.dart
+++ b/lib/model/node/spawn_isolate_dto.dart
@@ -8,6 +8,14 @@ class SpawnIsolateDto {
   final int port;
   final bool ssl;
   final NetworkType networkType;
+  final String? pinnedCertFingerprint;
 
-  SpawnIsolateDto(this.isolateToMainSendPort, this.host, this.port, this.ssl, this.networkType);
+  SpawnIsolateDto(
+    this.isolateToMainSendPort,
+    this.host,
+    this.port,
+    this.ssl,
+    this.networkType, [
+    this.pinnedCertFingerprint,
+  ]);
 }

--- a/lib/providers/node_provider/isolate/isolate_manager.dart
+++ b/lib/providers/node_provider/isolate/isolate_manager.dart
@@ -63,7 +63,13 @@ class IsolateManager {
     _isolateReady = Completer<void>();
   }
 
-  Future<void> initialize(String host, int port, bool ssl, NetworkType networkType) async {
+  Future<void> initialize(
+    String host,
+    int port,
+    bool ssl,
+    NetworkType networkType, [
+    String? pinnedCertFingerprint,
+  ]) async {
     // 이미 초기화 중인 경우 기존 작업 완료 대기
     if (_isInitializing) {
       Logger.log('IsolateManager: Already initializing, waiting for completion');
@@ -84,7 +90,7 @@ class IsolateManager {
       _createIsolateCompleter();
 
       final isolateToMainSendPort = _mainFromIsolateReceivePort!.sendPort;
-      final data = SpawnIsolateDto(isolateToMainSendPort, host, port, ssl, networkType);
+      final data = SpawnIsolateDto(isolateToMainSendPort, host, port, ssl, networkType, pinnedCertFingerprint);
 
       _isolate = await Isolate.spawn<SpawnIsolateDto>(_isolateEntry, data);
       _setUpReceivePortListener();
@@ -269,7 +275,12 @@ class IsolateManager {
     final electrumService = ElectrumService();
 
     try {
-      final isConnected = await electrumService.connect(data.host, data.port, ssl: data.ssl);
+      final isConnected = await electrumService.connect(
+        data.host,
+        data.port,
+        ssl: data.ssl,
+        pinnedCertFingerprint: data.pinnedCertFingerprint,
+      );
 
       final isolateController = IsolateInitializer.entryInitialize(data.isolateToMainSendPort, electrumService);
 

--- a/lib/providers/node_provider/node_provider.dart
+++ b/lib/providers/node_provider/node_provider.dart
@@ -27,6 +27,8 @@ import 'package:coconut_wallet/services/analytics_service.dart';
 import 'package:coconut_wallet/services/electrum_service.dart';
 import 'package:coconut_wallet/services/model/response/block_timestamp.dart';
 import 'package:coconut_wallet/services/model/response/recommended_fee.dart';
+import 'package:coconut_wallet/services/network/socket/socket_factory.dart';
+import 'package:coconut_wallet/utils/certificate_util.dart';
 import 'package:coconut_wallet/utils/result.dart';
 import 'package:flutter/foundation.dart';
 
@@ -204,6 +206,7 @@ class NodeProvider extends ChangeNotifier {
   String get host => _electrumServer.host;
   int get port => _electrumServer.port;
   bool get ssl => _electrumServer.ssl;
+  String? get pinnedCertFingerprint => _electrumServer.pinnedCertFingerprint;
   bool get isServerChanging => _isServerChanging;
   bool get hasConnectionError => _hasConnectionError;
   int get currentBlockHeight => _currentBlockNotifier.value?.height ?? 0;
@@ -383,7 +386,7 @@ class NodeProvider extends ChangeNotifier {
     try {
       _createNewCompleter();
       _createStateManager();
-      await _isolateManager.initialize(host, port, ssl, _networkType);
+      await _isolateManager.initialize(host, port, ssl, _networkType, pinnedCertFingerprint);
       unawaited(_recordCurrentServerGenesisHash());
 
       if (_initCompleter != null && !_initCompleter!.isCompleted) {
@@ -694,6 +697,9 @@ class NodeProvider extends ChangeNotifier {
     } catch (e) {
       Logger.error('NodeProvider: 서버 연결 확인 실패 - ${electrumServer.host}:${electrumServer.port}: $e');
       await electrumService.close();
+      if (electrumService.lastConnectionFailedDueToUntrustedCertificate) {
+        return Result.failure(ErrorCodes.untrustedCertificateError);
+      }
       return Result.failure(ErrorCodes.networkError);
     } finally {
       await electrumService.close();
@@ -704,10 +710,29 @@ class NodeProvider extends ChangeNotifier {
     final isOnionHost = server.host.trim().toLowerCase().endsWith('.onion');
     final connectionTimeout = isOnionHost ? kIsolateInitTimeoutForOnion : kIsolateInitTimeout;
 
-    await service.connect(server.host, server.port, ssl: server.ssl).timeout(connectionTimeout);
+    await service
+        .connect(server.host, server.port, ssl: server.ssl, pinnedCertFingerprint: server.pinnedCertFingerprint)
+        .timeout(connectionTimeout);
 
     if (service.connectionStatus != SocketConnectionStatus.connected) {
       throw Exception('Socket connection failed');
+    }
+  }
+
+  /// 커스텀 서버가 제시하는 인증서의 SHA-256 지문을 확인만 하기 위한 임시 연결
+  /// 실제 프로토콜 통신은 하지 않으며, TOFU 확인 UI에서만 사용한다.
+  Future<Result<String>> probeCertificateFingerprint(ElectrumServer server) async {
+    try {
+      final cert = await DefaultSocketFactory().peekCertificate(server.host, server.port).timeout(kIsolateInitTimeout);
+
+      if (cert == null) {
+        return Result.failure(ErrorCodes.networkError);
+      }
+
+      return Result.success(CertificateUtil.sha256Fingerprint(cert));
+    } catch (e) {
+      Logger.error('NodeProvider: 인증서 확인 실패 - ${server.host}:${server.port}: $e');
+      return Result.failure(ErrorCodes.networkError);
     }
   }
 

--- a/lib/providers/node_provider/node_provider.dart
+++ b/lib/providers/node_provider/node_provider.dart
@@ -572,27 +572,29 @@ class NodeProvider extends ChangeNotifier {
     return result;
   }
 
-  /// 연결이 끊긴 상태면(NodeSyncState.failed 또는 hasConnectionError) 재연결을 시도한다.
+  /// 연결이 끊긴 상태면 재연결을 시도
   /// pull-to-refresh 등에서 조건 분기 없이 호출할 수 있도록, 필요 없으면 내부에서 바로 no-op한다.
-  Future<void> reconnectIfNeeded() async {
-    if (state.nodeSyncState != NodeSyncState.failed && !hasConnectionError) return;
-    await reconnect();
+  Future<Result<bool>> reconnectIfNeeded() async {
+    if (!isInitialized) return reconnect();
+    if (state.nodeSyncState != NodeSyncState.failed && !hasConnectionError) return Result.success(true);
+    return reconnect();
   }
 
-  Future<void> reconnect() async {
-    _setConnectionError(false); // 재연결 시작 시 에러 상태 리셋
+  Future<Result<bool>> reconnect() async {
     // 네트워크 연결 상태 확인
     if (_connectivityProvider.isInternetOff) {
       Logger.log('NodeProvider: 네트워크가 연결되지 않아 재연결을 보류합니다.');
       _isPendingInitialization = true;
-      return;
+      return Result.failure(ErrorCodes.networkError);
     }
 
     // 이미 초기화 중이거나 종료 중인 경우 대기
     if (_isInitializing || _isClosing) {
       Logger.log('NodeProvider: Reconnect skipped - operation in progress');
-      return;
+      return Result.failure(ErrorCodes.nodeConnectionError);
     }
+
+    _setConnectionError(false); // 재연결 시작 시 에러 상태 리셋
 
     try {
       Logger.log('NodeProvider: Starting reconnect');
@@ -615,26 +617,31 @@ class NodeProvider extends ChangeNotifier {
           _setConnectionError(false);
           _restartBlockUpdates();
           _analyticsService?.logWalletBulkSyncCompleted();
+          return Result.success(true);
         } else {
           Logger.error('NodeProvider: subscribeWallets failed: ${result.error}');
           _stateManager?.setNodeSyncStateToFailed();
           _setConnectionError(true);
           _analyticsService?.logWalletBulkSyncFailed();
+          return Result.failure(result.error);
         }
       } else if (walletLoadState == WalletLoadState.loadCompleted && walletItems.isEmpty) {
         Logger.log('NodeProvider: Wallet Loaded & Wallet Items is Empty, set state to completed');
         _stateManager?.setNodeSyncStateToCompleted();
         _setConnectionError(false);
         notifyListeners();
+        return Result.success(true);
       } else {
         Logger.log('NodeProvider: Wallet Loading, reset flag for auto-subscription');
         _isFirstInitialization = true;
         notifyListeners();
+        return Result.success(true);
       }
     } catch (e) {
       Logger.error('NodeProvider: Reconnect failed: $e');
       _setConnectionError(true);
       _stateManager?.setNodeSyncStateToFailed();
+      return Result.failure(ErrorCodes.networkError);
     }
   }
 
@@ -831,9 +838,10 @@ class NodeProvider extends ChangeNotifier {
     }
   }
 
+  /// 사용할 엔드포인트만 교체하고, 실제 소켓은 건드리지 않는다.
+  /// 일렉트럼 서버 설정 화면에서 사용자가 후보를 고르는 동안 연결/해제가 반복되지 않도록,
+  /// 실제 반영은 화면을 벗어나는 시점에 [applyServerChange]로 한 번만 수행한다.
   Future<Result<bool>> changeServer(ElectrumServer electrumServer) async {
-    _isServerChanging = true;
-
     try {
       final chainCheckResult = await _verifyChainCompatibility(electrumServer);
       if (chainCheckResult.isFailure) {
@@ -841,29 +849,36 @@ class NodeProvider extends ChangeNotifier {
         return Result.failure(chainCheckResult.error);
       }
 
-      await closeConnection();
       _electrumServer = electrumServer;
 
-      Logger.log('NodeProvider: 서버 변경: $host:$port, ssl=$ssl');
+      Logger.log('NodeProvider: 서버 엔드포인트 교체: $host:$port, ssl=$ssl');
 
-      await initialize();
-
-      subscribeWallets().then((result) {
-        if (result.isFailure) {
-          Logger.error('NodeProvider: 서버 변경 실패: ${result.error}');
-          _stateManager?.setNodeSyncStateToFailed();
-          notifyListeners();
-        }
-      });
-
-      Logger.log('NodeProvider: 서버 변경 성공');
       notifyListeners();
       return Result.success(true);
     } catch (e) {
-      Logger.error('NodeProvider: 서버 변경 중 초기화 실패: $e');
-      _stateManager?.setNodeSyncStateToFailed();
+      Logger.error('NodeProvider: 서버 엔드포인트 교체 실패: $e');
       notifyListeners();
       return Result.failure(ErrorCodes.networkError);
+    }
+  }
+
+  /// [changeServer]로 교체해둔 엔드포인트를 실제 연결에 반영한다.
+  /// reconnect는 host/port/ssl/pinnedCertFingerprint 게터를 통해 _electrumServer를 읽으므로,
+  /// 여기서 새 엔드포인트로 소켓이 다시 열리는 것이 보장된다.
+  Future<Result<bool>> applyServerChange() async {
+    _isServerChanging = true;
+
+    try {
+      Logger.log('NodeProvider: 서버 변경 반영: $host:$port, ssl=$ssl');
+      final result = await reconnect();
+
+      if (result.isFailure) {
+        Logger.error('NodeProvider: 서버 변경 반영 실패: ${result.error}');
+      } else {
+        Logger.log('NodeProvider: 서버 변경 반영 성공');
+      }
+
+      return result;
     } finally {
       _isServerChanging = false;
     }

--- a/lib/providers/node_provider/subscription/subscription_service.dart
+++ b/lib/providers/node_provider/subscription/subscription_service.dart
@@ -242,20 +242,18 @@ class SubscriptionService {
       return _scanAndSubscribeRange(walletItem, isChange, 0, minKnownUsedIndex ?? -1, scriptStatusController);
     }
 
-    List<ScriptStatus> scriptStatuses = [];
     final activeAddresses = _addressRepository.getActiveUsedAddresses(walletItem.id, isChange);
-    for (final activeAddress in activeAddresses) {
-      final result = await _subscribeAddress(
-        walletItem,
-        activeAddress.index,
-        activeAddress.address,
-        isChange,
-        scriptStatusController,
-      );
-      if (!result.isSubscribed) {
-        scriptStatuses.add(result.scriptStatus);
-      }
-    }
+    final activeResults = await Future.wait(
+      activeAddresses.map(
+        (activeAddress) =>
+            _subscribeAddress(walletItem, activeAddress.index, activeAddress.address, isChange, scriptStatusController),
+      ),
+    );
+
+    List<ScriptStatus> scriptStatuses = [
+      for (final result in activeResults)
+        if (!result.isSubscribed) result.scriptStatus,
+    ];
 
     final scanResult = await _scanAndSubscribeRange(
       walletItem,

--- a/lib/providers/preferences/electrum_server_provider.dart
+++ b/lib/providers/preferences/electrum_server_provider.dart
@@ -10,7 +10,45 @@ class ElectrumServerProvider extends ChangeNotifier {
 
   static const String _customServerLabel = 'CUSTOM';
 
+  /// 기본 서버의 실제 인증서 도메인이 바뀌어 접속 주소가 달라진 경우의 이전 주소 매핑
+  /// migrateLegacyCustomServerStorage에서 기본 서버 매칭을 시도하기 전에 먼저 적용한다.
+  static const Map<String, String> _legacyDefaultServerHostAliases = {
+    'mainnet.foundationdevices.com': 'mainnet-0.foundation.xyz',
+    'electrum1.bluewallet.io': 'electrum2.bluewallet.io',
+  };
+
   ElectrumServerProvider();
+
+  /// 기본 서버를 선택했을 때 host/port/ssl을 리터럴로 저장하지 않고 serverName 참조로 저장한다.
+  /// 이후 해당 기본 서버의 host나 지문이 바뀌어도 getElectrumServer()가 항상 최신 enum 값을 반환한다.
+  Future<void> setSelectedDefaultServer(String serverName) async {
+    await _sharedPrefs.setString(SharedPrefKeys.kElectrumServerName, serverName);
+    await _sharedPrefs.deleteMultipleKeys([
+      SharedPrefKeys.kCustomElectrumHost,
+      SharedPrefKeys.kCustomElectrumPort,
+      SharedPrefKeys.kCustomElectrumIsSsl,
+      SharedPrefKeys.kCustomElectrumCertFingerprint,
+    ]);
+    notifyListeners();
+  }
+
+  /// 앱 부팅 시(NetworkType 결정 이후) 1회 호출
+  /// 예전 구조에서는 기본 서버를 선택해도 무조건 'CUSTOM' + 리터럴 host/port/ssl로 저장하는 구조 개선
+  /// - 저장된 값이 실제로는 기본 서버와 일치하면 serverName 참조로 옮긴다.
+  /// - 사용자가 직접 등록한 커스텀 서버 목록(kUserServers)은 건드리지 않는다.
+  Future<void> migrateLegacyCustomServerStorage() async {
+    if (_sharedPrefs.getString(SharedPrefKeys.kElectrumServerName) != _customServerLabel) return;
+
+    final storedHost = _sharedPrefs.getString(SharedPrefKeys.kCustomElectrumHost);
+    final host = _legacyDefaultServerHostAliases[storedHost] ?? storedHost;
+    final port = _sharedPrefs.getInt(SharedPrefKeys.kCustomElectrumPort);
+    final ssl = _sharedPrefs.getBool(SharedPrefKeys.kCustomElectrumIsSsl);
+
+    final matched = DefaultElectrumServer.findMatching(host, port, ssl);
+    if (matched != null) {
+      await setSelectedDefaultServer(matched.serverName);
+    }
+  }
 
   void _validateCustomElectrumServerParams(String host, int port, bool ssl) {
     if (host.trim().isEmpty) {
@@ -22,12 +60,17 @@ class ElectrumServerProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> setCustomElectrumServer(String host, int port, bool ssl) async {
+  Future<void> setCustomElectrumServer(String host, int port, bool ssl, {String? pinnedCertFingerprint}) async {
     _validateCustomElectrumServerParams(host, port, ssl);
     await _sharedPrefs.setString(SharedPrefKeys.kElectrumServerName, _customServerLabel);
     await _sharedPrefs.setString(SharedPrefKeys.kCustomElectrumHost, host);
     await _sharedPrefs.setInt(SharedPrefKeys.kCustomElectrumPort, port);
     await _sharedPrefs.setBool(SharedPrefKeys.kCustomElectrumIsSsl, ssl);
+    if (pinnedCertFingerprint != null) {
+      await _sharedPrefs.setString(SharedPrefKeys.kCustomElectrumCertFingerprint, pinnedCertFingerprint);
+    } else {
+      await _sharedPrefs.deleteSharedPrefsWithKey(SharedPrefKeys.kCustomElectrumCertFingerprint);
+    }
     notifyListeners();
   }
 
@@ -50,6 +93,7 @@ class ElectrumServerProvider extends ChangeNotifier {
         _sharedPrefs.getString(SharedPrefKeys.kCustomElectrumHost),
         _sharedPrefs.getInt(SharedPrefKeys.kCustomElectrumPort),
         _sharedPrefs.getBool(SharedPrefKeys.kCustomElectrumIsSsl),
+        pinnedCertFingerprint: _sharedPrefs.getStringOrNull(SharedPrefKeys.kCustomElectrumCertFingerprint),
       );
     }
 
@@ -60,8 +104,10 @@ class ElectrumServerProvider extends ChangeNotifier {
     return (await _sharedPrefs.getUserServers()) ?? [];
   }
 
-  Future<void> addUserServer(String host, int port, bool ssl) async {
-    await _sharedPrefs.addUserServer(ElectrumServer.custom(host, port, ssl));
+  Future<void> addUserServer(String host, int port, bool ssl, {String? pinnedCertFingerprint}) async {
+    await _sharedPrefs.addUserServer(
+      ElectrumServer.custom(host, port, ssl, pinnedCertFingerprint: pinnedCertFingerprint),
+    );
     notifyListeners();
   }
 

--- a/lib/providers/view_model/home/wallet_home_view_model.dart
+++ b/lib/providers/view_model/home/wallet_home_view_model.dart
@@ -342,11 +342,11 @@ class WalletHomeViewModel extends ChangeNotifier {
   Future<void> onRefresh() async {
     updateWalletBalancesAndRecentTxs();
 
+    await _nodeProvider.reconnectIfNeeded();
+
     for (final wallet in walletItemList) {
       unawaited(_nodeProvider.syncDormantAddresses(wallet));
     }
-
-    _nodeProvider.reconnectIfNeeded();
   }
 
   Future<void> updateWalletBalancesAndRecentTxs() async {

--- a/lib/providers/view_model/settings/electrum_server_view_model.dart
+++ b/lib/providers/view_model/settings/electrum_server_view_model.dart
@@ -30,11 +30,16 @@ class ElectrumServerViewModel extends ChangeNotifier {
   bool _isPortOutOfRangeError = false; // 1 ~ 65535 포트 범위
   bool _isDefaultServerMenuVisible = false; // 기본 서버 메뉴 visibility
 
+  // 인증서를 신뢰할 수 없는 경우, 사용자 확인이 필요한 커스텀 서버와 확인창에 보여줄 지문
+  ElectrumServer? _pendingUntrustedServer;
+  String? _pendingCertificateFingerprint;
+
   NodeConnectionStatus get nodeConnectionStatus => _nodeConnectionStatus;
   Map<ElectrumServer, NodeConnectionStatus> get connectionStatusMap => _connectionStatusMap;
   bool get isServerAddressFormatError => _isServerAddressFormatError;
   bool get isPortOutOfRangeError => _isPortOutOfRangeError;
   bool get isDefaultServerMenuVisible => _isDefaultServerMenuVisible;
+  String? get pendingCertificateFingerprint => _pendingCertificateFingerprint;
 
   ElectrumServerViewModel(this._nodeProvider, this._electrumServerProvider) {
     // 현재 설정된 서버 정보 가져오기
@@ -191,8 +196,16 @@ class ElectrumServerViewModel extends ChangeNotifier {
     setNodeConnectionStatus(NodeConnectionStatus.connecting);
 
     if (!isSameServer) {
+      // 이전에 이미 핀닝된 커스텀 서버라면 저장된 지문을 그대로 사용해 매번 다시 신뢰 확인창을 띄우지 않음
+      newServer = _withKnownFingerprint(newServer);
+
       final connectionResult = await _nodeProvider.checkServerConnection(newServer);
       if (connectionResult.isFailure) {
+        // 커스텀 서버에서 인증서를 신뢰할 수 없는 경우에만 지문 확인 절차 진행
+        if (connectionResult.error.code == ErrorCodes.untrustedCertificateError.code && !_isDefaultServer(newServer)) {
+          await _beginUntrustedCertificateFlow(newServer);
+          return false;
+        }
         setNodeConnectionStatus(NodeConnectionStatus.failed);
         return false;
       }
@@ -210,11 +223,27 @@ class ElectrumServerViewModel extends ChangeNotifier {
     }
 
     _setCurrentServer(newServer);
-    _electrumServerProvider.setCustomElectrumServer(newServer.host, newServer.port, newServer.ssl);
 
-    // 연결된 서버가 default 서버에도 없고, 사용자 서버에도 없으면 사용자 서버 추가
-    if (!_isDefaultServer(newServer) && !_isUserServer(newServer)) {
-      await _electrumServerProvider.addUserServer(newServer.host, newServer.port, newServer.ssl);
+    // 기본 서버는 host/port/ssl을 리터럴로 얼리지 않고 serverName 참조로 저장한다.
+    // 이후 해당 기본 서버의 host나 지문이 바뀌어도 항상 최신 값을 따라간다.
+    final matchedDefault = DefaultElectrumServer.findMatching(newServer.host, newServer.port, newServer.ssl);
+    if (matchedDefault != null) {
+      await _electrumServerProvider.setSelectedDefaultServer(matchedDefault.serverName);
+    } else {
+      await _electrumServerProvider.setCustomElectrumServer(
+        newServer.host,
+        newServer.port,
+        newServer.ssl,
+        pinnedCertFingerprint: newServer.pinnedCertFingerprint,
+      );
+
+      // 커스텀 서버는 사용자 서버 목록에도 (지문 포함) 최신 상태로 저장한다.
+      await _electrumServerProvider.addUserServer(
+        newServer.host,
+        newServer.port,
+        newServer.ssl,
+        pinnedCertFingerprint: newServer.pinnedCertFingerprint,
+      );
       await _loadUserServers();
     }
 
@@ -224,31 +253,67 @@ class ElectrumServerViewModel extends ChangeNotifier {
     return true;
   }
 
+  /// 인증서를 신뢰할 수 없는 커스텀 서버의 지문을 확인하고, TOFU 확인창(untrustedCertificate 상태)으로 전환한다.
+  Future<void> _beginUntrustedCertificateFlow(ElectrumServer server) async {
+    final probeResult = await _nodeProvider.probeCertificateFingerprint(server);
+    if (probeResult.isFailure) {
+      setNodeConnectionStatus(NodeConnectionStatus.failed);
+      return;
+    }
+
+    _pendingUntrustedServer = server;
+    _pendingCertificateFingerprint = probeResult.value;
+    setNodeConnectionStatus(NodeConnectionStatus.untrustedCertificate);
+  }
+
+  /// 사용자가 확인창에서 지문을 확인하고 신뢰를 승인했을 때 호출한다.
+  Future<bool> trustPendingCertificateAndConnect() async {
+    final server = _pendingUntrustedServer;
+    final fingerprint = _pendingCertificateFingerprint;
+    if (server == null || fingerprint == null) {
+      return false;
+    }
+
+    _pendingUntrustedServer = null;
+    _pendingCertificateFingerprint = null;
+
+    return changeServerAndUpdateState(server.copyWith(pinnedCertFingerprint: fingerprint));
+  }
+
+  /// 사용자가 확인창에서 신뢰를 거부했을 때 호출한다.
+  void cancelPendingCertificateTrust() {
+    _pendingUntrustedServer = null;
+    _pendingCertificateFingerprint = null;
+    setNodeConnectionStatus(NodeConnectionStatus.failed);
+  }
+
+  /// 동일한 host/port/ssl로 이미 신뢰 승인되어 저장된 사용자 서버가 있으면 그 지문을 붙여서 반환한다.
+  ElectrumServer _withKnownFingerprint(ElectrumServer server) {
+    if (server.pinnedCertFingerprint != null) return server;
+
+    final known = _findUserServer(server);
+    if (known == null || known.pinnedCertFingerprint == null) return server;
+
+    return server.copyWith(pinnedCertFingerprint: known.pinnedCertFingerprint);
+  }
+
   Future<void> removeUserServer(ElectrumServer server) async {
     await _electrumServerProvider.removeUserServer(server);
     await _loadUserServers();
   }
 
   bool _isDefaultServer(ElectrumServer server) {
-    final networkType = NetworkType.currentNetworkType;
-    final defaultServers =
-        networkType == NetworkType.regtest
-            ? DefaultElectrumServer.regtestServers
-            : networkType == NetworkType.testnet
-            ? DefaultElectrumServer.testnetServers
-            : DefaultElectrumServer.mainnetServers;
-
-    return defaultServers.any(
-      (defaultServer) =>
-          defaultServer.host == server.host && defaultServer.port == server.port && defaultServer.ssl == server.ssl,
-    );
+    return DefaultElectrumServer.findMatching(server.host, server.port, server.ssl) != null;
   }
 
-  /// 사용자 서버 목록에 포함되어 있는지 확인
-  bool _isUserServer(ElectrumServer server) {
-    return _userServers.any(
-      (userServer) => userServer.host == server.host && userServer.port == server.port && userServer.ssl == server.ssl,
-    );
+  /// 사용자 서버 목록에서 동일한 host/port/ssl을 가진 항목을 찾는다.
+  ElectrumServer? _findUserServer(ElectrumServer server) {
+    for (final userServer in _userServers) {
+      if (userServer.host == server.host && userServer.port == server.port && userServer.ssl == server.ssl) {
+        return userServer;
+      }
+    }
+    return null;
   }
 
   /// 서버 연결 테스트 수행

--- a/lib/providers/view_model/settings/electrum_server_view_model.dart
+++ b/lib/providers/view_model/settings/electrum_server_view_model.dart
@@ -195,7 +195,9 @@ class ElectrumServerViewModel extends ChangeNotifier {
 
     setNodeConnectionStatus(NodeConnectionStatus.connecting);
 
-    if (!isSameServer) {
+    // 이 지점에 도달했다는 건 isAlreadyConnected가 false라는 뜻이다 — 서버가 그대로여도
+    // 현재 연결이 끊겼거나 실패한 상태이므로 반드시 재검증해야 한다.(저장 버튼 클릭으로 복구 가능)
+    {
       // 이전에 이미 핀닝된 커스텀 서버라면 저장된 지문을 그대로 사용해 매번 다시 신뢰 확인창을 띄우지 않음
       newServer = _withKnownFingerprint(newServer);
 

--- a/lib/providers/view_model/settings/electrum_server_view_model.dart
+++ b/lib/providers/view_model/settings/electrum_server_view_model.dart
@@ -64,6 +64,25 @@ class ElectrumServerViewModel extends ChangeNotifier {
     _performServerConnectionTest(currentServer);
   }
 
+  /// 1) 화면을 떠나 사용자의 선택이 끝난 시점에 변경된 엔드포인트를 실제 연결에 반영
+  /// 2) 엔드포인트가 그대로여도, 이 화면에서는 연결이 정상인데 실제 노드 상태가 실패로 남아 있으면 재연결
+  @override
+  void dispose() {
+    if (_isEndpointChangedSinceEntry) {
+      unawaited(_nodeProvider.applyServerChange());
+    } else if (_nodeConnectionStatus == NodeConnectionStatus.connected) {
+      unawaited(_nodeProvider.reconnectIfNeeded());
+    }
+    super.dispose();
+  }
+
+  bool get _isEndpointChangedSinceEntry {
+    return _currentServer.host != _initialServer.host ||
+        _currentServer.port != _initialServer.port ||
+        _currentServer.ssl != _initialServer.ssl ||
+        _currentServer.pinnedCertFingerprint != _initialServer.pinnedCertFingerprint;
+  }
+
   /// 모든 기본 일렉트럼 서버 상태 체크
   void _checkAllElectrumServerConnections() {
     final networkType = NetworkType.currentNetworkType;

--- a/lib/repository/shared_preference/shared_prefs_repository.dart
+++ b/lib/repository/shared_preference/shared_prefs_repository.dart
@@ -206,6 +206,7 @@ class SharedPrefsRepository {
               server.value['host'] as String,
               server.value['port'] as int,
               server.value['ssl'] as bool,
+              pinnedCertFingerprint: server.value['pinnedCertFingerprint'] as String?,
             ),
           );
         }
@@ -218,22 +219,16 @@ class SharedPrefsRepository {
     return null;
   }
 
-  /// 사용자 서버 추가 (키 기반으로 중복 확인)
+  /// 사용자 서버 추가 (키 기반으로 중복 확인, 이미 있으면 정보 갱신 - 인증서 지문 재승인 등)
   Future<void> addUserServer(ElectrumServer server) async {
-    final existingServers = await getUserServers();
+    final existingServers = await getUserServers() ?? [];
     final serverKey = '${server.host}:${server.port}';
 
-    // 중복 확인
-    final isDuplicate = existingServers?.any((existing) => '${existing.host}:${existing.port}' == serverKey);
+    existingServers.removeWhere((existing) => '${existing.host}:${existing.port}' == serverKey);
+    existingServers.add(server);
 
-    if (isDuplicate ?? false) {
-      Logger.log('User server already exists: $serverKey');
-      return;
-    }
-
-    existingServers?.add(server);
-    await saveUserServers(existingServers ?? []);
-    Logger.log('User server added: $serverKey');
+    await saveUserServers(existingServers);
+    Logger.log('User server added/updated: $serverKey');
   }
 
   /// 사용자 서버 목록 저장 (host:port를 키로 사용)
@@ -243,7 +238,12 @@ class SharedPrefsRepository {
 
     for (final server in servers) {
       final key = '${server.host}:${server.port}';
-      serversMap[key] = {'host': server.host, 'port': server.port, 'ssl': server.ssl};
+      serversMap[key] = {
+        'host': server.host,
+        'port': server.port,
+        'ssl': server.ssl,
+        'pinnedCertFingerprint': server.pinnedCertFingerprint,
+      };
     }
 
     await prefs.setString(SharedPrefKeys.kUserServers, jsonEncode(serversMap));

--- a/lib/screens/settings/app_settings/network/electrum_server_screen.dart
+++ b/lib/screens/settings/app_settings/network/electrum_server_screen.dart
@@ -202,7 +202,8 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
     );
   }
 
-  /// 저장 버튼 활성화 조건: 현재 입력된 서버 정보가 현재 연결된 서버와 다른지 확인
+  /// 저장 버튼 활성화 조건: 입력된 서버 정보가 현재 연결된 서버와 다르거나,
+  /// 같은 서버라도 지금 연결이 끊긴 상태라 재시도가 필요한 경우
   bool _hasActualChanges() {
     if (_serverAddressController.text.isEmpty ||
         _portController.text.isEmpty ||
@@ -211,7 +212,15 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
       return false;
     }
 
-    return !_viewModel.isSameWithCurrentServer(_serverAddressController.text, _portController.text, _currentSslState);
+    final isSameServer = _viewModel.isSameWithCurrentServer(
+      _serverAddressController.text,
+      _portController.text,
+      _currentSslState,
+    );
+    if (!isSameServer) return true;
+
+    // 서버는 그대로인데 연결이 실패한 상태 — 재저장으로 재검증/TOFU를 트리거할 수 있어야 한다.
+    return _viewModel.nodeConnectionStatus == NodeConnectionStatus.failed;
   }
 
   @override

--- a/lib/screens/settings/app_settings/network/electrum_server_screen.dart
+++ b/lib/screens/settings/app_settings/network/electrum_server_screen.dart
@@ -43,6 +43,7 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
   Size _defaultServerButtonSize = const Size(0, 0);
 
   late ElectrumServerViewModel _viewModel;
+  bool _isUntrustedCertificateDialogShowing = false;
 
   @override
   void initState() {
@@ -67,16 +68,66 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
           _viewModel.setDefaultServerMenuVisible(true);
         }
       });
+
+      _viewModel.addListener(_onViewModelChanged);
     });
   }
 
   @override
   void dispose() {
+    _viewModel.removeListener(_onViewModelChanged);
     _serverAddressController.dispose();
     _portController.dispose();
     serverAddressFocusNode.dispose();
     portFocusNode.dispose();
     super.dispose();
+  }
+
+  void _onViewModelChanged() {
+    if (_viewModel.nodeConnectionStatus == NodeConnectionStatus.untrustedCertificate &&
+        _viewModel.pendingCertificateFingerprint != null) {
+      _showUntrustedCertificateDialog();
+    }
+  }
+
+  void _showUntrustedCertificateDialog() {
+    if (_isUntrustedCertificateDialogShowing) return;
+    _isUntrustedCertificateDialogShowing = true;
+
+    final fingerprint = _viewModel.pendingCertificateFingerprint ?? '';
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) {
+        return CoconutPopup(
+          languageCode: context.read<PreferenceProvider>().language,
+          title: t.settings_screen.electrum_server.popup.untrusted_certificate_title,
+          description: t.settings_screen.electrum_server.popup.untrusted_certificate_description(
+            fingerprint: fingerprint,
+          ),
+          onTapRight: () async {
+            final navigator = Navigator.of(dialogContext);
+            final success = await _viewModel.trustPendingCertificateAndConnect();
+            if (!mounted) return;
+            navigator.pop();
+            if (success) {
+              vibrateLight();
+            } else {
+              vibrateLightDouble();
+            }
+          },
+          onTapLeft: () {
+            _viewModel.cancelPendingCertificateTrust();
+            Navigator.of(dialogContext).pop();
+          },
+          leftButtonText: t.cancel,
+          rightButtonText: t.settings_screen.electrum_server.popup.trust_and_continue,
+        );
+      },
+    ).then((_) {
+      _isUntrustedCertificateDialogShowing = false;
+    });
   }
 
   void _unFocus() {
@@ -96,11 +147,12 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
   }
 
   void _onSave() async {
-    final newServer = ElectrumServer.custom(
-      _serverAddressController.text,
-      int.parse(_portController.text),
-      _currentSslState,
-    );
+    final host = _serverAddressController.text;
+    final port = int.parse(_portController.text);
+
+    // 텍스트 필드 값이 기본 서버와 일치하면 그 서버의 pinnedCertFingerprint를 그대로 쓴다
+    final matchedDefault = DefaultElectrumServer.findMatching(host, port, _currentSslState);
+    final newServer = matchedDefault?.server ?? ElectrumServer.custom(host, port, _currentSslState);
 
     final success = await _viewModel.changeServerAndUpdateState(newServer);
 
@@ -726,6 +778,7 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
     switch (status) {
       case NodeConnectionStatus.failed:
       case NodeConnectionStatus.networkMismatch:
+      case NodeConnectionStatus.untrustedCertificate:
         {
           return SvgPicture.asset(
             CustomIcons.triangleWarning,
@@ -761,6 +814,10 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
       case NodeConnectionStatus.networkMismatch:
         {
           return t.settings_screen.electrum_server.alert.network_mismatch;
+        }
+      case NodeConnectionStatus.untrustedCertificate:
+        {
+          return t.settings_screen.electrum_server.alert.untrusted_certificate;
         }
       case NodeConnectionStatus.connecting:
         {
@@ -816,7 +873,8 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
                       isActive:
                           hasActualChanges &&
                           nodeConnectionStatus != NodeConnectionStatus.connecting &&
-                          nodeConnectionStatus != NodeConnectionStatus.networkMismatch,
+                          nodeConnectionStatus != NodeConnectionStatus.networkMismatch &&
+                          nodeConnectionStatus != NodeConnectionStatus.untrustedCertificate,
                       onPressed: () {
                         _unFocus();
                         _onSave();

--- a/lib/screens/settings/app_settings/network/electrum_server_screen.dart
+++ b/lib/screens/settings/app_settings/network/electrum_server_screen.dart
@@ -106,16 +106,16 @@ class _ElectrumServerScreen extends State<ElectrumServerScreen> {
           description: t.settings_screen.electrum_server.popup.untrusted_certificate_description(
             fingerprint: fingerprint,
           ),
-          onTapRight: () async {
-            final navigator = Navigator.of(dialogContext);
-            final success = await _viewModel.trustPendingCertificateAndConnect();
-            if (!mounted) return;
-            navigator.pop();
-            if (success) {
-              vibrateLight();
-            } else {
-              vibrateLightDouble();
-            }
+          onTapRight: () {
+            Navigator.of(dialogContext).pop();
+            _viewModel.trustPendingCertificateAndConnect().then((success) {
+              if (!mounted) return;
+              if (success) {
+                vibrateLight();
+              } else {
+                vibrateLightDouble();
+              }
+            });
           },
           onTapLeft: () {
             _viewModel.cancelPendingCertificateTrust();

--- a/lib/screens/wallet_detail/wallet_resync/wallet_resync_screen.dart
+++ b/lib/screens/wallet_detail/wallet_resync/wallet_resync_screen.dart
@@ -544,6 +544,7 @@ class _WalletResyncScreenState extends State<WalletResyncScreen> {
     switch (_connectionStatus) {
       case NodeConnectionStatus.failed:
       case NodeConnectionStatus.networkMismatch:
+      case NodeConnectionStatus.untrustedCertificate:
         return SvgPicture.asset(
           CustomIcons.triangleWarning,
           height: 20,
@@ -565,6 +566,7 @@ class _WalletResyncScreenState extends State<WalletResyncScreen> {
   String _connectionAlertText() {
     switch (_connectionStatus) {
       case NodeConnectionStatus.failed:
+      case NodeConnectionStatus.untrustedCertificate:
         return t.wallet_resync_screen.confirm.connection_alert.failed;
       case NodeConnectionStatus.networkMismatch:
         return t.wallet_resync_screen.confirm.connection_alert.network_mismatch;

--- a/lib/services/electrum_service.dart
+++ b/lib/services/electrum_service.dart
@@ -33,7 +33,7 @@ class ElectrumService {
   }
 
   /// 연결 시도 후 성공/실패를 bool로 반환
-  Future<bool> connect(String host, int port, {bool ssl = true}) async {
+  Future<bool> connect(String host, int port, {bool ssl = true, String? pinnedCertFingerprint}) async {
     // // 이전 타이머 정리
     // _pingTimer?.cancel();
 
@@ -45,7 +45,12 @@ class ElectrumService {
     };
 
     try {
-      final isConnected = await _socketManager.connect(host, port, ssl: ssl);
+      final isConnected = await _socketManager.connect(
+        host,
+        port,
+        ssl: ssl,
+        pinnedCertFingerprint: pinnedCertFingerprint,
+      );
 
       if (!isConnected || _socketManager.connectionStatus != SocketConnectionStatus.connected) {
         return false;
@@ -365,4 +370,7 @@ class ElectrumService {
 
   /// connectionStatus getter 추가
   SocketConnectionStatus get connectionStatus => _socketManager.connectionStatus;
+
+  /// 직전 connect() 시도가 신뢰할 수 없는 인증서(HandshakeException) 때문에 실패했는지 여부
+  bool get lastConnectionFailedDueToUntrustedCertificate => _socketManager.lastConnectionFailedDueToUntrustedCertificate;
 }

--- a/lib/services/network/socket/socket_factory.dart
+++ b/lib/services/network/socket/socket_factory.dart
@@ -1,12 +1,19 @@
+import 'dart:async';
 import 'dart:io';
-import 'package:coconut_lib/coconut_lib.dart';
-import 'package:flutter/foundation.dart';
+import 'package:coconut_wallet/utils/certificate_util.dart';
 import 'package:coconut_wallet/utils/logger.dart';
 
 abstract class SocketFactory {
   Future<Socket> createSocket(String host, int port, {Duration timeout});
 
-  Future<SecureSocket> createSecureSocket(String host, int port, {String? publicKey});
+  /// [pinnedFingerprint]가 주어지면, OS 표준 인증서 검증에 실패하더라도
+  /// 실제 인증서의 SHA-256 지문이 [pinnedFingerprint]와 정확히 일치할 때만 연결을 허용
+  /// null이면 표준 검증 실패 시 항상 연결을 거부한다.(기본 제공 서버는 항상 null이어야 한다)
+  Future<SecureSocket> createSecureSocket(String host, int port, {String? pinnedFingerprint});
+
+  /// 서버가 제시하는 인증서만 확인하기 위한 임시 연결(연결을 실제로 사용하지 않음)
+  /// 커스텀 서버 등록 시 사용자에게 지문을 보여주고 신뢰 여부를 확인받는 용도로만 쓰인다.
+  Future<X509Certificate?> peekCertificate(String host, int port, {Duration timeout});
 }
 
 class DefaultSocketFactory implements SocketFactory {
@@ -17,33 +24,44 @@ class DefaultSocketFactory implements SocketFactory {
   }
 
   @override
-  Future<SecureSocket> createSecureSocket(String host, int port, {String? publicKey}) {
-    Logger.log('SocketFactory: Creating secure socket to $host:$port, hasPublicKey: ${publicKey != null}');
+  Future<SecureSocket> createSecureSocket(String host, int port, {String? pinnedFingerprint}) {
+    Logger.log(
+      'SocketFactory: Creating secure socket to $host:$port, hasPinnedFingerprint: ${pinnedFingerprint != null}',
+    );
 
     return SecureSocket.connect(
       host,
       port,
       onBadCertificate: (X509Certificate cert) {
-        Logger.log('SocketFactory: Bad certificate detected for $host:$port');
-        Logger.log('SocketFactory: Certificate subject: ${cert.subject}');
-        Logger.log('SocketFactory: Certificate issuer: ${cert.issuer}');
-
-        // 자체 서명된 인증서인지 확인
-        if (cert.subject == cert.issuer) {
-          Logger.log('SocketFactory: Self-signed certificate detected, allowing connection');
-          return true; // 자체 서명된 인증서 허용
+        if (pinnedFingerprint == null) {
+          Logger.log('SocketFactory: No pinned fingerprint for $host:$port, rejecting untrusted certificate');
+          return false;
         }
 
-        // 개발 모드나 regtest 환경에서는 모든 인증서 허용
-        if (kDebugMode || host.contains('regtest') || NetworkType.currentNetworkType.isTestnet) {
-          Logger.log('SocketFactory: Allowing bad certificate for development/test environment');
-          return true;
-        }
-
-        // 그 외에는 거부
-        Logger.log('SocketFactory: Rejecting bad certificate for production environment');
-        return false;
+        final actualFingerprint = CertificateUtil.sha256Fingerprint(cert);
+        final isMatch = actualFingerprint == pinnedFingerprint;
+        Logger.log(
+          isMatch
+              ? 'SocketFactory: Certificate fingerprint matches pinned value for $host:$port'
+              : 'SocketFactory: Certificate fingerprint mismatch for $host:$port, rejecting',
+        );
+        return isMatch;
       },
     );
+  }
+
+  @override
+  Future<X509Certificate?> peekCertificate(
+    String host,
+    int port, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    SecureSocket? socket;
+    try {
+      socket = await SecureSocket.connect(host, port, onBadCertificate: (_) => true, timeout: timeout);
+      return socket.peerCertificate;
+    } finally {
+      unawaited(socket?.close());
+    }
   }
 }

--- a/lib/services/network/socket/socket_manager.dart
+++ b/lib/services/network/socket/socket_manager.dart
@@ -63,11 +63,9 @@ class SocketManager {
   }
 
   // .onion 주소인 경우 타임아웃을 길게 설정
-  Duration getConnectionTimeout(bool isOnionHost, bool isTailscale) {
+  Duration getConnectionTimeout(bool isOnionHost) {
     if (isOnionHost) {
       return kIsolateInitTimeoutForOnion;
-    } else if (isTailscale) {
-      return kIsolateInitTimeout;
     } else {
       return kIsolateInitTimeout;
     }
@@ -100,17 +98,15 @@ class SocketManager {
 
     _connectionStatus = SocketConnectionStatus.connecting;
 
-    final isTailscale = await _detectTailscaleNetwork();
-
-    final connectionTimeout = getConnectionTimeout(isOnionHost, isTailscale);
+    final connectionTimeout = getConnectionTimeout(isOnionHost);
 
     try {
-      // ssl false이거나 tailscale이 감지되는 경우, 일반 연결 사용
-      if (!_ssl || isTailscale || isOnionHost) {
+      // ssl false인 경우 일반 연결 사용
+      if (!_ssl || isOnionHost) {
         Logger.log('Socket connection: $_host:$_port');
         _socket = await socketFactory.createSocket(_host, _port, timeout: connectionTimeout);
       } else {
-        Logger.log('Secure Socket connection: $_host:$_port (SSL: $_ssl, Tailscale: $isTailscale)');
+        Logger.log('Secure Socket connection: $_host:$_port (SSL: $_ssl)');
         _socket = await socketFactory.createSecureSocket(_host, _port, pinnedFingerprint: pinnedCertFingerprint);
       }
 
@@ -128,45 +124,6 @@ class SocketManager {
 
   bool _isOnionAddress(String host) {
     return host.trim().toLowerCase().endsWith('.onion');
-  }
-
-  Future<bool> _detectTailscaleNetwork() async {
-    try {
-      final interfaces = await NetworkInterface.list();
-      final tailscaleIps = <String>[];
-
-      for (final interface in interfaces) {
-        for (final addr in interface.addresses) {
-          if (_isTailscaleIP(addr.address)) {
-            tailscaleIps.add(addr.address);
-            Logger.log('🌐 Tailscale IP Detected: ${addr.address} (${interface.name})');
-            return true;
-          }
-        }
-      }
-    } catch (e) {
-      Logger.log('❌ Tailscale IP Not Detected');
-      return false;
-    }
-    return false;
-  }
-
-  /// Tailscale IP 범위 확인
-  bool _isTailscaleIP(String ip) {
-    try {
-      final parts = ip.split('.');
-      if (parts.length != 4) return false;
-
-      final firstOctet = int.tryParse(parts[0]);
-      final secondOctet = int.tryParse(parts[1]);
-
-      if (firstOctet == null || secondOctet == null) return false;
-
-      // 100.64.0.0/10 범위: 100.64.x.x ~ 100.127.x.x
-      return firstOctet == 100 && secondOctet >= 64 && secondOctet <= 127;
-    } catch (e) {
-      return false;
-    }
   }
 
   Future<void> disconnect() async {

--- a/lib/services/network/socket/socket_manager.dart
+++ b/lib/services/network/socket/socket_manager.dart
@@ -73,10 +73,14 @@ class SocketManager {
     }
   }
 
-  Future<bool> connect(String host, int port, {bool ssl = true}) async {
+  bool _lastConnectionFailedDueToUntrustedCertificate = false;
+  bool get lastConnectionFailedDueToUntrustedCertificate => _lastConnectionFailedDueToUntrustedCertificate;
+
+  Future<bool> connect(String host, int port, {bool ssl = true, String? pinnedCertFingerprint}) async {
     _host = host;
     _port = port;
     _ssl = ssl;
+    _lastConnectionFailedDueToUntrustedCertificate = false;
 
     final isOnionHost = _isOnionAddress(host);
     _ssl = isOnionHost ? false : ssl;
@@ -107,7 +111,7 @@ class SocketManager {
         _socket = await socketFactory.createSocket(_host, _port, timeout: connectionTimeout);
       } else {
         Logger.log('Secure Socket connection: $_host:$_port (SSL: $_ssl, Tailscale: $isTailscale)');
-        _socket = await socketFactory.createSecureSocket(_host, _port);
+        _socket = await socketFactory.createSecureSocket(_host, _port, pinnedFingerprint: pinnedCertFingerprint);
       }
 
       _connectionStatus = SocketConnectionStatus.connected;
@@ -115,6 +119,7 @@ class SocketManager {
       _socket!.listen(_onData, onError: _onError, onDone: _onDone, cancelOnError: true);
     } catch (e) {
       Logger.error('Socket connection failed: $e');
+      _lastConnectionFailedDueToUntrustedCertificate = e is HandshakeException;
       markConnectionLost();
       return false;
     }

--- a/lib/utils/certificate_util.dart
+++ b/lib/utils/certificate_util.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+
+/// TLS 인증서 지문(fingerprint) 계산 유틸
+///
+/// 커스텀 Electrum 서버의 인증서 핀닝에서 사용
+/// 인증서의 신뢰 판단 기준으로 인증서 DER 바이트 전체의 SHA-256 해시만 사용한다.
+class CertificateUtil {
+  const CertificateUtil._();
+
+  static String sha256Fingerprint(X509Certificate certificate) {
+    final digest = sha256.convert(certificate.der);
+    return digest.bytes.map((byte) => byte.toRadixString(16).padLeft(2, '0')).join(':').toUpperCase();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.16.0+88
+version: 0.17.0+90
 app_versions:
   ios_regtest: 3.16.0+1
   ios_mainnet: 0.16.0+1

--- a/test/providers/preferences/electrum_server_provider_test.dart
+++ b/test/providers/preferences/electrum_server_provider_test.dart
@@ -1,0 +1,115 @@
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/constants/shared_pref_keys.dart';
+import 'package:coconut_wallet/providers/preferences/electrum_server_provider.dart';
+import 'package:coconut_wallet/repository/shared_preference/shared_prefs_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ElectrumServerProvider.migrateLegacyCustomServerStorage (mainnet)', () {
+    late ElectrumServerProvider provider;
+
+    setUp(() async {
+      NetworkType.setNetworkType(NetworkType.mainnet);
+      SharedPreferences.setMockInitialValues({});
+      SharedPrefsRepository().setSharedPreferencesForTest(await SharedPreferences.getInstance());
+      provider = ElectrumServerProvider();
+    });
+
+    test('옛 foundationdevices 주소로 저장되어 있던 값은 새 주소의 기본 서버 참조로 옮긴다', () async {
+      await provider.setCustomElectrumServer('mainnet.foundationdevices.com', 50002, true);
+
+      await provider.migrateLegacyCustomServerStorage();
+
+      expect(SharedPrefsRepository().getString(SharedPrefKeys.kElectrumServerName), 'FOUNDATIONDEVICES');
+      expect(SharedPrefsRepository().isContainsKey(SharedPrefKeys.kCustomElectrumHost), false);
+
+      final migrated = provider.getElectrumServer();
+      expect(migrated.host, 'mainnet-0.foundation.xyz');
+      expect(migrated.port, 50002);
+      expect(migrated.ssl, true);
+    });
+
+    test('옛 bluewallet 주소로 저장되어 있던 값도 새 주소의 기본 서버 참조로 옮긴다', () async {
+      await provider.setCustomElectrumServer('electrum1.bluewallet.io', 443, true);
+
+      await provider.migrateLegacyCustomServerStorage();
+
+      expect(provider.getElectrumServer().host, 'electrum2.bluewallet.io');
+    });
+
+    test('self-signed 기본 서버(emzy)를 지문 없이 CUSTOM으로 저장해 두었던 경우, 기본 서버 참조로 옮기면서 지문도 라이브로 따라온다', () async {
+      // 지문 고정(pinning) 도입 전에 저장된 값을 흉내: emzy를 host/port/ssl만 저장, 지문은 없음.
+      await provider.setCustomElectrumServer('electrum.emzy.de', 50002, true);
+
+      await provider.migrateLegacyCustomServerStorage();
+
+      final migrated = provider.getElectrumServer();
+      expect(migrated.host, 'electrum.emzy.de');
+      expect(migrated.pinnedCertFingerprint, isNotNull);
+    });
+
+    test('현재 기본 서버(coconut)와 host/port/ssl이 같으면 참조로 옮긴다(변화 없이도 안전)', () async {
+      await provider.setCustomElectrumServer('electrum.coconut.onl', 443, true);
+
+      await provider.migrateLegacyCustomServerStorage();
+
+      expect(SharedPrefsRepository().getString(SharedPrefKeys.kElectrumServerName), 'COCONUT');
+    });
+
+    test('기본 서버 목록에 없는 진짜 커스텀 서버는 그대로 둔다', () async {
+      await provider.setCustomElectrumServer('my-own-node.example.com', 50002, true);
+
+      await provider.migrateLegacyCustomServerStorage();
+
+      expect(SharedPrefsRepository().getString(SharedPrefKeys.kElectrumServerName), 'CUSTOM');
+      expect(provider.getElectrumServer().host, 'my-own-node.example.com');
+    });
+
+    test('삭제된 기본 서버(jochenhoenicke)로 저장되어 있던 값은 커스텀 서버로 취급해 그대로 둔다', () async {
+      await provider.setCustomElectrumServer('electrum.jochen-hoenicke.de', 50006, true);
+
+      await provider.migrateLegacyCustomServerStorage();
+
+      expect(SharedPrefsRepository().getString(SharedPrefKeys.kElectrumServerName), 'CUSTOM');
+      expect(provider.getElectrumServer().host, 'electrum.jochen-hoenicke.de');
+    });
+
+    test('서버를 저장한 적이 없으면(=최초 실행) 아무것도 하지 않는다', () async {
+      await provider.migrateLegacyCustomServerStorage();
+
+      expect(SharedPrefsRepository().isContainsKey(SharedPrefKeys.kCustomElectrumHost), false);
+    });
+
+    test('사용자가 직접 등록한 서버 목록(kUserServers)은 건드리지 않는다', () async {
+      await provider.addUserServer('mainnet.foundationdevices.com', 50002, true);
+      await provider.setCustomElectrumServer('some-other-host.example.com', 50002, true);
+
+      await provider.migrateLegacyCustomServerStorage();
+
+      final userServers = await provider.getUserServers();
+      expect(userServers.single.host, 'mainnet.foundationdevices.com');
+    });
+  });
+
+  group('ElectrumServerProvider.setSelectedDefaultServer', () {
+    setUp(() async {
+      NetworkType.setNetworkType(NetworkType.mainnet);
+      SharedPreferences.setMockInitialValues({});
+      SharedPrefsRepository().setSharedPreferencesForTest(await SharedPreferences.getInstance());
+    });
+
+    test('serverName 참조로 저장하고, 이전에 남아있던 커스텀 서버 필드는 정리한다', () async {
+      final provider = ElectrumServerProvider();
+      await provider.setCustomElectrumServer('leftover.example.com', 1234, true, pinnedCertFingerprint: 'AA:BB');
+
+      await provider.setSelectedDefaultServer('ACINQ');
+
+      expect(SharedPrefsRepository().getString(SharedPrefKeys.kElectrumServerName), 'ACINQ');
+      expect(SharedPrefsRepository().isContainsKey(SharedPrefKeys.kCustomElectrumHost), false);
+      expect(provider.getElectrumServer().host, 'electrum.acinq.co');
+    });
+  });
+}

--- a/test/services/network/socket/socket_factory_test.dart
+++ b/test/services/network/socket/socket_factory_test.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:coconut_wallet/services/network/socket/socket_factory.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// 테스트 전용으로 생성한 self-signed 인증서/개인키
+// 실제 서비스와 무관한 더미 값이며 이 테스트가 로컬 TLS 서버를 띄우기 위한 용도로만 사용된다.
+const _testCertPem = '''
+-----BEGIN CERTIFICATE-----
+MIICuDCCAaACCQDKf4EcMbQWHjANBgkqhkiG9w0BAQsFADAeMRwwGgYDVQQDDBNj
+b2NvbnV0LXdhbGxldC10ZXN0MB4XDTI2MDkwMjA0MjU0MFoXDTM2MDgzMDA0MjU0
+MFowHjEcMBoGA1UEAwwTY29jb251dC13YWxsZXQtdGVzdDCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAK6aS3MG3GHswFOaekhYbO/BQ7qxWuNLoakDE6GJ
+imuF/3r5EvLEJ5pIJwKEeWVlIUtJ9lg4UC/6+NvVo+lUdmuWXDuFf8wRaFqEImGZ
+/7ZDfpxBNq+SqbBr4xc5zBJTJsUGeO6Ktj0CaKldYzFFHfYkNZt5SdlXGwtSV305
+rUZU0nLbK15bqCtlOmsfbYgGt0zgjYp5OWEDCxYOtZPo8snK/nqQYkGu/B2kvlyj
+WEAwhu77L49XFHdUIp6spThH88SlksuXeNvk6Ai212dcQiv/cYPaTSsNOoxUoiSW
+BraB+Kakd79IaJ4fk5ejScAaIUF7tWeKgdpQExfrMETj4gECAwEAATANBgkqhkiG
+9w0BAQsFAAOCAQEAZUghJY/jDaxt5WNyBz9vH46PpNX+q6vnPpJVTFo1v/BjFwcI
+BxICS0b27aNadVT1+MKEAAZybnG5peNovbVarkapS37j/PvgCHmfMDVur9hzbtMf
+E48lb4o+PHfIbAgiZlcx5LtjUOJ+vPeC76xs0B4B468RIzjaOWpuInw+S0jVQ1KJ
+4HKO/hxdIT1hE9j0XaO7sxP+mArrmjDQM04i0H2tKEN8RGl389Xk/hAwQ74exKJJ
+d2dma7t/xgNYHvc5L7G2FtTOTgtfEj9KB8bZO9g6tIr8K/nELyHS1PSHhTtNPslx
+tGmpEszTsabuDV8S/5xcd1cjrZkfF0LNls+4Xg==
+-----END CERTIFICATE-----
+''';
+
+const _testKeyPem = '''
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCumktzBtxh7MBT
+mnpIWGzvwUO6sVrjS6GpAxOhiYprhf96+RLyxCeaSCcChHllZSFLSfZYOFAv+vjb
+1aPpVHZrllw7hX/MEWhahCJhmf+2Q36cQTavkqmwa+MXOcwSUybFBnjuirY9Amip
+XWMxRR32JDWbeUnZVxsLUld9Oa1GVNJy2yteW6grZTprH22IBrdM4I2KeTlhAwsW
+DrWT6PLJyv56kGJBrvwdpL5co1hAMIbu+y+PVxR3VCKerKU4R/PEpZLLl3jb5OgI
+ttdnXEIr/3GD2k0rDTqMVKIklga2gfimpHe/SGieH5OXo0nAGiFBe7VnioHaUBMX
+6zBE4+IBAgMBAAECggEBAIxHAGkY0QSHvnksuiPXjyYMosqiZQAKKoZsJ2B37VK3
+pGt7IwMSHzMv1s+J+TJCTr57XMTB8YKq4zdTbE4xArcrZUyY0/Ty42EdmbXKkQwx
+K86EAliKv3QzKY7ma5MpZROUQKJ9pS5c+hNgKSpTel/f9YXEq1VHSz4MWKgOJ61B
+csNxE3mw6pX48Op9LQlXVZt3V1GtgceMsCSdTmi392YWMzHIHhXIROzgbna0mHHf
+jrxQvRyHseFEJN66OLnaTKmbs00SomqZxzT8G68VC4m0xg3gdV/gGU3CAVZBtA/I
+NXxBU/oJT8rwP5OpSKmmNF3ahBhiTfF48sjuI2RH1HECgYEA2M0SqXDO4AHGDPpZ
+uW7hfJHzxrpHD6haP+mVW3FxIWtj/BEW6H+cnPstLOLKdN1NJvGjzZtDIQSOpMl3
+PR/rSf/6GKdUCcRRqPCGQxNL0KcUFLFQxWiHc0uvO0nc8XoTur1Zw01RfZWdePEV
+tJwlLNfubiLpkpY5VkhOW3p0bSUCgYEAziwDwuoytis1h/vdUhZLYwXQm2ttMgZ/
+f0Qxku7CNMmABK7C/DOlmFSrqcVUbnPQGBX3FVdcgUJTfvTjnFKYIgVkK9DK5HDR
+Dur57pEKR723S97IPA08JaKAo7sAwd/VBg8ayxrzz+Wm9eijaVa9xoxv/CZ8ros4
+gMZ8qtlToK0CgYAaHgJMhTl2xN/t+k7Kxu/FCPQcEZ6z5S0SG/qRLIZbZ0uBNzHS
+SmU8iAm2KZAIKgy8T0nTYAvjM2BXu6lwpKK8pGilharbDlpkBq218OImPapun7nC
+Pkhq/Egc1VYXhQRRb7QbkfnqLhbtVeWuf0z/LPgdLnmC3jQED+vYm1ThPQKBgC+9
+8YEJSoT0rIi4wh9oGjzr88qJrdePuaZ23CPyNfaTUpnC/lP4gbgsozPFBjAtkVqC
+e5zthfZIrZ0QiESCu8flB7U9vD36Ae86anXcEE1cmT1wcV22kt8EKlW/0AUVF/c3
+ODUgIKVbwLXhETYrZ/a6PpRdNTIV+xeW3veRK9RhAoGBAI+j/WGw6MDMO1ZAw/+v
+WHFLbJcXvmjanwPJk9lyVfZ9aeXzSpI9fzlGN6WP9Y+NwOesNZSu+FTfwTnTCcqh
+ms4xAhAP9sBWXTOoFZbeWzpGxmwM6vbKkpbn0GBEWbeK2Q8luIc6fIR/OzCe2w0m
+skkV/ZeWgrUuYrt1s7cbaQ8u
+-----END PRIVATE KEY-----
+''';
+
+/// PEM 텍스트 안의 DER(base64) 바이트를 프로덕션 코드와 무관하게 직접 추출한다.
+/// CertificateUtil을 거치지 않고 "기대값"을 독립적으로 계산하기 위함이다.
+List<int> _derBytesFromPem(String pem) {
+  final base64Body = pem.split('\n').where((line) => line.isNotEmpty && !line.startsWith('-----')).join();
+  return base64Decode(base64Body);
+}
+
+void main() {
+  group('DefaultSocketFactory 인증서 핀닝 테스트', () {
+    late SecureServerSocket server;
+    late String expectedFingerprint;
+
+    setUpAll(() async {
+      final context =
+          SecurityContext()
+            ..useCertificateChainBytes(utf8.encode(_testCertPem))
+            ..usePrivateKeyBytes(utf8.encode(_testKeyPem));
+
+      server = await SecureServerSocket.bind(InternetAddress.loopbackIPv4, 0, context);
+      // 일부 테스트 케이스는 클라이언트가 핸드셰이크를 의도적으로 거부하므로,
+      // 서버 쪽에서도 핸드셰이크 실패가 스트림 에러로 발생할 수 있다 - 무시한다.
+      server.listen((socket) {
+        socket.close();
+      }, onError: (_) {});
+
+      expectedFingerprint =
+          sha256
+              .convert(_derBytesFromPem(_testCertPem))
+              .bytes
+              .map((b) => b.toRadixString(16).padLeft(2, '0'))
+              .join(':')
+              .toUpperCase();
+    });
+
+    tearDownAll(() async {
+      await server.close();
+    });
+
+    test('pinnedFingerprint 없이 self-signed 서버에 연결하면 거부된다', () async {
+      final factory = DefaultSocketFactory();
+
+      expect(() => factory.createSecureSocket('localhost', server.port), throwsA(isA<HandshakeException>()));
+    });
+
+    test('잘못된 pinnedFingerprint로는 연결이 거부된다', () async {
+      final factory = DefaultSocketFactory();
+
+      expect(
+        () => factory.createSecureSocket(
+          'localhost',
+          server.port,
+          pinnedFingerprint:
+              'AA:BB:CC:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00',
+        ),
+        throwsA(isA<HandshakeException>()),
+      );
+    });
+
+    test('정확한 pinnedFingerprint로는 연결이 허용된다', () async {
+      final factory = DefaultSocketFactory();
+
+      final socket = await factory.createSecureSocket('localhost', server.port, pinnedFingerprint: expectedFingerprint);
+
+      expect(socket, isNotNull);
+      await socket.close();
+    });
+
+    test('peekCertificate는 신뢰 여부와 무관하게 서버 인증서를 반환한다', () async {
+      final factory = DefaultSocketFactory();
+
+      final cert = await factory.peekCertificate('localhost', server.port);
+
+      expect(cert, isNotNull);
+    });
+  });
+}

--- a/test/view_model/electrum_server_view_model_test.dart
+++ b/test/view_model/electrum_server_view_model_test.dart
@@ -1,0 +1,135 @@
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_wallet/enums/network_enums.dart';
+import 'package:coconut_wallet/enums/node_connection_status.dart';
+import 'package:coconut_wallet/model/error/app_error.dart';
+import 'package:coconut_wallet/model/node/electrum_server.dart';
+import 'package:coconut_wallet/model/node/node_provider_state.dart';
+import 'package:coconut_wallet/providers/node_provider/node_provider.dart';
+import 'package:coconut_wallet/providers/preferences/electrum_server_provider.dart';
+import 'package:coconut_wallet/providers/view_model/settings/electrum_server_view_model.dart';
+import 'package:coconut_wallet/utils/result.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+// 모킹할 클래스 목록
+// .mocks.dart 생성:
+//   fvm dart run build_runner build --delete-conflicting-outputs --build-filter="test/view_model/*.mocks.dart"
+// (전체 재생성 `make ready`)
+@GenerateMocks([NodeProvider, ElectrumServerProvider])
+import 'electrum_server_view_model_test.mocks.dart';
+
+/// 일렉트럼 서버 화면을 벗어날 때 실제 연결에 어떤 조치를 취하는지 검증한다.
+/// 이 화면은 임시 프로브로만 서버를 확인하고 소켓은 건드리지 않으므로,
+/// 이탈 시점의 판정이 유일하게 실제 연결을 움직이는 지점이다.
+///
+/// 미검증 - _isEndpointChangedSinceEntry의 pinnedCertFingerprint 비교
+/// host/port/ssl은 그대로인데 지문만 바뀌는 경우(TOFU로 인증서를 새로 신뢰 승인)를 덮는 테스트가 없어서,
+/// 그 비교를 지워도 아래 테스트는 전부 통과한다. 검증하려면 checkServerConnection이 처음에는
+/// untrustedCertificateError를 반환하고 trustPendingCertificateAndConnect() 이후에는 성공하도록
+/// 단계적으로 응답하는 스텁 추가가 필요하다.
+void main() {
+  late MockNodeProvider nodeProvider;
+  late MockElectrumServerProvider electrumServerProvider;
+
+  final initialServer = ElectrumServer.custom('initial.example.com', 50002, true);
+  final otherServer = ElectrumServer.custom('other.example.com', 50002, true);
+
+  setUpAll(() {
+    provideDummy<Result<bool>>(Result.success(true));
+    provideDummy<Result<String>>(Result.success(''));
+  });
+
+  setUp(() {
+    NetworkType.setNetworkType(NetworkType.regtest);
+
+    nodeProvider = MockNodeProvider();
+    electrumServerProvider = MockElectrumServerProvider();
+
+    when(electrumServerProvider.getElectrumServer()).thenReturn(initialServer);
+    when(electrumServerProvider.getUserServers()).thenAnswer((_) async => <ElectrumServer>[]);
+    when(
+      electrumServerProvider.setCustomElectrumServer(
+        any,
+        any,
+        any,
+        pinnedCertFingerprint: anyNamed('pinnedCertFingerprint'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      electrumServerProvider.addUserServer(any, any, any, pinnedCertFingerprint: anyNamed('pinnedCertFingerprint')),
+    ).thenAnswer((_) async {});
+    when(electrumServerProvider.setSelectedDefaultServer(any)).thenAnswer((_) async {});
+
+    when(nodeProvider.hasConnectionError).thenReturn(false);
+    when(
+      nodeProvider.state,
+    ).thenReturn(const NodeProviderState(nodeSyncState: NodeSyncState.completed, registeredWallets: {}));
+    when(nodeProvider.checkServerConnection(any)).thenAnswer((_) async => Result.success(true));
+    when(nodeProvider.changeServer(any)).thenAnswer((_) async => Result.success(true));
+    when(nodeProvider.applyServerChange()).thenAnswer((_) async => Result.success(true));
+    when(nodeProvider.reconnectIfNeeded()).thenAnswer((_) async => Result.success(true));
+  });
+
+  /// 생성자에서 시작한 프로브들이 끝나 nodeConnectionStatus가 확정될 때까지 기다린다.
+  Future<ElectrumServerViewModel> createViewModel() async {
+    final viewModel = ElectrumServerViewModel(nodeProvider, electrumServerProvider);
+    await pumpEventQueue();
+    return viewModel;
+  }
+
+  test('엔드포인트가 바뀌었으면 이탈 시 서버 변경을 반영한다', () async {
+    final viewModel = await createViewModel();
+
+    final changed = await viewModel.changeServerAndUpdateState(otherServer);
+    expect(changed, isTrue);
+
+    viewModel.dispose();
+
+    verify(nodeProvider.applyServerChange()).called(1);
+    verifyNever(nodeProvider.reconnectIfNeeded());
+  });
+
+  test('엔드포인트가 그대로여도 화면 연결이 정상이면 이탈 시 재연결을 확인한다', () async {
+    final viewModel = await createViewModel();
+    expect(viewModel.nodeConnectionStatus, NodeConnectionStatus.connected);
+
+    viewModel.dispose();
+
+    verify(nodeProvider.reconnectIfNeeded()).called(1);
+    verifyNever(nodeProvider.applyServerChange());
+  });
+
+  test('화면 연결 자체가 실패면 이탈 시 아무것도 하지 않는다', () async {
+    when(nodeProvider.checkServerConnection(any)).thenAnswer((_) async => Result.failure(ErrorCodes.networkError));
+
+    final viewModel = await createViewModel();
+    expect(viewModel.nodeConnectionStatus, NodeConnectionStatus.failed);
+
+    viewModel.dispose();
+
+    verifyNever(nodeProvider.reconnectIfNeeded());
+    verifyNever(nodeProvider.applyServerChange());
+  });
+
+  test('서버 주소를 편집하다 만 상태(waiting)면 이탈 시 아무것도 하지 않는다', () async {
+    final viewModel = await createViewModel();
+    viewModel.setNodeConnectionStatus(NodeConnectionStatus.waiting);
+
+    viewModel.dispose();
+
+    verifyNever(nodeProvider.reconnectIfNeeded());
+    verifyNever(nodeProvider.applyServerChange());
+  });
+
+  test('바꿨다가 원래 서버로 되돌렸으면 이탈 시 연결을 건드리지 않는다', () async {
+    final viewModel = await createViewModel();
+
+    await viewModel.changeServerAndUpdateState(otherServer);
+    await viewModel.changeServerAndUpdateState(initialServer);
+
+    viewModel.dispose();
+
+    verifyNever(nodeProvider.applyServerChange());
+  });
+}


### PR DESCRIPTION
### 문제점

1. Electrum 서버 인증: 인증서 검증 실패 시 self-signed 인증서를 수락함. self hosting 서버를 수락하기 위한 임시 조치로 기술 부채에 해당함.
2. 특정 영역대(Tailscale)의 주소를 실제 경로와 관계없이 평문 소켓으로 다운그레이드 함. (1과 연관. Tailscale 환경에서 SSL 연결이 안 되던 경험적 문제 때문에 우회하도록 추가된 코드)

### 작업 범위

- 인증서 검증 실패 시, 사용자 허용 전제의 SHA-256 fingerprint pinning를 거침

### 작업 목록 

#### 1. 인증서 검증 우회 제거

- socket_factory.dart: onBadCertificate 콜백을 SHA-256 지문 핀닝 단일 규칙으로 재작성
- socket_manager.dart: 지문을 isolate 경계까지 포함해 실제 연결 지점까지 전달
- electrum_server.dart: pinnedCertFingerprint 필드 추가
- node_connection_status.dart, app_error.dart: untrustedCertificate 상태/에러코드 추가 — 인증서 신뢰 불가를 일반 연결 실패와 구분

#### 2. TOFU 플로우 추가

- 커스텀 서버에서만 지문 확인 절차로 진입(기본 서버는 예외 없이 차단), 이미 지문이 핀닝된 서버의 인증서가 바뀌면 재확인창이 다시 뜨도록 처리
- electrum_server_screen.dart: 지문 확인 다이얼로그 UI, 승인된 지문은 저장 후 재연결 시 자동 재사용

#### 3. mainnet 기본 서버 목록 인증서 감사

- mainnet 11개 서버 전수 감사 결과 6개가 새 검증 로직에서 실패 판정
- self-signed 4개(fulrum/lukechilds/bitaroo/emzy): 지문을 electrum_enums.dart에 하드코딩(emzy 인증서 2026-10-11 만료 예정으로 배포 필요)
- 호스트명 불일치 2개(foundationdevices/bluewallet): 실제 인증서 도메인으로 접속 주소 매핑
- 지속적으로 연결 불가능한 jochenhoenicke는 목록에서 삭제

#### 4. 서버 정보 저장 구조 개선

- 기존엔 기본 서버를 선택해도 host/port/ssl을 문자 그대로 "CUSTOM"으로 저장 → 기본 서버의 주소/지문이 바뀌어도 기존 저장값이 갱신되지 않는 문제가 있다. 
- electrum_server_provider.dart: 기본 서버는 serverName 참조로 저장하도록 변경, 구버전 사용자를 위한 1회성 부팅 마이그레이션(migrateLegacyCustomServerStorage) 추가

### 테스트 절차 

#### 1. 자동 테스트 추가
- socket_factory_test.dart: TLS 서버 인증서 지문 검증 테스트 
- electrum_server_provider_test.dart: 서버 마이그레이션 테스트
- (참고) 기존 테스트 : socket_manager_test.dart, node_provider_test.dart(회귀 테스트용)

#### 2. 라이브 테스트 
(실기기 + 로컬 regtest·electrs·socat 환경, self-signed TLS)

[일렉트럼 서버 설정 화면]
- 커스텀 서버 최초 등록 시 TOFU 다이얼로그, 지문 일치 확인
- 신뢰 거부 시 재시도하면 처음부터 다시 TOFU
- 승인 후 재연결 시 다이얼로그 없이 자동 재사용
- 인증서 교체(갱신 시뮬레이션) 시 TOFU 재등장 및 새 지문 확인 — 완료
- develop → 이 브랜치로 마이그레이션 시 기존 서버 유지·연결 성공 확인

상세 내용은 팀 노션 페이지 확인해주세요
